### PR TITLE
Return un-wrapped Float and Ints by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "jsdoc": "^3.5.5",
     "lodash.random": "^3.2.0",
     "mocha": "^4.0.1",
-    "multiline": "^1.0.2",
     "nyc": "^11.2.1",
     "p-queue": "^2.3.0",
     "power-assert": "^1.4.4",

--- a/src/codec.js
+++ b/src/codec.js
@@ -74,9 +74,12 @@ codec.Int = Int;
  */
 function generateToJSONFromRow(row) {
   return function(options) {
-    options = extend({
-      wrapNumbers: false,
-    }, options);
+    options = extend(
+      {
+        wrapNumbers: false,
+      },
+      options
+    );
 
     return row.reduce(function(serializedRow, keyVal) {
       var name = keyVal.name;

--- a/src/codec.js
+++ b/src/codec.js
@@ -67,6 +67,10 @@ Int.prototype.valueOf = function() {
 
 codec.Int = Int;
 
+/**
+ * Wherever a row object is returned, it is assigned a "toJSON" function. This
+ * function will create that function in a consistent format.
+ */
 function generateToJSONFromRow(row) {
   return function(options) {
     options = options || {
@@ -90,7 +94,7 @@ function generateToJSONFromRow(row) {
         } catch (e) {
           e.message = [
             `Serializing column "${name}" encountered an error: ${e.message}`,
-            'Pass { wrapNumbers: true } to toJSON() to receive a custom type.',
+            'Call row.toJSON({ wrapNumbers: true }) to receive a custom type.',
           ].join(' ');
           throw e;
         }
@@ -157,7 +161,7 @@ function decode(value, field) {
 
         Object.defineProperty(formattedRow, 'toJSON', {
           enumerable: false,
-          value: generateToJSONFromRow(formattedRow),
+          value: codec.generateToJSONFromRow(formattedRow),
         });
 
         decoded = formattedRow;

--- a/src/codec.js
+++ b/src/codec.js
@@ -20,6 +20,7 @@ var codec = module.exports;
 
 var Buffer = require('safe-buffer').Buffer;
 var commonGrpc = require('@google-cloud/common-grpc');
+var extend = require('extend');
 var is = require('is');
 
 function SpannerDate(value) {
@@ -73,18 +74,16 @@ codec.Int = Int;
  */
 function generateToJSONFromRow(row) {
   return function(options) {
-    options = options || {
+    options = extend({
       wrapNumbers: false,
-    };
+    }, options);
 
-    var serializedRow = {};
-
-    row.forEach(function(keyVal) {
+    return row.reduce(function(serializedRow, keyVal) {
       var name = keyVal.name;
       var value = keyVal.value;
 
       if (!name) {
-        return;
+        return serializedRow;
       }
 
       var isNumber = value instanceof Float || value instanceof Int;
@@ -101,9 +100,9 @@ function generateToJSONFromRow(row) {
       }
 
       serializedRow[name] = value;
-    });
 
-    return serializedRow;
+      return serializedRow;
+    }, {});
   };
 }
 

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -170,22 +170,12 @@ partialResultStream.formatRow_ = function(metadata, row) {
     });
   }
 
-  var formattedRow = [];
-  var serializedRow = {};
-
-  row.values.forEach(function(value, index) {
+  var formattedRow = row.values.map(function(value, index) {
     var field = fields[index];
-
-    var column = {
+    return {
       name: field.name,
       value: codec.decode(value, field),
     };
-
-    formattedRow.push(column);
-
-    if (column.name) {
-      serializedRow[column.name] = column.value;
-    }
   });
 
   Object.defineProperty(formattedRow, 'toJSON', {

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -190,9 +190,7 @@ partialResultStream.formatRow_ = function(metadata, row) {
 
   Object.defineProperty(formattedRow, 'toJSON', {
     enumerable: false,
-    value: function() {
-      return serializedRow;
-    },
+    value: codec.generateToJSONFromRow(formattedRow),
   });
 
   return formattedRow;

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+var codec = require('./codec.js');
 var is = require('is');
 
 /*!
@@ -176,9 +177,7 @@ RowBuilder.prototype.toJSON = function() {
 
     Object.defineProperty(formattedRow, 'toJSON', {
       enumerable: false,
-      value: function() {
-        return serializedRow;
-      },
+      value: codec.generateToJSONFromRow(formattedRow),
     });
 
     return formattedRow;

--- a/src/table.js
+++ b/src/table.js
@@ -399,7 +399,8 @@ Table.prototype.insert = function(keyVals, callback) {
  *     object has a `name` and `value` property. To get a serialized object,
  *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
  *     specifying `wrapNumbers: true` to protect large integer values outside of
- *     the range of JavaScript Number.
+ *     the range of JavaScript Number. If set, FLOAT64 values will be returned
+ *     as {@link Spanner.Float} objects and INT64 values as @{link Spanner.Int}.
  */
 /**
  * @callback TableReadCallback
@@ -408,7 +409,8 @@ Table.prototype.insert = function(keyVals, callback) {
  *     object has a `name` and `value` property. To get a serialized object,
  *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
  *     specifying `wrapNumbers: true` to protect large integer values outside of
- *     the range of JavaScript Number.
+ *     the range of JavaScript Number. If set, FLOAT64 values will be returned
+ *     as {@link Spanner.Float} objects and INT64 values as @{link Spanner.Int}.
  */
 /**
  * Receive rows from the database using key lookups and scans.

--- a/src/table.js
+++ b/src/table.js
@@ -397,14 +397,18 @@ Table.prototype.insert = function(keyVals, callback) {
  * @property {Table} 0 The new {@link Table}.
  * @property {array[]} 1 Rows are returned as an array of object arrays. Each
  *     object has a `name` and `value` property. To get a serialized object,
- *     call `toJSON()`.
+ *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
+ *     specifying `wrapNumbers: true` to protect large integer values outside of
+ *     the range of JavaScript Number.
  */
 /**
  * @callback TableReadCallback
  * @param {?Error} err Request error, if any.
  * @param {array[]} rows Rows are returned as an array of object arrays. Each
  *     object has a `name` and `value` property. To get a serialized object,
- *     call `toJSON()`.
+ *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
+ *     specifying `wrapNumbers: true` to protect large integer values outside of
+ *     the range of JavaScript Number.
  */
 /**
  * Receive rows from the database using key lookups and scans.

--- a/src/transaction-request.js
+++ b/src/transaction-request.js
@@ -466,14 +466,18 @@ TransactionRequest.prototype.insert = function(table, keyVals, callback) {
  * @typedef {array} TransactionRequestReadResponse
  * @property {array[]} 0 Rows are returned as an array of object arrays. Each
  *     object has a `name` and `value` property. To get a serialized object,
- *     call `toJSON()`.
+ *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
+ *     specifying `wrapNumbers: true` to protect large integer values outside of
+ *     the range of JavaScript Number.
  */
 /**
  * @callback TransactionRequestReadCallback
  * @param {?Error} err Request error, if any.
  * @param {array[]} rows Rows are returned as an array of object arrays. Each
  *     object has a `name` and `value` property. To get a serialized object,
- *     call `toJSON()`.
+ *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
+ *     specifying `wrapNumbers: true` to protect large integer values outside of
+ *     the range of JavaScript Number.
  */
 /**
  * Performs a read request against the specified Table.

--- a/src/transaction-request.js
+++ b/src/transaction-request.js
@@ -468,7 +468,8 @@ TransactionRequest.prototype.insert = function(table, keyVals, callback) {
  *     object has a `name` and `value` property. To get a serialized object,
  *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
  *     specifying `wrapNumbers: true` to protect large integer values outside of
- *     the range of JavaScript Number.
+ *     the range of JavaScript Number. If set, FLOAT64 values will be returned
+ *     as {@link Spanner.Float} objects and INT64 values as @{link Spanner.Int}.
  */
 /**
  * @callback TransactionRequestReadCallback
@@ -477,7 +478,8 @@ TransactionRequest.prototype.insert = function(table, keyVals, callback) {
  *     object has a `name` and `value` property. To get a serialized object,
  *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
  *     specifying `wrapNumbers: true` to protect large integer values outside of
- *     the range of JavaScript Number.
+ *     the range of JavaScript Number. If set, FLOAT64 values will be returned
+ *     as {@link Spanner.Float} objects and INT64 values as @{link Spanner.Int}.
  */
 /**
  * Performs a read request against the specified Table.

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -3164,7 +3164,7 @@ describe('Spanner', function() {
                 }
 
                 var row = rows[0].toJSON();
-                callback(null, parseInt(row.NumberValue.value, 10));
+                callback(null, row.NumberValue);
               }
             );
           }
@@ -3220,7 +3220,7 @@ describe('Spanner', function() {
                 }
 
                 var row = rows[0].toJSON();
-                callback(null, parseInt(row.NumberValue.value, 10));
+                callback(null, row.NumberValue);
               }
             );
           }

--- a/test/codec.js
+++ b/test/codec.js
@@ -117,7 +117,6 @@ describe('codec', function() {
         value: 'value',
       },
     ];
-    var OPTIONS = {};
 
     var toJSON;
 

--- a/test/partial-result-stream.js
+++ b/test/partial-result-stream.js
@@ -530,10 +530,6 @@ describe('PartialResultStream', function() {
           return toJSONOverride;
         };
 
-        var value = {
-          fieldName: '1',
-        };
-
         FORMATTED_ROW = partialResultStreamModule.formatRow_(METADATA, ROW);
       });
 

--- a/test/partial-result-stream.js
+++ b/test/partial-result-stream.js
@@ -27,9 +27,16 @@ var util = require('@google-cloud/common').util;
 var codec = require('../src/codec.js');
 
 var decodeValueOverride;
+var generateToJSONFromRowOverride;
 var fakeCodec = extend({}, codec);
 fakeCodec.decode = function() {
   return (decodeValueOverride || codec.decode).apply(null, arguments);
+};
+fakeCodec.generateToJSONFromRow = function() {
+  return (generateToJSONFromRowOverride || codec.generateToJSONFromRow).apply(
+    null,
+    arguments
+  );
 };
 
 var checkpointStreamOverride;
@@ -92,6 +99,7 @@ describe('PartialResultStream', function() {
     FakeRowBuilderOverrides = {};
     checkpointStreamOverride = null;
     decodeValueOverride = null;
+    generateToJSONFromRowOverride = null;
     fakeRequestStream = through.obj();
 
     extend(partialResultStreamModule, partialResultStreamCached);
@@ -474,9 +482,6 @@ describe('PartialResultStream', function() {
       assert.strictEqual(formattedRows.length, 2);
       assert.strictEqual(formattedRows[0].value, 'value-1');
       assert.strictEqual(formattedRows[1].value, 'value-2');
-
-      // Only the field with a name should exist in the JSON serialization.
-      assert.deepEqual(formattedRows.toJSON(), {'field-1': 'value-1'});
     });
 
     it('should chunk rows with more values than fields', function() {
@@ -512,40 +517,36 @@ describe('PartialResultStream', function() {
       ]);
     });
 
-    it('should decode values and return a formatted object', function() {
-      var decodedValues = ['decoded-value-1', 'decoded-value-2'];
+    describe('toJSON', function() {
+      var toJSONOverride = function() {};
+      var FORMATTED_ROW;
 
-      var numTimesDecodeValueCalled = 0;
-      decodeValueOverride = function(value) {
-        numTimesDecodeValueCalled++;
+      beforeEach(function() {
+        decodeValueOverride = function(value) {
+          return value;
+        };
 
-        if (numTimesDecodeValueCalled === 1) {
-          assert.strictEqual(value, VALUES[0]);
-          return decodedValues[0];
+        generateToJSONFromRowOverride = function() {
+          return toJSONOverride;
+        };
+
+        var value = {
+          fieldName: '1',
+        };
+
+        FORMATTED_ROW = partialResultStreamModule.formatRow_(METADATA, ROW);
+      });
+
+      it('should assign a toJSON method', function() {
+        assert.strictEqual(FORMATTED_ROW.toJSON, toJSONOverride);
+      });
+
+      it('should not include toJSON when iterated', function() {
+        for (var keyVal in FORMATTED_ROW) {
+          if (keyVal === 'toJSON') {
+            throw new Error('toJSON should not be iterated.');
+          }
         }
-
-        if (numTimesDecodeValueCalled === 2) {
-          assert.strictEqual(value, VALUES[1]);
-          return decodedValues[1];
-        }
-      };
-
-      var formattedRow = partialResultStreamModule.formatRow_(METADATA, ROW);
-
-      assert.deepEqual(formattedRow, [
-        {
-          name: 'field-1',
-          value: decodedValues[0],
-        },
-        {
-          name: 'field-2',
-          value: decodedValues[1],
-        },
-      ]);
-
-      assert.deepEqual(formattedRow.toJSON(), {
-        'field-1': decodedValues[0],
-        'field-2': decodedValues[1],
       });
     });
   });

--- a/test/row-builder.js
+++ b/test/row-builder.js
@@ -463,7 +463,7 @@ describe('RowBuilder', function() {
 
         var formattedValue = {};
 
-        RowBuilder.formatValue = function(type, value) {
+        RowBuilder.formatValue = function() {
           return formattedValue;
         };
 


### PR DESCRIPTION
Fixes #80

When `toJSON()` is called on a Row object, Float64 and Int64 values will now be returned as a JavaScript Number:

```js
var values = row.toJSON()
values.numUsers; // 8
```