### PR TITLE
Remove autoCreate for objects that return operations.

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -506,12 +506,10 @@ Database.prototype.get = function(options, callback) {
             return;
           }
 
-          operation
-            .on('error', callback)
-            .on('complete', function(metadata) {
-              self.metadata = metadata;
-              callback(null, self, metadata);
-            });
+          operation.on('error', callback).on('complete', function(metadata) {
+            self.metadata = metadata;
+            callback(null, self, metadata);
+          });
         });
         return;
       }

--- a/src/instance.js
+++ b/src/instance.js
@@ -128,52 +128,6 @@ function Instance(spanner, name) {
      * });
      */
     exists: true,
-
-    /**
-     * @typedef {array} GetInstanceResponse
-     * @property {Instance} 0 The {@link Instance}.
-     * @property {object} 1 The full API response.
-     */
-    /**
-     * @callback GetInstanceCallback
-     * @param {?Error} err Request error, if any.
-     * @param {Instance} instance The {@link Instance}.
-     * @param {object} apiResponse The full API response.
-     */
-    /**
-     * Get an instance if it exists.
-     *
-     * You may optionally use this to "get or create" an object by providing an
-     * object with `autoCreate` set to `true`. Any extra configuration that is
-     * normally required for the `create` method must be contained within this
-     * object as well.
-     *
-     * @method Instance#get
-     * @param {options} [options] Configuration object.
-     * @param {boolean} [options.autoCreate=false] Automatically create the
-     *     object if it does not exist.
-     * @param {GetInstanceCallback} [callback] Callback function.
-     * @returns {Promise<GetInstanceResponse>}
-     *
-     * @example
-     * const Spanner = require('@google-cloud/spanner');
-     * const spanner = new Spanner();
-     *
-     * const instance = spanner.instance('my-instance');
-     *
-     * instance.get(function(err, instance, apiResponse) {
-     *   // `instance.metadata` has been populated.
-     * });
-     *
-     * //-
-     * // If the callback is omitted, we'll return a Promise.
-     * //-
-     * instance.get().then(function(data) {
-     *   var instance = data[0];
-     *   var apiResponse = data[0];
-     * });
-     */
-    get: true,
   };
 
   commonGrpc.ServiceObject.call(this, {
@@ -451,6 +405,85 @@ Instance.prototype.delete = function(callback) {
         }
       );
     });
