### PR TITLE
chore: serialize sample tests execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,3 +250,4 @@ jobs:
       - run:
          name: Publish the module to npm.
          command: npm publish
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ workflows:
             - lint
             - docs
           filters:
-#           branches:
-#             only: master
+            branches:
+              only: master
             tags:
               only: /^v[\d.]+$/
       - publish_npm:
@@ -250,4 +250,3 @@ jobs:
       - run:
          name: Publish the module to npm.
          command: npm publish
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ workflows:
             - lint
             - docs
           filters:
-            branches:
-              only: master
+#           branches:
+#             only: master
             tags:
               only: /^v[\d.]+$/
       - publish_npm:
@@ -196,6 +196,9 @@ jobs:
             cd ..
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
+      - run:
+          name: Wait for other samples-test jobs to finish.
+          command: node samples/system-test/util/circleci_wait.js
       - run:
           name: Run sample tests.
           command: npm run samples-test

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "docs": "repo-tools exec -- jsdoc -c .jsdoc.js",
     "generate-scaffolding": "repo-tools generate all && repo-tools generate lib_samples_readme -l samples/ --config ../.cloud-repo-tools.json",
     "lint": "repo-tools lint --cmd eslint -- src/ samples/ system-test/ test/",
-    "prettier": "repo-tools exec -- prettier --write benchmark/*.js src/*.js src/*/*.js src/admin/database/*/*.js src/admin/instance/*/*.js samples/*.js samples/*/*.js test/*.js test/*/*.js system-test/*.js system-test/*/*.js",
+    "prettier": "repo-tools exec -- prettier --write benchmark/*.js src/*.js src/*/*.js src/admin/database/*/*.js src/admin/instance/*/*.js samples/*.js samples/*/*.js samples/*/*/*.js test/*.js test/*/*.js system-test/*.js system-test/*/*.js",
     "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "system-test": "repo-tools test run --cmd mocha -- system-test/*.js --no-timeouts",
     "test-no-cover": "repo-tools test run --cmd mocha -- test/*.js --no-timeouts",

--- a/samples/package.json
+++ b/samples/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "2.1.0",
     "ava": "0.22.0",
+    "axios": "^0.17.1",
     "proxyquire": "1.8.0",
     "sinon": "3.2.1"
   }

--- a/samples/system-test/util/circleci_wait.js
+++ b/samples/system-test/util/circleci_wait.js
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Samples tests work with the same project in Google Cloud and
+ * can fail if more than one test job is running at the same time.
+ * This script will help CircleCI job wait until all the similar tasks are
+ * completed.
+ */
+
+const axios = require('axios');
+const TIMEOUT = 5000;
+
+function waitForRunningTasks(options) {
+  return new Promise(fulfill => {
+    axios
+      .get(
+        `https://circleci.com/api/v1.1/project/github/${options['username']}/${
+          options['reponame']
+        }`,
+        {
+          headers: {
+            Accept: 'application/json',
+          },
+          params: {
+            'circle-token': options['circleToken'],
+          },
+        }
+      )
+      .then(response => {
+        let ahead = [];
+        let builds = response['data'];
+        for (let build of builds) {
+          if (
+            build['username'] === options['username'] &&
+            build['reponame'] === options['reponame'] &&
+            build['build_parameters']['CIRCLE_JOB'] === options['job'] &&
+            build['build_num'] < options['buildNum'] &&
+            build['status'] === 'running'
+          ) {
+            ahead.push(build['build_num']);
+          }
+        }
+
+        if (ahead.length === 0) {
+          console.log(`No running ${options['job']} builds found.`);
+          fulfill();
+        } else {
+          console.log(
+            `Found ${ahead.length} running ${
+              options['job']
+            } builds: ${ahead.join(', ')}. Waiting...`
+          );
+          setTimeout(() => {
+            waitForRunningTasks(options).then(fulfill);
+          }, TIMEOUT);
+        }
+      });
+  });
+}
+
+function main() {
+  if (process.env['CIRCLECI'] === undefined) {
+    console.log('Not in CircleCI, no need to wait. Exiting.');
+    return;
+  }
+
+  let circleToken = process.env['CIRCLECI_TOKEN'];
+  if (circleToken === undefined) {
+    console.log(
+      'You need to define CIRCLECI_TOKEN environment variable to enable waiting for jobs. Exiting.'
+    );
+    return;
+  }
+
+  let username = process.env['CIRCLE_PROJECT_USERNAME'];
+  let reponame = process.env['CIRCLE_PROJECT_REPONAME'];
+  let job = process.env['CIRCLE_JOB'];
+  let buildNum = Number.parseInt(process.env['CIRCLE_BUILD_NUM']);
+
+  waitForRunningTasks({username, reponame, job, buildNum, circleToken}).then(
+    () => {
+      console.log('Wait complete, starting tests.');
+    }
+  );
+}
+
+main();


### PR DESCRIPTION
I know it might be not the right way to approach the problem but I have serious concerns that running more than one instance of sample tests for Spanner will break. I'm not sure if it's possible to fix the test fast enough (I thought that changing the instance ID to something unique should help, but something is still wrong), so I suggest having this wait as a temporary might-be-a-solution. 

If we notice it does not help, we can revert it back.