### PR TITLE
Issue - 134 : Fix for session leak issue

### DIFF
--- a/src/session-pool.js
+++ b/src/session-pool.js
@@ -790,9 +790,8 @@ SessionPool.prototype.pingSession_ = function(session) {
         });
     })
     .catch(function() {
-      // var index = self.borrowed_.indexOf(session);
-      // self.borrowed_.splice(index, 1);
-      self.release(session); // session is borrowed but not released, it will cause a session leak.
+      // session is borrowed but not released, it will cause a session leak.
+      self.release(session);
     });
 };
 

--- a/src/session-pool.js
+++ b/src/session-pool.js
@@ -636,7 +636,7 @@ SessionPool.prototype.getNextAvailableSession_ = function(type) {
     session = this.reads_[0];
   }
 
-  if (this.writes_.length) {
+  if (type === READWRITE && this.writes_.length) {
     session = this.writes_[0];
   }
 

--- a/src/session-pool.js
+++ b/src/session-pool.js
@@ -634,9 +634,7 @@ SessionPool.prototype.getNextAvailableSession_ = function(type) {
 
   if (type === READONLY && this.reads_.length) {
     session = this.reads_[0];
-  }
-
-  if (type === READWRITE && this.writes_.length) {
+  } else if (this.writes_.length) {
     session = this.writes_[0];
   }
 

--- a/test/session-pool.js
+++ b/test/session-pool.js
@@ -857,7 +857,6 @@ describe('SessionPool', function() {
       return sessionPool.acquireSession_(fakeType).then(function(session) {
         assert.strictEqual(session, fakeSession);
         assert(isAround(session.lastUsed, Date.now()));
-        assert.strictEqual(borrowCalled, true);
       });
     });
 
@@ -1710,7 +1709,6 @@ describe('SessionPool', function() {
 
       return sessionPool.pingSession_(fakeSession).then(function() {
         assert.strictEqual(emitted, true);
-        assert.strictEqual(released, false);
         assert.deepEqual(sessionPool.borrowed_, []);
       });
     });

--- a/test/session-pool.js
+++ b/test/session-pool.js
@@ -1317,10 +1317,16 @@ describe('SessionPool', function() {
 
       sessionPool.reads_ = [fakeSession];
 
+      var borrowCalled = false;
+      sessionPool.borrowSession_ = function(session) {
+        assert.strictEqual(session, fakeSession);
+        borrowCalled = true;
+      };
       return sessionPool
         .getNextAvailableSession_('readonly')
         .then(function(session) {
           assert.strictEqual(session, fakeSession);
+          assert.strictEqual(borrowCalled, true);
         });
     });
 
@@ -1329,10 +1335,17 @@ describe('SessionPool', function() {
 
       sessionPool.writes_ = [fakeSession];
 
+      var borrowCalled = false;
+      sessionPool.borrowSession_ = function(session) {
+        assert.strictEqual(session, fakeSession);
+        borrowCalled = true;
+      };
+
       return sessionPool
         .getNextAvailableSession_('readonly')
         .then(function(session) {
           assert.strictEqual(session, fakeSession);
+          assert.strictEqual(borrowCalled, true);
         });
     });
 
@@ -1341,10 +1354,16 @@ describe('SessionPool', function() {
 
       sessionPool.writes_ = [fakeSession];
 
+      var borrowCalled = false;
+      sessionPool.borrowSession_ = function(session) {
+        assert.strictEqual(session, fakeSession);
+        borrowCalled = true;
+      };
       return sessionPool
         .getNextAvailableSession_('readwrite')
         .then(function(session) {
           assert.strictEqual(session, fakeSession);
+          assert.strictEqual(borrowCalled, true);
         });
     });
 
@@ -1352,6 +1371,12 @@ describe('SessionPool', function() {
       var fakeSession = {};
 
       sessionPool.reads_ = [fakeSession];
+
+      var borrowCalled = false;
+      sessionPool.borrowSession_ = function(session) {
+        assert.strictEqual(session, fakeSession);
+        borrowCalled = true;
+      };
 
       var transformed = false;
       var fakePromise = Promise.resolve();
@@ -1371,6 +1396,7 @@ describe('SessionPool', function() {
         .then(function(session) {
           assert.strictEqual(transformed, true);
           assert.strictEqual(session, fakeSession);
+          assert.strictEqual(borrowCalled, true);
         });
     });
 
@@ -1390,6 +1416,12 @@ describe('SessionPool', function() {
         released = true;
       };
 
+      var borrowCalled = false;
+      sessionPool.borrowSession_ = function(session) {
+        assert.strictEqual(session, fakeSession);
+        borrowCalled = true;
+      };
+
       sessionPool.race_ = function(promise) {
         return promise;
       };
@@ -1401,6 +1433,7 @@ describe('SessionPool', function() {
         function(err) {
           assert.strictEqual(err, fakeError);
           assert.strictEqual(released, true);
+          assert.strictEqual(borrowCalled, true);
         }
       );
     });
@@ -1709,7 +1742,7 @@ describe('SessionPool', function() {
 
       return sessionPool.pingSession_(fakeSession).then(function() {
         assert.strictEqual(emitted, true);
-        assert.deepEqual(sessionPool.borrowed_, []);
+        assert.strictEqual(released, true);
       });
     });
   });


### PR DESCRIPTION
https://github.com/googleapis/nodejs-spanner/issues/134

Description:
Fixing the session leak issue. The session was removed from the reads_ or writes_ array but it was not added to borrowed_ array immediately. Due to which, there would be a time where a session is not present in either writes_ or reads_ or borrowed_. This causes the code to create new session as it concludes that 1 session is missing. Hence, the code is always creating session, maxing out the total connections to be made to spanner which eventually locks the database as we cannot create any new connections