+};
+
+
+/**
+ * @typedef {array} GetInstanceResponse
+ * @property {Instance} 0 The {@link Instance}.
+ * @property {object} 1 The full API response.
+ */
+/**
+ * @callback GetInstanceCallback
+ * @param {?Error} err Request error, if any.
+ * @param {Instance} instance The {@link Instance}.
+ * @param {object} apiResponse The full API response.
+ */
+/**
+ * Get an instance if it exists.
+ *
+ * You may optionally use this to "get or create" an object by providing an
+ * object with `autoCreate` set to `true`. Any extra configuration that is
+ * normally required for the `create` method must be contained within this
+ * object as well.
+ *
+ * @param {options} [options] Configuration object.
+ * @param {boolean} [options.autoCreate=false] Automatically create the
+ *     object if it does not exist.
+ * @param {GetInstanceCallback} [callback] Callback function.
+ * @returns {Promise<GetInstanceResponse>}
+ *
+ * @example
+ * const Spanner = require('@google-cloud/spanner');
+ * const spanner = new Spanner();
+ *
+ * const instance = spanner.instance('my-instance');
+ *
+ * instance.get(function(err, instance, apiResponse) {
+ *   // `instance.metadata` has been populated.
+ * });
+ *
+ * //-
+ * // If the callback is omitted, we'll return a Promise.
+ * //-
+ * instance.get().then(function(data) {
+ *   var instance = data[0];
+ *   var apiResponse = data[0];
+ * });
+ */
+Instance.prototype.get = function(options, callback) {
+  var self = this;
+
+  if (is.fn(options)) {
+    callback = options;
+    options = {};
+  }
+
+  this.getMetadata(function(err, metadata) {
+    if (err) {
+      if (err.code === 5 && options.autoCreate) {
+        self.create(options, function(err, database, operation) {
+          if (err) {
+            callback(err);
+            return;
+          }
+
+          operation
+            .on('error', callback)
+            .on('complete', function(metadata) {
+              self.metadata = metadata;
+              callback(null, self, metadata);
+            });
+        });
+        return;
+      }
+
+      callback(err);
+      return;
+    }
+
+    callback(null, self, metadata);
+  });
 };
 
 /**

--- a/src/instance.js
+++ b/src/instance.js
@@ -407,7 +407,6 @@ Instance.prototype.delete = function(callback) {
     });
 };
 
-
 /**
  * @typedef {array} GetInstanceResponse
  * @property {Instance} 0 The {@link Instance}.
@@ -468,12 +467,10 @@ Instance.prototype.get = function(options, callback) {
             return;
           }
 
-          operation
-            .on('error', callback)
-            .on('complete', function(metadata) {
-              self.metadata = metadata;
-              callback(null, self, metadata);
-            });
+          operation.on('error', callback).on('complete', function(metadata) {
+            self.metadata = metadata;
+            callback(null, self, metadata);
+          });
         });
         return;
       }

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -620,9 +620,12 @@ describe('Spanner', function() {
     it('should auto create an instance', function(done) {
       var instance = spanner.instance(generateName('instance'));
 
-      var config = extend({
-        autoCreate: true,
-      }, INSTANCE_CONFIG);
+      var config = extend(
+        {
+          autoCreate: true,
+        },
+        INSTANCE_CONFIG
+      );
 
       instance.get(config, function(err) {
         assert.ifError(err);
@@ -734,7 +737,7 @@ describe('Spanner', function() {
     it('should auto create a database', function(done) {
       var database = instance.database(generateName('database'));
 
-      database.get({ autoCreate: true }, function(err) {
+      database.get({autoCreate: true}, function(err) {
         assert.ifError(err);
         database.getMetadata(done);
       });

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -34,22 +34,21 @@ var spanner = new Spanner({projectId: process.env.GCLOUD_PROJECT});
 describe('Spanner', function() {
   var instance = spanner.instance(generateName('instance'));
 
+  var INSTANCE_CONFIG = {
+    config: 'regional-us-central1',
+    nodes: 1,
+    labels: {
+      'gcloud-tests': 'true',
+    },
+  };
+
   before(function(done) {
     async.series(
       [
         deleteTestResources,
 
         function(next) {
-          instance.create(
-            {
-              config: 'regional-us-central1',
-              nodes: 1,
-              labels: {
-                'gcloud-tests': 'true',
-              },
-            },
-            execAfterOperationComplete(next)
-          );
+          instance.create(INSTANCE_CONFIG, execAfterOperationComplete(next));
         },
       ],
       done
@@ -618,6 +617,19 @@ describe('Spanner', function() {
       });
     });
 
+    it('should auto create an instance', function(done) {
+      var instance = spanner.instance(generateName('instance'));
+
+      var config = extend({
+        autoCreate: true,
+      }, INSTANCE_CONFIG);
+
+      instance.get(config, function(err) {
+        assert.ifError(err);
+        instance.getMetadata(done);
+      });
+    });
+
     it('should list the instances', function(done) {
       spanner.getInstances(function(err, instances) {
         assert.ifError(err);
@@ -716,6 +728,15 @@ describe('Spanner', function() {
         }
 
         database.delete(done);
+      });
+    });
+
+    it('should auto create a database', function(done) {
+      var database = instance.database(generateName('database'));
+
+      database.get({ autoCreate: true }, function(err) {
+        assert.ifError(err);
+        database.getMetadata(done);
       });
     });
 

--- a/test/database.js
+++ b/test/database.js
@@ -579,7 +579,7 @@ describe('Database', function() {
       });
 
       it('should call create', function(done) {
-        database.create = function(options, callback) {
+        database.create = function(options) {
           assert.strictEqual(options, OPTIONS);
           done();
         };
@@ -614,7 +614,6 @@ describe('Database', function() {
       });
 
       it('should execute callback if opereation succeeded', function(done) {
-        var error = new Error('Error.');
         var metadata = {};
 
         setImmediate(function() {

--- a/test/instance.js
+++ b/test/instance.js
@@ -478,7 +478,7 @@ describe('Instance', function() {
       });
 
       it('should call create', function(done) {
-        instance.create = function(options, callback) {
+        instance.create = function(options) {
           assert.strictEqual(options, OPTIONS);
           done();
         };
@@ -513,7 +513,6 @@ describe('Instance', function() {
       });
 
       it('should execute callback if opereation succeeded', function(done) {
-        var error = new Error('Error.');
         var metadata = {};
 
         setImmediate(function() {


### PR DESCRIPTION
Fixes #127 

This adds get-or-create behavior to database.get() and instance.get().