### PR TITLE
bugfix: promisify database#delete

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1529,7 +1529,6 @@ Database.prototype.session_ = function(name) {
 common.util.promisifyAll(Database, {
   exclude: [
     'batchTransaction',
-    'delete',
     'getMetadata',
     'runTransaction',
     'table',

--- a/test/database.js
+++ b/test/database.js
@@ -34,7 +34,6 @@ var fakeUtil = extend({}, util, {
     promisified = true;
     assert.deepEqual(options.exclude, [
       'batchTransaction',
-      'delete',
       'getMetadata',
       'runTransaction',
       'table',


### PR DESCRIPTION
I think we used to exclude it because we returned the gapic request, but never included it after changing that.