### PR TITLE
test: fix get session by name test

### DIFF
--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -864,7 +864,7 @@ describe('Spanner', function() {
       session.delete(done);
     });
 
-    it.only('should have created the session', function(done) {
+    it('should have created the session', function(done) {
       session.getMetadata(function(err, metadata) {
         assert.ifError(err);
         assert.strictEqual(session.formattedName_, metadata.name);
@@ -872,7 +872,7 @@ describe('Spanner', function() {
       });
     });
 
-    it.only('should get a session by name', function(done) {
+    it('should get a session by name', function(done) {
       var shortName = session.formattedName_.split('/').pop();
       var sessionByShortName = database.session_(shortName);
 
@@ -886,7 +886,7 @@ describe('Spanner', function() {
       });
     });
 
-    it.only('should keep the session alive', function(done) {
+    it('should keep the session alive', function(done) {
       session.keepAlive(done);
     });
   });

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -864,7 +864,7 @@ describe('Spanner', function() {
       session.delete(done);
     });
 
-    it('should have created the session', function(done) {
+    it.only('should have created the session', function(done) {
       session.getMetadata(function(err, metadata) {
         assert.ifError(err);
         assert.strictEqual(session.formattedName_, metadata.name);
@@ -872,18 +872,21 @@ describe('Spanner', function() {
       });
     });
 
-    it('should get a session by name', function(done) {
+    it.only('should get a session by name', function(done) {
       var shortName = session.formattedName_.split('/').pop();
       var sessionByShortName = database.session_(shortName);
 
-      sessionByShortName.getMetadata(function(err, metadata) {
+      sessionByShortName.getMetadata(function(err, metadataByName) {
         assert.ifError(err);
-        assert.strictEqual(metadata.name, session.metadata.name);
-        done();
+        session.getMetadata(function(err, metadata) {
+          assert.ifError(err);
+          assert.strictEqual(metadataByName.name, metadata.name);
+          done();
+        });
       });
     });
 
-    it('should keep the session alive', function(done) {
+    it.only('should keep the session alive', function(done) {
       session.keepAlive(done);
     });
   });


### PR DESCRIPTION
The test `should get a session by name` always fails for me. Looks like the `session.metadata` is an empty object, but `.getMetadata()` resolves to a valid metadata that can be used for comparison. @callmehiphop, please review if the test fix looks good to you :)

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
