### PR TITLE
Regenerate gapic

### DIFF
--- a/protos/google/spanner/admin/database/v1/spanner_database_admin.proto
+++ b/protos/google/spanner/admin/database/v1/spanner_database_admin.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/admin/databas
 option java_multiple_files = true;
 option java_outer_classname = "SpannerDatabaseAdminProto";
 option java_package = "com.google.spanner.admin.database.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\Admin\\Database\\V1";
 
 
 // Cloud Spanner Database Admin API
@@ -38,7 +39,9 @@ option java_package = "com.google.spanner.admin.database.v1";
 service DatabaseAdmin {
   // Lists Cloud Spanner databases.
   rpc ListDatabases(ListDatabasesRequest) returns (ListDatabasesResponse) {
-    option (google.api.http) = { get: "/v1/{parent=projects/*/instances/*}/databases" };
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*/instances/*}/databases"
+    };
   }
 
   // Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -50,12 +53,17 @@ service DatabaseAdmin {
   // [response][google.longrunning.Operation.response] field type is
   // [Database][google.spanner.admin.database.v1.Database], if successful.
   rpc CreateDatabase(CreateDatabaseRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { post: "/v1/{parent=projects/*/instances/*}/databases" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*/instances/*}/databases"
+      body: "*"
+    };
   }
 
   // Gets the state of a Cloud Spanner database.
   rpc GetDatabase(GetDatabaseRequest) returns (Database) {
-    option (google.api.http) = { get: "/v1/{name=projects/*/instances/*/databases/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/instances/*/databases/*}"
+    };
   }
 
   // Updates the schema of a Cloud Spanner database by
@@ -66,19 +74,26 @@ service DatabaseAdmin {
   // [metadata][google.longrunning.Operation.metadata] field type is
   // [UpdateDatabaseDdlMetadata][google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   rpc UpdateDatabaseDdl(UpdateDatabaseDdlRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { patch: "/v1/{database=projects/*/instances/*/databases/*}/ddl" body: "*" };
+    option (google.api.http) = {
+      patch: "/v1/{database=projects/*/instances/*/databases/*}/ddl"
+      body: "*"
+    };
   }
 
   // Drops (aka deletes) a Cloud Spanner database.
   rpc DropDatabase(DropDatabaseRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { delete: "/v1/{database=projects/*/instances/*/databases/*}" };
+    option (google.api.http) = {
+      delete: "/v1/{database=projects/*/instances/*/databases/*}"
+    };
   }
 
   // Returns the schema of a Cloud Spanner database as a list of formatted
   // DDL statements. This method does not show pending schema updates, those may
   // be queried using the [Operations][google.longrunning.Operations] API.
   rpc GetDatabaseDdl(GetDatabaseDdlRequest) returns (GetDatabaseDdlResponse) {
-    option (google.api.http) = { get: "/v1/{database=projects/*/instances/*/databases/*}/ddl" };
+    option (google.api.http) = {
+      get: "/v1/{database=projects/*/instances/*/databases/*}/ddl"
+    };
   }
 
   // Sets the access control policy on a database resource. Replaces any
@@ -87,7 +102,10 @@ service DatabaseAdmin {
   // Authorization requires `spanner.databases.setIamPolicy` permission on
   // [resource][google.iam.v1.SetIamPolicyRequest.resource].
   rpc SetIamPolicy(google.iam.v1.SetIamPolicyRequest) returns (google.iam.v1.Policy) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*/databases/*}:setIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*/databases/*}:setIamPolicy"
+      body: "*"
+    };
   }
 
   // Gets the access control policy for a database resource. Returns an empty
@@ -96,7 +114,10 @@ service DatabaseAdmin {
   // Authorization requires `spanner.databases.getIamPolicy` permission on
   // [resource][google.iam.v1.GetIamPolicyRequest.resource].
   rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest) returns (google.iam.v1.Policy) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*/databases/*}:getIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*/databases/*}:getIamPolicy"
+      body: "*"
+    };
   }
 
   // Returns permissions that the caller has on the specified database resource.
@@ -106,7 +127,10 @@ service DatabaseAdmin {
   // the containing Cloud Spanner instance. Otherwise returns an empty set of
   // permissions.
   rpc TestIamPermissions(google.iam.v1.TestIamPermissionsRequest) returns (google.iam.v1.TestIamPermissionsResponse) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*/databases/*}:testIamPermissions" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*/databases/*}:testIamPermissions"
+      body: "*"
+    };
   }
 }
 

--- a/protos/google/spanner/admin/instance/v1/spanner_instance_admin.proto
+++ b/protos/google/spanner/admin/instance/v1/spanner_instance_admin.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/admin/instanc
 option java_multiple_files = true;
 option java_outer_classname = "SpannerInstanceAdminProto";
 option java_package = "com.google.spanner.admin.instance.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\Admin\\Instance\\V1";
 
 
 // Cloud Spanner Instance Admin API
@@ -55,22 +56,30 @@ option java_package = "com.google.spanner.admin.instance.v1";
 service InstanceAdmin {
   // Lists the supported instance configurations for a given project.
   rpc ListInstanceConfigs(ListInstanceConfigsRequest) returns (ListInstanceConfigsResponse) {
-    option (google.api.http) = { get: "/v1/{parent=projects/*}/instanceConfigs" };
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*}/instanceConfigs"
+    };
   }
 
   // Gets information about a particular instance configuration.
   rpc GetInstanceConfig(GetInstanceConfigRequest) returns (InstanceConfig) {
-    option (google.api.http) = { get: "/v1/{name=projects/*/instanceConfigs/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/instanceConfigs/*}"
+    };
   }
 
   // Lists all instances in the given project.
   rpc ListInstances(ListInstancesRequest) returns (ListInstancesResponse) {
-    option (google.api.http) = { get: "/v1/{parent=projects/*}/instances" };
+    option (google.api.http) = {
+      get: "/v1/{parent=projects/*}/instances"
+    };
   }
 
   // Gets information about a particular instance.
   rpc GetInstance(GetInstanceRequest) returns (Instance) {
-    option (google.api.http) = { get: "/v1/{name=projects/*/instances/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/instances/*}"
+    };
   }
 
   // Creates an instance and begins preparing it to begin serving. The
@@ -108,7 +117,10 @@ service InstanceAdmin {
   // The [response][google.longrunning.Operation.response] field type is
   // [Instance][google.spanner.admin.instance.v1.Instance], if successful.
   rpc CreateInstance(CreateInstanceRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { post: "/v1/{parent=projects/*}/instances" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{parent=projects/*}/instances"
+      body: "*"
+    };
   }
 
   // Updates an instance, and begins allocating or releasing resources
@@ -152,7 +164,10 @@ service InstanceAdmin {
   // Authorization requires `spanner.instances.update` permission on
   // resource [name][google.spanner.admin.instance.v1.Instance.name].
   rpc UpdateInstance(UpdateInstanceRequest) returns (google.longrunning.Operation) {
-    option (google.api.http) = { patch: "/v1/{instance.name=projects/*/instances/*}" body: "*" };
+    option (google.api.http) = {
+      patch: "/v1/{instance.name=projects/*/instances/*}"
+      body: "*"
+    };
   }
 
   // Deletes an instance.
@@ -167,7 +182,9 @@ service InstanceAdmin {
   //     irrevocably disappear from the API. All data in the databases
   //     is permanently deleted.
   rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { delete: "/v1/{name=projects/*/instances/*}" };
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/instances/*}"
+    };
   }
 
   // Sets the access control policy on an instance resource. Replaces any
@@ -176,7 +193,10 @@ service InstanceAdmin {
   // Authorization requires `spanner.instances.setIamPolicy` on
   // [resource][google.iam.v1.SetIamPolicyRequest.resource].
   rpc SetIamPolicy(google.iam.v1.SetIamPolicyRequest) returns (google.iam.v1.Policy) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*}:setIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*}:setIamPolicy"
+      body: "*"
+    };
   }
 
   // Gets the access control policy for an instance resource. Returns an empty
@@ -185,7 +205,10 @@ service InstanceAdmin {
   // Authorization requires `spanner.instances.getIamPolicy` on
   // [resource][google.iam.v1.GetIamPolicyRequest.resource].
   rpc GetIamPolicy(google.iam.v1.GetIamPolicyRequest) returns (google.iam.v1.Policy) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*}:getIamPolicy" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*}:getIamPolicy"
+      body: "*"
+    };
   }
 
   // Returns permissions that the caller has on the specified instance resource.
@@ -195,7 +218,10 @@ service InstanceAdmin {
   // permission on the containing Google Cloud Project. Otherwise returns an
   // empty set of permissions.
   rpc TestIamPermissions(google.iam.v1.TestIamPermissionsRequest) returns (google.iam.v1.TestIamPermissionsResponse) {
-    option (google.api.http) = { post: "/v1/{resource=projects/*/instances/*}:testIamPermissions" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{resource=projects/*/instances/*}:testIamPermissions"
+      body: "*"
+    };
   }
 }
 

--- a/protos/google/spanner/v1/keys.proto
+++ b/protos/google/spanner/v1/keys.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "KeysProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // KeyRange represents a range of rows in a table or index.

--- a/protos/google/spanner/v1/mutation.proto
+++ b/protos/google/spanner/v1/mutation.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "MutationProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // A modification to one or more Cloud Spanner rows.  Mutations can be
@@ -61,6 +62,8 @@ message Mutation {
     string table = 1;
 
     // Required. The primary keys of the rows within [table][google.spanner.v1.Mutation.Delete.table] to delete.
+    // Delete is idempotent. The transaction will succeed even if some or all
+    // rows do not exist.
     KeySet key_set = 2;
   }
 

--- a/protos/google/spanner/v1/query_plan.proto
+++ b/protos/google/spanner/v1/query_plan.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "QueryPlanProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // Node information for nodes appearing in a [QueryPlan.plan_nodes][google.spanner.v1.QueryPlan.plan_nodes].

--- a/protos/google/spanner/v1/result_set.proto
+++ b/protos/google/spanner/v1/result_set.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "ResultSetProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // Results from [Read][google.spanner.v1.Spanner.Read] or

--- a/protos/google/spanner/v1/spanner.proto
+++ b/protos/google/spanner/v1/spanner.proto
@@ -59,24 +59,33 @@ service Spanner {
   // Idle sessions can be kept alive by sending a trivial SQL query
   // periodically, e.g., `"SELECT 1"`.
   rpc CreateSession(CreateSessionRequest) returns (Session) {
-    option (google.api.http) = { post: "/v1/{database=projects/*/instances/*/databases/*}/sessions" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{database=projects/*/instances/*/databases/*}/sessions"
+      body: "*"
+    };
   }
 
   // Gets a session. Returns `NOT_FOUND` if the session does not exist.
   // This is mainly useful for determining whether a session is still
   // alive.
   rpc GetSession(GetSessionRequest) returns (Session) {
-    option (google.api.http) = { get: "/v1/{name=projects/*/instances/*/databases/*/sessions/*}" };
+    option (google.api.http) = {
+      get: "/v1/{name=projects/*/instances/*/databases/*/sessions/*}"
+    };
   }
 
   // Lists all sessions in a given database.
   rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse) {
-    option (google.api.http) = { get: "/v1/{database=projects/*/instances/*/databases/*}/sessions" };
+    option (google.api.http) = {
+      get: "/v1/{database=projects/*/instances/*/databases/*}/sessions"
+    };
   }
 
   // Ends a session, releasing server resources associated with it.
   rpc DeleteSession(DeleteSessionRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { delete: "/v1/{name=projects/*/instances/*/databases/*/sessions/*}" };
+    option (google.api.http) = {
+      delete: "/v1/{name=projects/*/instances/*/databases/*/sessions/*}"
+    };
   }
 
   // Executes an SQL query, returning all rows in a single reply. This
@@ -91,7 +100,10 @@ service Spanner {
   // Larger result sets can be fetched in streaming fashion by calling
   // [ExecuteStreamingSql][google.spanner.v1.Spanner.ExecuteStreamingSql] instead.
   rpc ExecuteSql(ExecuteSqlRequest) returns (ResultSet) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:executeSql" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:executeSql"
+      body: "*"
+    };
   }
 
   // Like [ExecuteSql][google.spanner.v1.Spanner.ExecuteSql], except returns the result
@@ -100,7 +112,10 @@ service Spanner {
   // individual row in the result set can exceed 100 MiB, and no
   // column value can exceed 10 MiB.
   rpc ExecuteStreamingSql(ExecuteSqlRequest) returns (stream PartialResultSet) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:executeStreamingSql" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:executeStreamingSql"
+      body: "*"
+    };
   }
 
   // Reads rows from the database using key lookups and scans, as a
@@ -117,7 +132,10 @@ service Spanner {
   // Larger result sets can be yielded in streaming fashion by calling
   // [StreamingRead][google.spanner.v1.Spanner.StreamingRead] instead.
   rpc Read(ReadRequest) returns (ResultSet) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:read" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:read"
+      body: "*"
+    };
   }
 
   // Like [Read][google.spanner.v1.Spanner.Read], except returns the result set as a
@@ -126,7 +144,10 @@ service Spanner {
   // the result set can exceed 100 MiB, and no column value can exceed
   // 10 MiB.
   rpc StreamingRead(ReadRequest) returns (stream PartialResultSet) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:streamingRead" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:streamingRead"
+      body: "*"
+    };
   }
 
   // Begins a new transaction. This step can often be skipped:
@@ -134,7 +155,10 @@ service Spanner {
   // [Commit][google.spanner.v1.Spanner.Commit] can begin a new transaction as a
   // side-effect.
   rpc BeginTransaction(BeginTransactionRequest) returns (Transaction) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:beginTransaction" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:beginTransaction"
+      body: "*"
+    };
   }
 
   // Commits a transaction. The request includes the mutations to be
@@ -146,7 +170,10 @@ service Spanner {
   // reasons. If `Commit` returns `ABORTED`, the caller should re-attempt
   // the transaction from the beginning, re-using the same session.
   rpc Commit(CommitRequest) returns (CommitResponse) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:commit" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:commit"
+      body: "*"
+    };
   }
 
   // Rolls back a transaction, releasing any locks it holds. It is a good
@@ -158,7 +185,10 @@ service Spanner {
   // transaction was already aborted, or the transaction is not
   // found. `Rollback` never returns `ABORTED`.
   rpc Rollback(RollbackRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:rollback" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:rollback"
+      body: "*"
+    };
   }
 
   // Creates a set of partition tokens that can be used to execute a query
@@ -170,7 +200,10 @@ service Spanner {
   // Partition tokens become invalid when the session used to create them
   // is deleted or begins a new transaction.
   rpc PartitionQuery(PartitionQueryRequest) returns (PartitionResponse) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:partitionQuery" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:partitionQuery"
+      body: "*"
+    };
   }
 
   // Creates a set of partition tokens that can be used to execute a read
@@ -182,7 +215,10 @@ service Spanner {
   // Partition tokens become invalid when the session used to create them
   // is deleted or begins a new transaction.
   rpc PartitionRead(PartitionReadRequest) returns (PartitionResponse) {
-    option (google.api.http) = { post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:partitionRead" body: "*" };
+    option (google.api.http) = {
+      post: "/v1/{session=projects/*/instances/*/databases/*/sessions/*}:partitionRead"
+      body: "*"
+    };
   }
 }
 

--- a/protos/google/spanner/v1/transaction.proto
+++ b/protos/google/spanner/v1/transaction.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "TransactionProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // # Transactions

--- a/protos/google/spanner/v1/type.proto
+++ b/protos/google/spanner/v1/type.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ option go_package = "google.golang.org/genproto/googleapis/spanner/v1;spanner";
 option java_multiple_files = true;
 option java_outer_classname = "TypeProto";
 option java_package = "com.google.spanner.v1";
+option php_namespace = "Google\\Cloud\\Spanner\\V1";
 
 
 // `Type` indicates the type of a Cloud Spanner value, as might be stored in a

--- a/src/v1/database_admin_client.js
+++ b/src/v1/database_admin_client.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,10 +42,10 @@ class DatabaseAdminClient {
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
    * @param {string} [options.email] - Account email address. Required when
-   *   usaing a .pem or .p12 keyFilename.
+   *     using a .pem or .p12 keyFilename.
    * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
    *     .p12 key downloaded from the Google Developers Console. If you provide
-   *     a path to a JSON file, the projectId option above is not necessary.
+   *     a path to a JSON file, the projectId option below is not necessary.
    *     NOTE: .pem and .p12 require you to specify options.email as well.
    * @param {number} [options.port] - The port on which to connect to
    *     the remote host.

--- a/src/v1/doc/google/protobuf/doc_duration.js
+++ b/src/v1/doc/google/protobuf/doc_duration.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_struct.js
+++ b/src/v1/doc/google/protobuf/doc_struct.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_timestamp.js
+++ b/src/v1/doc/google/protobuf/doc_timestamp.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/spanner/v1/doc_keys.js
+++ b/src/v1/doc/google/spanner/v1/doc_keys.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/spanner/v1/doc_mutation.js
+++ b/src/v1/doc/google/spanner/v1/doc_mutation.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -102,6 +102,8 @@ var Mutation = {
    *
    * @property {Object} keySet
    *   Required. The primary keys of the rows within table to delete.
+   *   Delete is idempotent. The transaction will succeed even if some or all
+   *   rows do not exist.
    *
    *   This object should have the same structure as [KeySet]{@link google.spanner.v1.KeySet}
    *

--- a/src/v1/doc/google/spanner/v1/doc_query_plan.js
+++ b/src/v1/doc/google/spanner/v1/doc_query_plan.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/spanner/v1/doc_result_set.js
+++ b/src/v1/doc/google/spanner/v1/doc_result_set.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/spanner/v1/doc_spanner.js
+++ b/src/v1/doc/google/spanner/v1/doc_spanner.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,7 +38,8 @@ var CreateSessionRequest = {
  * A session in the Cloud Spanner API.
  *
  * @property {string} name
- *   The name of the session.
+ *   The name of the session. This is always system-assigned; values provided
+ *   when creating a session are ignored.
  *
  * @property {Object.<string, string>} labels
  *   The labels for the session.
@@ -208,9 +209,16 @@ var DeleteSessionRequest = {
  *
  * @property {number} queryMode
  *   Used to control the amount of debugging information returned in
- *   ResultSetStats.
+ *   ResultSetStats. If partition_token is set, query_mode can only
+ *   be set to QueryMode.NORMAL.
  *
  *   The number should be among the values of [QueryMode]{@link google.spanner.v1.QueryMode}
+ *
+ * @property {string} partitionToken
+ *   If present, results will be restricted to the specified partition
+ *   previously created using PartitionQuery().  There must be an exact
+ *   match for the values of fields common to this message and the
+ *   PartitionQueryRequest message used to create this partition_token.
  *
  * @typedef ExecuteSqlRequest
  * @memberof google.spanner.v1
@@ -248,6 +256,178 @@ var ExecuteSqlRequest = {
 };
 
 /**
+ * Options for a PartitionQueryRequest and
+ * PartitionReadRequest.
+ *
+ * @property {number} partitionSizeBytes
+ *   The desired data size for each partition generated.  The default for this
+ *   option is currently 1 GiB.  This is only a hint. The actual size of each
+ *   partition may be smaller or larger than this size request.
+ *
+ * @property {number} maxPartitions
+ *   The desired maximum number of partitions to return.  For example, this may
+ *   be set to the number of workers available.  The default for this option
+ *   is currently 10,000. The maximum value is currently 200,000.  This is only
+ *   a hint.  The actual number of partitions returned may be smaller or larger
+ *   than this maximum count request.
+ *
+ * @typedef PartitionOptions
+ * @memberof google.spanner.v1
+ * @see [google.spanner.v1.PartitionOptions definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto}
+ */
+var PartitionOptions = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The request for PartitionQuery
+ *
+ * @property {string} session
+ *   Required. The session used to create the partitions.
+ *
+ * @property {Object} transaction
+ *   Read only snapshot transactions are supported, read/write and single use
+ *   transactions are not.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link google.spanner.v1.TransactionSelector}
+ *
+ * @property {string} sql
+ *   The query request to generate partitions for. The request will fail if
+ *   the query is not root partitionable. The query plan of a root
+ *   partitionable query has a single distributed union operator. A distributed
+ *   union operator conceptually divides one or more tables into multiple
+ *   splits, remotely evaluates a subquery independently on each split, and
+ *   then unions all results.
+ *
+ * @property {Object} params
+ *   The SQL query string can contain parameter placeholders. A parameter
+ *   placeholder consists of `'@'` followed by the parameter
+ *   name. Parameter names consist of any combination of letters,
+ *   numbers, and underscores.
+ *
+ *   Parameters can appear anywhere that a literal value is expected.  The same
+ *   parameter name can be used more than once, for example:
+ *     `"WHERE id > @msg_id AND id < @msg_id + 100"`
+ *
+ *   It is an error to execute an SQL query with unbound parameters.
+ *
+ *   Parameter values are specified using `params`, which is a JSON
+ *   object whose keys are parameter names, and whose values are the
+ *   corresponding parameter values.
+ *
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+ *
+ * @property {Object.<string, Object>} paramTypes
+ *   It is not always possible for Cloud Spanner to infer the right SQL type
+ *   from a JSON value.  For example, values of type `BYTES` and values
+ *   of type `STRING` both appear in params as JSON strings.
+ *
+ *   In these cases, `param_types` can be used to specify the exact
+ *   SQL type for some or all of the SQL query parameters. See the
+ *   definition of Type for more information
+ *   about SQL types.
+ *
+ * @property {Object} partitionOptions
+ *   Additional options that affect how many partitions are created.
+ *
+ *   This object should have the same structure as [PartitionOptions]{@link google.spanner.v1.PartitionOptions}
+ *
+ * @typedef PartitionQueryRequest
+ * @memberof google.spanner.v1
+ * @see [google.spanner.v1.PartitionQueryRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto}
+ */
+var PartitionQueryRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The request for PartitionRead
+ *
+ * @property {string} session
+ *   Required. The session used to create the partitions.
+ *
+ * @property {Object} transaction
+ *   Read only snapshot transactions are supported, read/write and single use
+ *   transactions are not.
+ *
+ *   This object should have the same structure as [TransactionSelector]{@link google.spanner.v1.TransactionSelector}
+ *
+ * @property {string} table
+ *   Required. The name of the table in the database to be read.
+ *
+ * @property {string} index
+ *   If non-empty, the name of an index on table. This index is
+ *   used instead of the table primary key when interpreting key_set
+ *   and sorting result rows. See key_set for further information.
+ *
+ * @property {string[]} columns
+ *   The columns of table to be returned for each row matching
+ *   this request.
+ *
+ * @property {Object} keySet
+ *   Required. `key_set` identifies the rows to be yielded. `key_set` names the
+ *   primary keys of the rows in table to be yielded, unless index
+ *   is present. If index is present, then key_set instead names
+ *   index keys in index.
+ *
+ *   It is not an error for the `key_set` to name rows that do not
+ *   exist in the database. Read yields nothing for nonexistent rows.
+ *
+ *   This object should have the same structure as [KeySet]{@link google.spanner.v1.KeySet}
+ *
+ * @property {Object} partitionOptions
+ *   Additional options that affect how many partitions are created.
+ *
+ *   This object should have the same structure as [PartitionOptions]{@link google.spanner.v1.PartitionOptions}
+ *
+ * @typedef PartitionReadRequest
+ * @memberof google.spanner.v1
+ * @see [google.spanner.v1.PartitionReadRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto}
+ */
+var PartitionReadRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Information returned for each partition returned in a
+ * PartitionResponse.
+ *
+ * @property {string} partitionToken
+ *   This token can be passed to Read, StreamingRead, ExecuteSql, or
+ *   ExecuteStreamingSql requests to restrict the results to those identified by
+ *   this partition token.
+ *
+ * @typedef Partition
+ * @memberof google.spanner.v1
+ * @see [google.spanner.v1.Partition definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto}
+ */
+var Partition = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * The response for PartitionQuery
+ * or PartitionRead
+ *
+ * @property {Object[]} partitions
+ *   Partitions created by this request.
+ *
+ *   This object should have the same structure as [Partition]{@link google.spanner.v1.Partition}
+ *
+ * @property {Object} transaction
+ *   Transaction created by this request.
+ *
+ *   This object should have the same structure as [Transaction]{@link google.spanner.v1.Transaction}
+ *
+ * @typedef PartitionResponse
+ * @memberof google.spanner.v1
+ * @see [google.spanner.v1.PartitionResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/spanner/v1/spanner.proto}
+ */
+var PartitionResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
  * The request for Read and
  * StreamingRead.
  *
@@ -278,8 +458,10 @@ var ExecuteSqlRequest = {
  *   is present. If index is present, then key_set instead names
  *   index keys in index.
  *
- *   Rows are yielded in table primary key order (if index is empty)
- *   or index key order (if index is non-empty).
+ *   If the partition_token field is empty, rows are yielded
+ *   in table primary key order (if index is empty) or index key order
+ *   (if index is non-empty).  If the partition_token field is not
+ *   empty, rows will be yielded in an unspecified order.
  *
  *   It is not an error for the `key_set` to name rows that do not
  *   exist in the database. Read yields nothing for nonexistent rows.
@@ -288,7 +470,8 @@ var ExecuteSqlRequest = {
  *
  * @property {number} limit
  *   If greater than zero, only the first `limit` rows are yielded. If `limit`
- *   is zero, the default is no limit.
+ *   is zero, the default is no limit. A limit cannot be specified if
+ *   `partition_token` is set.
  *
  * @property {string} resumeToken
  *   If this request is resuming a previously interrupted read,
@@ -297,6 +480,12 @@ var ExecuteSqlRequest = {
  *   enables the new read to resume where the last read left off. The
  *   rest of the request parameters must exactly match the request
  *   that yielded this token.
+ *
+ * @property {string} partitionToken
+ *   If present, results will be restricted to the specified partition
+ *   previously created using PartitionRead().    There must be an exact
+ *   match for the values of fields common to this message and the
+ *   PartitionReadRequest message used to create this partition_token.
  *
  * @typedef ReadRequest
  * @memberof google.spanner.v1

--- a/src/v1/doc/google/spanner/v1/doc_transaction.js
+++ b/src/v1/doc/google/spanner/v1/doc_transaction.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/instance_admin_client.js
+++ b/src/v1/instance_admin_client.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google Inc. All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -58,10 +58,10 @@ class InstanceAdminClient {
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
    * @param {string} [options.email] - Account email address. Required when
-   *   usaing a .pem or .p12 keyFilename.
+   *     using a .pem or .p12 keyFilename.
    * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
    *     .p12 key downloaded from the Google Developers Console. If you provide
-   *     a path to a JSON file, the projectId option above is not necessary.
+   *     a path to a JSON file, the projectId option below is not necessary.
    *     NOTE: .pem and .p12 require you to specify options.email as well.
    * @param {number} [options.port] - The port on which to connect to
    *     the remote host.

--- a/src/v1/spanner_client.js
+++ b/src/v1/spanner_client.js
@@ -40,10 +40,10 @@ class SpannerClient {
    * @param {string} [options.credentials.client_email]
    * @param {string} [options.credentials.private_key]
    * @param {string} [options.email] - Account email address. Required when
-   *   usaing a .pem or .p12 keyFilename.
+   *     using a .pem or .p12 keyFilename.
    * @param {string} [options.keyFilename] - Full path to the a .json, .pem, or
    *     .p12 key downloaded from the Google Developers Console. If you provide
-   *     a path to a JSON file, the projectId option above is not necessary.
+   *     a path to a JSON file, the projectId option below is not necessary.
    *     NOTE: .pem and .p12 require you to specify options.email as well.
    * @param {number} [options.port] - The port on which to connect to
    *     the remote host.
@@ -205,7 +205,6 @@ class SpannerClient {
   static get scopes() {
     return [
       'https://www.googleapis.com/auth/cloud-platform',
-      'https://www.googleapis.com/auth/spanner.admin',
       'https://www.googleapis.com/auth/spanner.data',
     ];
   }
@@ -607,7 +606,8 @@ class SpannerClient {
    *   request that yielded this token.
    * @param {number} [request.queryMode]
    *   Used to control the amount of debugging information returned in
-   *   ResultSetStats.
+   *   ResultSetStats. If partition_token is set, query_mode can only
+   *   be set to QueryMode.NORMAL.
    *
    *   The number should be among the values of [QueryMode]{@link google.spanner.v1.QueryMode}
    * @param {string} [request.partitionToken]
@@ -712,7 +712,8 @@ class SpannerClient {
    *   request that yielded this token.
    * @param {number} [request.queryMode]
    *   Used to control the amount of debugging information returned in
-   *   ResultSetStats.
+   *   ResultSetStats. If partition_token is set, query_mode can only
+   *   be set to QueryMode.NORMAL.
    *
    *   The number should be among the values of [QueryMode]{@link google.spanner.v1.QueryMode}
    * @param {string} [request.partitionToken]

--- a/src/v1/spanner_client_config.json
+++ b/src/v1/spanner_client_config.json
@@ -88,7 +88,7 @@
           "retry_params_name": "default"
         },
         "PartitionQuery": {
-          "timeout_millis": 3600000,
+          "timeout_millis": 30000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },

--- a/test/gapic-v1-database-admin.js
+++ b/test/gapic-v1-database-admin.js
@@ -1,0 +1,721 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+
+const spannerModule = require('../src');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('DatabaseAdminClient', () => {
+  describe('listDatabases', () => {
+    it('invokes listDatabases without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var databasesElement = {};
+      var databases = [databasesElement];
+      var expectedResponse = {
+        nextPageToken: nextPageToken,
+        databases: databases,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listDatabases = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.databases);
+      };
+
+      client.listDatabases(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.databases);
+        done();
+      });
+    });
+
+    it('invokes listDatabases with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listDatabases = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listDatabases(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('createDatabase', function() {
+    it('invokes createDatabase without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var createStatement = 'createStatement552974828';
+      var request = {
+        parent: formattedParent,
+        createStatement: createStatement,
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var expectedResponse = {
+        name: name,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createDatabase = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .createDatabase(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes createDatabase with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var createStatement = 'createStatement552974828';
+      var request = {
+        parent: formattedParent,
+        createStatement: createStatement,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createDatabase = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .createDatabase(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.createDatabase
+          .responseDecoder instanceof Function
+      );
+      assert(
+        client._descriptors.longrunning.createDatabase
+          .metadataDecoder instanceof Function
+      );
+    });
+  });
+
+  describe('getDatabase', () => {
+    it('invokes getDatabase without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var expectedResponse = {
+        name: name2,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getDatabase = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getDatabase(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getDatabase with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getDatabase = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getDatabase(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('updateDatabaseDdl', function() {
+    it('invokes updateDatabaseDdl without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var statements = [];
+      var request = {
+        database: formattedDatabase,
+        statements: statements,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateDatabaseDdl = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .updateDatabaseDdl(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes updateDatabaseDdl with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var statements = [];
+      var request = {
+        database: formattedDatabase,
+        statements: statements,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateDatabaseDdl = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .updateDatabaseDdl(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.updateDatabaseDdl
+          .responseDecoder instanceof Function
+      );
+      assert(
+        client._descriptors.longrunning.updateDatabaseDdl
+          .metadataDecoder instanceof Function
+      );
+    });
+  });
+
+  describe('dropDatabase', () => {
+    it('invokes dropDatabase without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.dropDatabase = mockSimpleGrpcMethod(request);
+
+      client.dropDatabase(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes dropDatabase with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.dropDatabase = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.dropDatabase(request, err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('getDatabaseDdl', () => {
+    it('invokes getDatabaseDdl without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.getDatabaseDdl = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getDatabaseDdl(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getDatabaseDdl with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getDatabaseDdl = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getDatabaseDdl(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('setIamPolicy', () => {
+    it('invokes setIamPolicy without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var policy = {};
+      var request = {
+        resource: formattedResource,
+        policy: policy,
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+        version: version,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.setIamPolicy = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.setIamPolicy(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes setIamPolicy with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var policy = {};
+      var request = {
+        resource: formattedResource,
+        policy: policy,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.setIamPolicy = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.setIamPolicy(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getIamPolicy', () => {
+    it('invokes getIamPolicy without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        resource: formattedResource,
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+        version: version,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getIamPolicy = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getIamPolicy(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getIamPolicy with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        resource: formattedResource,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getIamPolicy = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getIamPolicy(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('testIamPermissions', () => {
+    it('invokes testIamPermissions without error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var permissions = [];
+      var request = {
+        resource: formattedResource,
+        permissions: permissions,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.testIamPermissions = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.testIamPermissions(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes testIamPermissions with error', done => {
+      var client = new spannerModule.v1.DatabaseAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var permissions = [];
+      var request = {
+        resource: formattedResource,
+        permissions: permissions,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.testIamPermissions = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.testIamPermissions(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockLongRunningGrpcMethod(expectedRequest, response, error) {
+  return request => {
+    assert.deepStrictEqual(request, expectedRequest);
+    var mockOperation = {
+      promise: function() {
+        return new Promise((resolve, reject) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve([response]);
+          }
+        });
+      },
+    };
+    return Promise.resolve([mockOperation]);
+  };
+}

--- a/test/gapic-v1-instance-admin.js
+++ b/test/gapic-v1-instance-admin.js
@@ -1,0 +1,768 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+
+const spannerModule = require('../src');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('InstanceAdminClient', () => {
+  describe('listInstanceConfigs', () => {
+    it('invokes listInstanceConfigs without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var instanceConfigsElement = {};
+      var instanceConfigs = [instanceConfigsElement];
+      var expectedResponse = {
+        nextPageToken: nextPageToken,
+        instanceConfigs: instanceConfigs,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listInstanceConfigs = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.instanceConfigs);
+      };
+
+      client.listInstanceConfigs(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.instanceConfigs);
+        done();
+      });
+    });
+
+    it('invokes listInstanceConfigs with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listInstanceConfigs = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listInstanceConfigs(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getInstanceConfig', () => {
+    it('invokes getInstanceConfig without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instanceConfigPath(
+        '[PROJECT]',
+        '[INSTANCE_CONFIG]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var displayName = 'displayName1615086568';
+      var expectedResponse = {
+        name: name2,
+        displayName: displayName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getInstanceConfig = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getInstanceConfig(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getInstanceConfig with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instanceConfigPath(
+        '[PROJECT]',
+        '[INSTANCE_CONFIG]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getInstanceConfig = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getInstanceConfig(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('listInstances', () => {
+    it('invokes listInstances without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var instancesElement = {};
+      var instances = [instancesElement];
+      var expectedResponse = {
+        nextPageToken: nextPageToken,
+        instances: instances,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listInstances = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.instances);
+      };
+
+      client.listInstances(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.instances);
+        done();
+      });
+    });
+
+    it('invokes listInstances with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var request = {
+        parent: formattedParent,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listInstances = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listInstances(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getInstance', () => {
+    it('invokes getInstance without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+        name: name2,
+        config: config,
+        displayName: displayName,
+        nodeCount: nodeCount,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getInstance = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getInstance(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getInstance with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getInstance = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getInstance(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('createInstance', function() {
+    it('invokes createInstance without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var instanceId = 'instanceId-2101995259';
+      var instance = {};
+      var request = {
+        parent: formattedParent,
+        instanceId: instanceId,
+        instance: instance,
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+        name: name,
+        config: config,
+        displayName: displayName,
+        nodeCount: nodeCount,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createInstance = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .createInstance(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes createInstance with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedParent = client.projectPath('[PROJECT]');
+      var instanceId = 'instanceId-2101995259';
+      var instance = {};
+      var request = {
+        parent: formattedParent,
+        instanceId: instanceId,
+        instance: instance,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createInstance = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .createInstance(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.createInstance
+          .responseDecoder instanceof Function
+      );
+      assert(
+        client._descriptors.longrunning.createInstance
+          .metadataDecoder instanceof Function
+      );
+    });
+  });
+
+  describe('updateInstance', function() {
+    it('invokes updateInstance without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var instance = {};
+      var fieldMask = {};
+      var request = {
+        instance: instance,
+        fieldMask: fieldMask,
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var config = 'config-1354792126';
+      var displayName = 'displayName1615086568';
+      var nodeCount = 1539922066;
+      var expectedResponse = {
+        name: name,
+        config: config,
+        displayName: displayName,
+        nodeCount: nodeCount,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateInstance = mockLongRunningGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client
+        .updateInstance(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(responses => {
+          assert.deepStrictEqual(responses[0], expectedResponse);
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
+
+    it('invokes updateInstance with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var instance = {};
+      var fieldMask = {};
+      var request = {
+        instance: instance,
+        fieldMask: fieldMask,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.updateInstance = mockLongRunningGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client
+        .updateInstance(request)
+        .then(responses => {
+          var operation = responses[0];
+          return operation.promise();
+        })
+        .then(() => {
+          assert.fail();
+        })
+        .catch(err => {
+          assert(err instanceof Error);
+          assert.equal(err.code, FAKE_STATUS_CODE);
+          done();
+        });
+    });
+
+    it('has longrunning decoder functions', () => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+      assert(
+        client._descriptors.longrunning.updateInstance
+          .responseDecoder instanceof Function
+      );
+      assert(
+        client._descriptors.longrunning.updateInstance
+          .metadataDecoder instanceof Function
+      );
+    });
+  });
+
+  describe('deleteInstance', () => {
+    it('invokes deleteInstance without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.deleteInstance = mockSimpleGrpcMethod(request);
+
+      client.deleteInstance(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes deleteInstance with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.deleteInstance = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.deleteInstance(request, err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('setIamPolicy', () => {
+    it('invokes setIamPolicy without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var policy = {};
+      var request = {
+        resource: formattedResource,
+        policy: policy,
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+        version: version,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.setIamPolicy = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.setIamPolicy(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes setIamPolicy with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var policy = {};
+      var request = {
+        resource: formattedResource,
+        policy: policy,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.setIamPolicy = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.setIamPolicy(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getIamPolicy', () => {
+    it('invokes getIamPolicy without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        resource: formattedResource,
+      };
+
+      // Mock response
+      var version = 351608024;
+      var etag = '21';
+      var expectedResponse = {
+        version: version,
+        etag: etag,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getIamPolicy = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getIamPolicy(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getIamPolicy with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var request = {
+        resource: formattedResource,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getIamPolicy = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getIamPolicy(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('testIamPermissions', () => {
+    it('invokes testIamPermissions without error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var permissions = [];
+      var request = {
+        resource: formattedResource,
+        permissions: permissions,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.testIamPermissions = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.testIamPermissions(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes testIamPermissions with error', done => {
+      var client = new spannerModule.v1.InstanceAdminClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedResource = client.instancePath('[PROJECT]', '[INSTANCE]');
+      var permissions = [];
+      var request = {
+        resource: formattedResource,
+        permissions: permissions,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.testIamPermissions = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.testIamPermissions(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockLongRunningGrpcMethod(expectedRequest, response, error) {
+  return request => {
+    assert.deepStrictEqual(request, expectedRequest);
+    var mockOperation = {
+      promise: function() {
+        return new Promise((resolve, reject) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve([response]);
+          }
+        });
+      },
+    };
+    return Promise.resolve([mockOperation]);
+  };
+}

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -1,0 +1,1001 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const through2 = require('through2');
+
+const spannerModule = require('../src');
+
+var FAKE_STATUS_CODE = 1;
+var error = new Error();
+error.code = FAKE_STATUS_CODE;
+
+describe('SpannerClient', () => {
+  describe('createSession', () => {
+    it('invokes createSession without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock response
+      var name = 'name3373707';
+      var expectedResponse = {
+        name: name,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createSession = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.createSession(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes createSession with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.createSession = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.createSession(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('getSession', () => {
+    it('invokes getSession without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var expectedResponse = {
+        name: name2,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getSession = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.getSession(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes getSession with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.getSession = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.getSession(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('listSessions', () => {
+    it('invokes listSessions without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock response
+      var nextPageToken = '';
+      var sessionsElement = {};
+      var sessions = [sessionsElement];
+      var expectedResponse = {
+        nextPageToken: nextPageToken,
+        sessions: sessions,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listSessions = (
+        actualRequest,
+        options,
+        callback
+      ) => {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null, expectedResponse.sessions);
+      };
+
+      client.listSessions(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse.sessions);
+        done();
+      });
+    });
+
+    it('invokes listSessions with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedDatabase = client.databasePath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]'
+      );
+      var request = {
+        database: formattedDatabase,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.listSessions = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.listSessions(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('deleteSession', () => {
+    it('invokes deleteSession without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.deleteSession = mockSimpleGrpcMethod(request);
+
+      client.deleteSession(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes deleteSession with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedName = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var request = {
+        name: formattedName,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.deleteSession = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.deleteSession(request, err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('executeSql', () => {
+    it('invokes executeSql without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.executeSql = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.executeSql(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes executeSql with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.executeSql = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.executeSql(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('executeStreamingSql', () => {
+    it('invokes executeStreamingSql without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock response
+      var chunkedValue = true;
+      var resumeToken = '103';
+      var expectedResponse = {
+        chunkedValue: chunkedValue,
+        resumeToken: resumeToken,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.executeStreamingSql = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      var stream = client.executeStreamingSql(request);
+      stream.on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+      stream.on('error', err => {
+        done(err);
+      });
+
+      stream.write();
+    });
+
+    it('invokes executeStreamingSql with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.executeStreamingSql = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      var stream = client.executeStreamingSql(request);
+      stream.on('data', () => {
+        assert.fail();
+      });
+      stream.on('error', err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write();
+    });
+  });
+
+  describe('read', () => {
+    it('invokes read without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        columns: columns,
+        keySet: keySet,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.read = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.read(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes read with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        columns: columns,
+        keySet: keySet,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.read = mockSimpleGrpcMethod(request, null, error);
+
+      client.read(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('streamingRead', () => {
+    it('invokes streamingRead without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        columns: columns,
+        keySet: keySet,
+      };
+
+      // Mock response
+      var chunkedValue = true;
+      var resumeToken = '103';
+      var expectedResponse = {
+        chunkedValue: chunkedValue,
+        resumeToken: resumeToken,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingRead = mockServerStreamingGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      var stream = client.streamingRead(request);
+      stream.on('data', response => {
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+      stream.on('error', err => {
+        done(err);
+      });
+
+      stream.write();
+    });
+
+    it('invokes streamingRead with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var columns = [];
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        columns: columns,
+        keySet: keySet,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.streamingRead = mockServerStreamingGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      var stream = client.streamingRead(request);
+      stream.on('data', () => {
+        assert.fail();
+      });
+      stream.on('error', err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+
+      stream.write();
+    });
+  });
+
+  describe('beginTransaction', () => {
+    it('invokes beginTransaction without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var options = {};
+      var request = {
+        session: formattedSession,
+        options: options,
+      };
+
+      // Mock response
+      var id = '27';
+      var expectedResponse = {
+        id: id,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.beginTransaction = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.beginTransaction(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes beginTransaction with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var options = {};
+      var request = {
+        session: formattedSession,
+        options: options,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.beginTransaction = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.beginTransaction(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('commit', () => {
+    it('invokes commit without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var mutations = [];
+      var request = {
+        session: formattedSession,
+        mutations: mutations,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.commit = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.commit(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes commit with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var mutations = [];
+      var request = {
+        session: formattedSession,
+        mutations: mutations,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.commit = mockSimpleGrpcMethod(request, null, error);
+
+      client.commit(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('rollback', () => {
+    it('invokes rollback without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var transactionId = '28';
+      var request = {
+        session: formattedSession,
+        transactionId: transactionId,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.rollback = mockSimpleGrpcMethod(request);
+
+      client.rollback(request, err => {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('invokes rollback with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var transactionId = '28';
+      var request = {
+        session: formattedSession,
+        transactionId: transactionId,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.rollback = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.rollback(request, err => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        done();
+      });
+    });
+  });
+
+  describe('partitionQuery', () => {
+    it('invokes partitionQuery without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.partitionQuery = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.partitionQuery(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes partitionQuery with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var sql = 'sql114126';
+      var request = {
+        session: formattedSession,
+        sql: sql,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.partitionQuery = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.partitionQuery(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+
+  describe('partitionRead', () => {
+    it('invokes partitionRead without error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        keySet: keySet,
+      };
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._innerApiCalls.partitionRead = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.partitionRead(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+
+    it('invokes partitionRead with error', done => {
+      var client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      var formattedSession = client.sessionPath(
+        '[PROJECT]',
+        '[INSTANCE]',
+        '[DATABASE]',
+        '[SESSION]'
+      );
+      var table = 'table110115790';
+      var keySet = {};
+      var request = {
+        session: formattedSession,
+        table: table,
+        keySet: keySet,
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.partitionRead = mockSimpleGrpcMethod(
+        request,
+        null,
+        error
+      );
+
+      client.partitionRead(request, (err, response) => {
+        assert(err instanceof Error);
+        assert.equal(err.code, FAKE_STATUS_CODE);
+        assert(typeof response === 'undefined');
+        done();
+      });
+    });
+  });
+});
+
+function mockSimpleGrpcMethod(expectedRequest, response, error) {
+  return function(actualRequest, options, callback) {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    if (error) {
+      callback(error);
+    } else if (response) {
+      callback(null, response);
+    } else {
+      callback(null);
+    }
+  };
+}
+
+function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
+  return actualRequest => {
+    assert.deepStrictEqual(actualRequest, expectedRequest);
+    var mockStream = through2.obj((chunk, enc, callback) => {
+      if (error) {
+        callback(error);
+      } else {
+        callback(null, response);
+      }
+    });
+    return mockStream;
+  };
+}


### PR DESCRIPTION
Regenerating GAPIC code for spanner, database admin and instance admin. I think it only contains docs and cosmetic changes. Also, added three auto-generated unit test files.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
