### PR TITLE
Changes RowBuilder.formatValue to return null in case value is 'NULL_VALUE'

### DIFF
--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -61,6 +61,10 @@ RowBuilder.getValue = function(obj) {
  * object.
  */
 RowBuilder.formatValue = function(field, value) {
+  if (value == 'NULL_VALUE') {
+    return null;
+  }
+  
   if (field.code === 'ARRAY') {
     return value.map(function(value) {
       return RowBuilder.formatValue(field.arrayElementType, value);

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -61,10 +61,10 @@ RowBuilder.getValue = function(obj) {
  * object.
  */
 RowBuilder.formatValue = function(field, value) {
-  if (value == 'NULL_VALUE') {
+  if (value === 'NULL_VALUE') {
     return null;
   }
-  
+
   if (field.code === 'ARRAY') {
     return value.map(function(value) {
       return RowBuilder.formatValue(field.arrayElementType, value);

--- a/test/row-builder.js
+++ b/test/row-builder.js
@@ -155,6 +155,18 @@ describe('RowBuilder', function() {
       assert.strictEqual(formattedValue[0], value[0]);
     });
 
+    it('should return null if value is NULL_VALUE', function() {
+      var field = {
+        code: 'ARRAY',
+        arrayElementType: 'type',
+      };
+
+      var value = 'NULL_VALUE';
+
+      var formattedValue = RowBuilder.formatValue(field, value);
+      assert.strictEqual(formattedValue, null);
+    });
+
     it('should return the original value if not an array', function() {
       var field = {
         code: 'NOT_STRUCT_OR_ARRAY', // so it returns original value


### PR DESCRIPTION
Fixes #95

Simple validation. In case Rowbuilder.formatValue receives 'NULL_VALUE' as value, which applies to all types, return null as value for that field.
 
# Tests
Unit test were also included in this PR
