### PR TITLE
fix path to api key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           command: npm run samples-test
           environment:
             GCLOUD_PROJECT: long-door-651
-            GOOGLE_APPLICATION_CREDENTIALS: /var/spanner/.circleci/key.json
+            GOOGLE_APPLICATION_CREDENTIALS: /home/node/spanner-samples/.circleci/key.json
             NPM_CONFIG_PREFIX: /home/node/.npm-global
       - run:
           name: Remove unencrypted key.


### PR DESCRIPTION
I hate it when you cannot make sure the samples tests run before you merge. Here is the fix, I remember fixing the same thing for the other repo a few weeks ago after I made the same mistake.
