### PR TITLE
Use unique label for resources created from Sample tests

### DIFF
--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -61,7 +61,7 @@ test.before(async () => {
     config: 'regional-us-central1',
     nodes: 1,
     labels: {
-      'gcloud-tests': 'true',
+      'gcloud-sample-tests': 'true',
     },
   });
 
@@ -70,7 +70,7 @@ test.before(async () => {
 
 test.before(async () => {
   const [instances] = await spanner.getInstances({
-    filter: 'labels.gcloud-tests:true',
+    filter: 'labels.gcloud-sample-tests:true',
   });
 
   instances.forEach(async instance => {


### PR DESCRIPTION
Fixes #190 

This should fix the flakyness. Thanks to [this tip](https://github.com/googleapis/nodejs-spanner/issues/190#issuecomment-387150075), it seems clear now what is wrong-- thanks to our labeling convention, the system tests after hook was erasing resources that were still in use by the sample system tests.

Resources created from both the system tests and the sample system tests use the same label, "gcloud-tests". We use a label so we can filter and remove any resources created with them during the clean-up stage.

This PR introduces a different label for sample tests, so there shouldn't be any more issues.