### PR TITLE
testing: remove samples after hook

### DIFF
--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -65,22 +65,6 @@ test.before(async () => {
   await operation.promise();
 });
 
-test.after.always(async () => {
-  const instance = spanner.instance(INSTANCE_ID);
-  const database = instance.database(DATABASE_ID);
-  try {
-    await database.delete();
-  } catch (err) {
-    // Ignore error
-  }
-
-  try {
-    await instance.delete();
-  } catch (err) {
-    // Ignore error
-  }
-});
-
 // create_database
 test.serial(`should create an example database`, async t => {
   const results = await tools.runAsyncWithIO(


### PR DESCRIPTION
Test resources get deleted in the before hook and it appears as though deleting our instance in the after hook triggers an error somewhere.

https://circleci.com/gh/googleapis/nodejs-spanner/2886