### PR TITLE
fix(sessionPool): fix race condition

### DIFF
--- a/src/session-pool.js
+++ b/src/session-pool.js
@@ -730,10 +730,6 @@ SessionPool.prototype.needsFill_ = function() {
 SessionPool.prototype.onAvailable_ = function() {
   var self = this;
 
-  if (this.available() > 0) {
-    return Promise.resolve();
-  }
-
   return new Promise(function(resolve) {
     self.once('available', resolve);
   });
@@ -932,6 +928,10 @@ SessionPool.prototype.waitForNextAvailable_ = function(type) {
   var self = this;
 
   return this.acquireQueue_.add(function() {
+    if (self.available() > 0) {
+      return self.getNextAvailableSession_(type);
+    }
+
     return self.onAvailable_().then(function() {
       return self.getNextAvailableSession_(type);
     });


### PR DESCRIPTION
Fixes #173

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

### Summary of Changes

In the event that the client is waiting for multiple sessions to free up, it was possible that we hit a race condition where the pool thought there were sessions available, when in fact there were not.