### PR TITLE
test: make sure tests can run in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "power-assert": "^1.4.4",
     "prettier": "^1.7.4",
     "proxyquire": "^2.0.0",
+    "request": "^2.83.0",
     "stats-lite": "^2.1.0",
     "time-span": "^2.0.0",
     "uuid": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "power-assert": "^1.4.4",
     "prettier": "^1.7.4",
     "proxyquire": "^2.0.0",
-    "request": "^2.83.0",
     "stats-lite": "^2.1.0",
     "time-span": "^2.0.0",
     "uuid": "^3.2.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -21,6 +21,7 @@
     "@google-cloud/nodejs-repo-tools": "2.1.0",
     "ava": "0.22.0",
     "proxyquire": "1.8.0",
+    "request": "^2.83.0",
     "sinon": "3.2.1"
   }
 }

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const path = require(`path`);
-const request = require('request');
+const request = require(`request`);
 const Spanner = require(`@google-cloud/spanner`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
@@ -87,7 +87,7 @@ test.before(async () => {
 
         return instanceCreated < yesterday;
       })
-      .forEach(async operation => await instance.delete());
+      .forEach(async () => await instance.delete());
   });
 });
 

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -38,7 +38,7 @@ const spanner = new Spanner({
   projectId: PROJECT_ID,
 });
 
-test.before(tools.checkCredentials());
+test.before(tools.checkCredentials);
 
 test.before(async () => {
   const instance = spanner.instance(INSTANCE_ID);

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const path = require(`path`);
+const request = require('request');
 const Spanner = require(`@google-cloud/spanner`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
@@ -37,18 +38,17 @@ const spanner = new Spanner({
   projectId: PROJECT_ID,
 });
 
-test.before(async () => {
-  tools.checkCredentials();
+test.before(tools.checkCredentials());
 
+test.before(async () => {
   const instance = spanner.instance(INSTANCE_ID);
+  const database = instance.database(DATABASE_ID);
 
   try {
     await instance.delete();
   } catch (err) {
     // Ignore error
   }
-
-  const database = instance.database(DATABASE_ID);
 
   try {
     await database.delete();
@@ -67,9 +67,34 @@ test.before(async () => {
   await operation.promise();
 });
 
+test.before(async () => {
+  const [instances] = await spanner.getInstances({
+    filter: 'labels.gcloud-tests:true',
+  });
+
+  instances.forEach(async instance => {
+    const {operations} = await getOperations(instance.metadata.name);
+
+    operations
+      .filter(operation => {
+        return operation.metadata['@type'].includes('CreateInstance');
+      })
+      .filter(operation => {
+        const yesterday = new Date();
+        yesterday.setHours(-24);
+
+        const instanceCreated = new Date(operation.metadata.startTime);
+
+        return instanceCreated < yesterday;
+      })
+      .forEach(async operation => await instance.delete());
+  });
+});
+
 test.after.always(async () => {
   const instance = spanner.instance(INSTANCE_ID);
   const database = instance.database(DATABASE_ID);
+
   try {
     await database.delete();
   } catch (err) {
@@ -339,3 +364,34 @@ test.serial(`should execute a partition`, async t => {
 
   await transaction.close();
 });
+
+function apiRequest(reqOpts) {
+  return new Promise((resolve, reject) => {
+    spanner.auth.authorizeRequest(reqOpts, (err, reqOpts) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      request(reqOpts, (err, response) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(response.body));
+        } catch (e) {
+          reject(e);
+          return;
+        }
+      });
+    });
+  });
+}
+
+function getOperations(instanceName) {
+  return apiRequest({
+    uri: `https://spanner.googleapis.com/v1/${instanceName}/operations`,
+  });
+}


### PR DESCRIPTION
Since the problem of failing spanner tests was resolved in #148, the fix from #147 is not needed so let's put it back: we still want to delete our test data. Also, since we now allow multiple samples tests to run simultaneously (#149), we need to make sure that they are working with different instances, otherwise, when two CI tasks run simultaneously, the `before` hook of the second run will delete the instance that the first run is still using.

[Also, found out that we cannot just make the test run in parallel, as they depend on their order. Ideally, they should be rewritten :)]

- [x] Tests and linter pass
- [x] And samples tests pass as well
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
