### PR TITLE
refactor: use protobufjs library to load proto file

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -56,12 +56,7 @@ var DEFAULT_TRANSACTION_TIMEOUT = config.methods.Commit.timeout_millis;
 
 var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
 protoFilesRoot = protobuf.loadSync(
-  path.join(
-    __dirname,
-    '..',
-    'protos',
-    'google/rpc/error_details.proto'
-  ),
+  path.join(__dirname, '..', 'protos', 'google/rpc/error_details.proto'),
   protoFilesRoot
 );
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -21,6 +21,7 @@ var extend = require('extend');
 var gax = require('google-gax');
 var is = require('is');
 var path = require('path');
+var protobuf = require('protobufjs');
 var through = require('through2');
 var util = require('util');
 
@@ -53,19 +54,18 @@ var RETRY_INFO_KEY = 'google.rpc.retryinfo-bin';
  */
 var DEFAULT_TRANSACTION_TIMEOUT = config.methods.Commit.timeout_millis;
 
-var services = gax.grpc().load(
-  {
-    root: path.resolve(__dirname, '../protos'),
-    file: 'google/rpc/error_details.proto',
-  },
-  'proto',
-  {
-    binaryAsBase64: true,
-    convertFieldsToCamelCase: true,
-  }
+var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+protoFilesRoot = protobuf.loadSync(
+  path.join(
+    __dirname,
+    '..',
+    'protos',
+    'google/rpc/error_details.proto'
+  ),
+  protoFilesRoot
 );
 
-var RetryInfo = services.google.rpc.RetryInfo;
+var RetryInfo = protoFilesRoot.lookup('google.rpc.RetryInfo');
 
 /**
  * Read/write transaction options.

--- a/test/transaction.js
+++ b/test/transaction.js
@@ -30,24 +30,20 @@ var FakeRetryInfo = {
   decode: util.noop,
 };
 
-var grpc = gax.grpc();
-var fakeGrpc = {
-  load: function(options, type, config) {
-    assert.strictEqual(options.root, path.resolve(__dirname, '../protos'));
-    assert.strictEqual(options.file, 'google/rpc/error_details.proto');
-    assert.strictEqual(type, 'proto');
-    assert.strictEqual(config.binaryAsBase64, true);
-    assert.strictEqual(config.convertFieldsToCamelCase, true);
-
-    var services = grpc.load(options, type, config);
-    services.google.rpc.RetryInfo = FakeRetryInfo;
-    return services;
-  },
-};
-
 var fakeGax = {
-  grpc: function() {
-    return fakeGrpc;
+  grpc: {
+    GoogleProtoFilesRoot: class extends gax.grpc.GoogleProtoFilesRoot {
+      loadSync(filename) {
+        assert.strictEqual(
+          filename,
+          path.resolve(__dirname, '../protos/google/rpc/error_details.proto')
+        );
+        const result = super.loadSync(filename);
+        const n = 'nested';
+        result[n].google[n].rpc[n].RetryInfo = FakeRetryInfo;
+        return result;
+      }
+    },
   },
 };
 


### PR DESCRIPTION
This PR uses `protobufjs` to load a proto file instead of `grpc.load`.

See https://github.com/googleapis/nodejs-vision/pull/55 for context.