### PR TITLE
Rewrite PartialResultStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,18 +16,18 @@
       "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "package-hash": "1.2.0"
+        "babel-plugin-check-es2015-constants": "^6.8.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
+        "babel-plugin-transform-async-to-generator": "^6.16.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+        "babel-plugin-transform-es2015-function-name": "^6.9.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
+        "babel-plugin-transform-es2015-parameters": "^6.21.0",
+        "babel-plugin-transform-es2015-spread": "^6.8.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.8.0",
+        "package-hash": "^1.2.0"
       },
       "dependencies": {
         "md5-hex": {
@@ -36,7 +36,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "package-hash": {
@@ -45,7 +45,7 @@
           "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0"
+            "md5-hex": "^1.3.0"
           }
         }
       }
@@ -56,8 +56,8 @@
       "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
       "dev": true,
       "requires": {
-        "@ava/babel-plugin-throws-helper": "2.0.0",
-        "babel-plugin-espower": "2.4.0"
+        "@ava/babel-plugin-throws-helper": "^2.0.0",
+        "babel-plugin-espower": "^2.3.2"
       }
     },
     "@ava/write-file-atomic": {
@@ -66,9 +66,9 @@
       "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "@concordance/react": {
@@ -77,7 +77,7 @@
       "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1"
+        "arrify": "^1.0.1"
       }
     },
     "@google-cloud/common": {
@@ -85,24 +85,24 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
       "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
       "requires": {
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "concat-stream": "1.6.2",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.6.0",
-        "ent": "2.2.0",
-        "extend": "3.0.1",
-        "google-auto-auth": "0.10.1",
-        "is": "3.2.1",
+        "array-uniq": "^1.0.3",
+        "arrify": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.1",
+        "google-auto-auth": "^0.10.0",
+        "is": "^3.2.0",
         "log-driver": "1.2.7",
-        "methmeth": "1.1.0",
-        "modelo": "4.2.3",
-        "request": "2.87.0",
-        "retry-request": "3.3.1",
-        "split-array-stream": "1.0.3",
-        "stream-events": "1.0.4",
-        "string-format-obj": "1.1.1",
-        "through2": "2.0.3"
+        "methmeth": "^1.1.0",
+        "modelo": "^4.2.0",
+        "request": "^2.79.0",
+        "retry-request": "^3.0.0",
+        "split-array-stream": "^1.0.0",
+        "stream-events": "^1.0.1",
+        "string-format-obj": "^1.1.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "split-array-stream": {
@@ -110,8 +110,8 @@
           "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
           "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
           "requires": {
-            "async": "2.6.1",
-            "is-stream-ended": "0.1.4"
+            "async": "^2.4.0",
+            "is-stream-ended": "^0.1.0"
           }
         }
       }
@@ -121,15 +121,15 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/common-grpc/-/common-grpc-0.6.1.tgz",
       "integrity": "sha512-pspOZVfmrCTP0svTNwFE8nYJsQp5rTUaeUpJwpgslDk5tDWFbYT3dZkANbiURcTSq0mo6hZmd+M5rPIzWMVUmA==",
       "requires": {
-        "@google-cloud/common": "0.17.0",
-        "dot-prop": "4.2.0",
-        "duplexify": "3.6.0",
-        "extend": "3.0.1",
-        "grpc": "1.11.3",
-        "is": "3.2.1",
-        "modelo": "4.2.3",
-        "retry-request": "3.3.1",
-        "through2": "2.0.3"
+        "@google-cloud/common": "^0.17.0",
+        "dot-prop": "^4.2.0",
+        "duplexify": "^3.5.1",
+        "extend": "^3.0.1",
+        "grpc": "^1.10.0",
+        "is": "^3.2.0",
+        "modelo": "^4.2.0",
+        "retry-request": "^3.3.1",
+        "through2": "^2.0.3"
       }
     },
     "@google-cloud/nodejs-repo-tools": {
@@ -146,7 +146,7 @@
         "lodash": "4.17.5",
         "nyc": "11.4.1",
         "proxyquire": "1.8.0",
-        "semver": "5.5.0",
+        "semver": "^5.5.0",
         "sinon": "4.3.0",
         "string": "3.3.3",
         "supertest": "3.0.0",
@@ -166,33 +166,33 @@
           "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
           "dev": true,
           "requires": {
-            "archy": "1.0.0",
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.5.1",
-            "debug-log": "1.0.1",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "2.1.0",
-            "foreground-child": "1.5.6",
-            "glob": "7.1.2",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-hook": "1.1.0",
-            "istanbul-lib-instrument": "1.9.1",
-            "istanbul-lib-report": "1.1.2",
-            "istanbul-lib-source-maps": "1.2.2",
-            "istanbul-reports": "1.1.3",
-            "md5-hex": "1.3.0",
-            "merge-source-map": "1.0.4",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "spawn-wrap": "1.4.2",
-            "test-exclude": "4.1.1",
-            "yargs": "10.0.3",
-            "yargs-parser": "8.0.0"
+            "archy": "^1.0.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.3.0",
+            "debug-log": "^1.0.1",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^2.1.0",
+            "foreground-child": "^1.5.3",
+            "glob": "^7.0.6",
+            "istanbul-lib-coverage": "^1.1.1",
+            "istanbul-lib-hook": "^1.1.0",
+            "istanbul-lib-instrument": "^1.9.1",
+            "istanbul-lib-report": "^1.1.2",
+            "istanbul-lib-source-maps": "^1.2.2",
+            "istanbul-reports": "^1.1.3",
+            "md5-hex": "^1.2.0",
+            "merge-source-map": "^1.0.2",
+            "micromatch": "^2.3.11",
+            "mkdirp": "^0.5.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.5.4",
+            "signal-exit": "^3.0.1",
+            "spawn-wrap": "^1.4.2",
+            "test-exclude": "^4.1.1",
+            "yargs": "^10.0.3",
+            "yargs-parser": "^8.0.0"
           },
           "dependencies": {
             "align-text": {
@@ -200,9 +200,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
               }
             },
             "amdefine": {
@@ -225,7 +225,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "default-require-extensions": "1.0.0"
+                "default-require-extensions": "^1.0.0"
               }
             },
             "archy": {
@@ -238,7 +238,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
               }
             },
             "arr-flatten": {
@@ -266,9 +266,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
               }
             },
             "babel-generator": {
@@ -276,14 +276,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.4",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.6",
+                "trim-right": "^1.0.1"
               }
             },
             "babel-messages": {
@@ -291,7 +291,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
               }
             },
             "babel-runtime": {
@@ -299,8 +299,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
               }
             },
             "babel-template": {
@@ -308,11 +308,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.4"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
               }
             },
             "babel-traverse": {
@@ -320,15 +320,15 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
               }
             },
             "babel-types": {
@@ -336,10 +336,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
               }
             },
             "babylon": {
@@ -357,7 +357,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -366,9 +366,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
               }
             },
             "builtin-modules": {
@@ -381,9 +381,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.3.4"
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
               }
             },
             "camelcase": {
@@ -398,8 +398,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
               }
             },
             "chalk": {
@@ -407,11 +407,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "cliui": {
@@ -420,8 +420,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
               },
               "dependencies": {
@@ -463,8 +463,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
               }
             },
             "debug": {
@@ -490,7 +490,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "strip-bom": "2.0.0"
+                "strip-bom": "^2.0.0"
               }
             },
             "detect-indent": {
@@ -498,7 +498,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
               }
             },
             "error-ex": {
@@ -506,7 +506,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
               }
             },
             "escape-string-regexp": {
@@ -524,13 +524,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
               },
               "dependencies": {
                 "cross-spawn": {
@@ -538,9 +538,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "lru-cache": "4.1.1",
-                    "shebang-command": "1.2.0",
-                    "which": "1.3.0"
+                    "lru-cache": "^4.0.1",
+                    "shebang-command": "^1.2.0",
+                    "which": "^1.2.9"
                   }
                 }
               }
@@ -550,7 +550,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
               }
             },
             "expand-range": {
@@ -558,7 +558,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
               }
             },
             "extglob": {
@@ -566,7 +566,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "filename-regex": {
@@ -579,11 +579,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
               }
             },
             "find-cache-dir": {
@@ -591,9 +591,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
               }
             },
             "find-up": {
@@ -601,7 +601,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
               }
             },
             "for-in": {
@@ -614,7 +614,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
               }
             },
             "foreground-child": {
@@ -622,8 +622,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cross-spawn": "4.0.2",
-                "signal-exit": "3.0.2"
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
               }
             },
             "fs.realpath": {
@@ -646,12 +646,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "glob-base": {
@@ -659,8 +659,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
               }
             },
             "glob-parent": {
@@ -668,7 +668,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
               }
             },
             "globals": {
@@ -686,10 +686,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
               },
               "dependencies": {
                 "source-map": {
@@ -697,7 +697,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.1"
+                    "amdefine": ">=0.0.4"
                   }
                 }
               }
@@ -707,7 +707,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "has-flag": {
@@ -730,8 +730,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -744,7 +744,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
               }
             },
             "invert-kv": {
@@ -767,7 +767,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               }
             },
             "is-dotfile": {
@@ -780,7 +780,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
               }
             },
             "is-extendable": {
@@ -798,7 +798,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-fullwidth-code-point": {
@@ -806,7 +806,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-glob": {
@@ -814,7 +814,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "is-number": {
@@ -822,7 +822,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "is-posix-bracket": {
@@ -873,7 +873,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "append-transform": "0.4.0"
+                "append-transform": "^0.4.0"
               }
             },
             "istanbul-lib-instrument": {
@@ -881,13 +881,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "babel-generator": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.1.1",
-                "semver": "5.4.1"
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.1.1",
+                "semver": "^5.3.0"
               }
             },
             "istanbul-lib-report": {
@@ -895,10 +895,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
+                "istanbul-lib-coverage": "^1.1.1",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
               },
               "dependencies": {
                 "supports-color": {
@@ -906,7 +906,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "has-flag": "1.0.0"
+                    "has-flag": "^1.0.0"
                   }
                 }
               }
@@ -916,11 +916,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.1.1",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "source-map": "0.5.7"
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.1.1",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
               },
               "dependencies": {
                 "debug": {
@@ -938,7 +938,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "handlebars": "4.0.11"
+                "handlebars": "^4.0.3"
               }
             },
             "js-tokens": {
@@ -956,7 +956,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             },
             "lazy-cache": {
@@ -970,7 +970,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
               }
             },
             "load-json-file": {
@@ -978,11 +978,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
               }
             },
             "locate-path": {
@@ -990,8 +990,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
               },
               "dependencies": {
                 "path-exists": {
@@ -1016,7 +1016,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0"
               }
             },
             "lru-cache": {
@@ -1024,8 +1024,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
               }
             },
             "md5-hex": {
@@ -1033,7 +1033,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "md5-o-matic": "0.1.1"
+                "md5-o-matic": "^0.1.1"
               }
             },
             "md5-o-matic": {
@@ -1046,7 +1046,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mimic-fn": "1.1.0"
+                "mimic-fn": "^1.0.0"
               }
             },
             "merge-source-map": {
@@ -1054,7 +1054,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
               }
             },
             "micromatch": {
@@ -1062,19 +1062,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
               }
             },
             "mimic-fn": {
@@ -1087,7 +1087,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
@@ -1113,10 +1113,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               }
             },
             "normalize-path": {
@@ -1124,7 +1124,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             },
             "npm-run-path": {
@@ -1132,7 +1132,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
               }
             },
             "number-is-nan": {
@@ -1150,8 +1150,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
               }
             },
             "once": {
@@ -1159,7 +1159,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "optimist": {
@@ -1167,8 +1167,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
               }
             },
             "os-homedir": {
@@ -1181,9 +1181,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
               }
             },
             "p-finally": {
@@ -1201,7 +1201,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "p-limit": "1.1.0"
+                "p-limit": "^1.1.0"
               }
             },
             "parse-glob": {
@@ -1209,10 +1209,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
               }
             },
             "parse-json": {
@@ -1220,7 +1220,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
               }
             },
             "path-exists": {
@@ -1228,7 +1228,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "path-is-absolute": {
@@ -1251,9 +1251,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pify": {
@@ -1271,7 +1271,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               }
             },
             "pkg-dir": {
@@ -1279,7 +1279,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "1.1.2"
+                "find-up": "^1.0.0"
               },
               "dependencies": {
                 "find-up": {
@@ -1287,8 +1287,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
                   }
                 }
               }
@@ -1308,8 +1308,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
               },
               "dependencies": {
                 "is-number": {
@@ -1317,7 +1317,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "kind-of": "3.2.2"
+                    "kind-of": "^3.0.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -1325,7 +1325,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                       }
                     }
                   }
@@ -1335,7 +1335,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -1345,9 +1345,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
               }
             },
             "read-pkg-up": {
@@ -1355,8 +1355,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
               },
               "dependencies": {
                 "find-up": {
@@ -1364,8 +1364,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "path-exists": "2.1.0",
-                    "pinkie-promise": "2.0.1"
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
                   }
                 }
               }
@@ -1380,7 +1380,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
               }
             },
             "remove-trailing-separator": {
@@ -1403,7 +1403,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
               }
             },
             "require-directory": {
@@ -1427,7 +1427,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
               }
             },
             "rimraf": {
@@ -1435,7 +1435,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
               }
             },
             "semver": {
@@ -1453,7 +1453,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
@@ -1481,12 +1481,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "foreground-child": "1.5.6",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.2",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "which": "1.3.0"
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
               }
             },
             "spdx-correct": {
@@ -1494,7 +1494,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "^1.0.2"
               }
             },
             "spdx-expression-parse": {
@@ -1512,8 +1512,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -1531,7 +1531,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -1541,7 +1541,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-bom": {
@@ -1549,7 +1549,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
               }
             },
             "strip-eof": {
@@ -1567,11 +1567,11 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "2.3.11",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
+                "arrify": "^1.0.1",
+                "micromatch": "^2.3.11",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
               }
             },
             "to-fast-properties": {
@@ -1590,9 +1590,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
               },
               "dependencies": {
                 "yargs": {
@@ -1601,9 +1601,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
                     "window-size": "0.1.0"
                   }
                 }
@@ -1620,8 +1620,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
               }
             },
             "which": {
@@ -1629,7 +1629,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
               }
             },
             "which-module": {
@@ -1653,8 +1653,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
               },
               "dependencies": {
                 "string-width": {
@@ -1662,9 +1662,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 }
               }
@@ -1679,9 +1679,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               }
             },
             "y18n": {
@@ -1699,18 +1699,18 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.0.0"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.0.0"
               },
               "dependencies": {
                 "cliui": {
@@ -1718,9 +1718,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wrap-ansi": "^2.0.0"
                   },
                   "dependencies": {
                     "string-width": {
@@ -1728,9 +1728,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                       }
                     }
                   }
@@ -1742,7 +1742,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               },
               "dependencies": {
                 "camelcase": {
@@ -1760,9 +1760,9 @@
           "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
           "dev": true,
           "requires": {
-            "fill-keys": "1.0.2",
-            "module-not-found-error": "1.0.1",
-            "resolve": "1.1.7"
+            "fill-keys": "^1.0.2",
+            "module-not-found-error": "^1.0.0",
+            "resolve": "~1.1.7"
           }
         }
       }
@@ -1773,10 +1773,10 @@
       "integrity": "sha512-weIbJqTMfQ4r1YX85u54DKfjLZs2jwn1XZ6tIOP/pFgMwhIN5BAtaCp/1wn9DzyLsDR9tW0R2NIePcVJ45ivQQ==",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "date-time": "0.1.1",
-        "pretty-ms": "0.2.2",
-        "text-table": "0.2.0"
+        "chalk": "^0.4.0",
+        "date-time": "^0.1.1",
+        "pretty-ms": "^0.2.1",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1791,9 +1791,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "pretty-ms": {
@@ -1802,7 +1802,7 @@
           "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
           "dev": true,
           "requires": {
-            "parse-ms": "0.1.2"
+            "parse-ms": "^0.1.0"
           }
         },
         "strip-ansi": {
@@ -1818,8 +1818,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "1.0.1",
-        "glob-to-regexp": "0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -1852,8 +1852,8 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/inquire": "1.1.0"
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
       }
     },
     "@protobufjs/float": {
@@ -1922,7 +1922,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -1938,10 +1938,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -1956,9 +1956,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1967,7 +1967,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1984,7 +1984,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2005,8 +2005,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -2015,7 +2015,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2037,7 +2037,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -2046,8 +2046,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -2056,7 +2056,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -2071,9 +2071,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "expand-brackets": {
@@ -2082,7 +2082,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -2091,7 +2091,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-extglob": {
@@ -2106,7 +2106,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "kind-of": {
@@ -2115,7 +2115,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -2124,19 +2124,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         }
       }
@@ -2147,7 +2147,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "argv": {
@@ -2205,7 +2205,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -2228,8 +2228,8 @@
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
       "requires": {
-        "colour": "0.7.1",
-        "optjs": "3.2.2"
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
       }
     },
     "asn1": {
@@ -2252,7 +2252,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "async-each": {
@@ -2283,89 +2283,89 @@
       "integrity": "sha512-4lGNJCf6xL8SvsKVEKxEE46se7JAUIAZoKHw9itTQuwcsydhpAMkBs5gOOiWiwt0JKNIuXWc2/r4r8ZdcNrBEw==",
       "dev": true,
       "requires": {
-        "@ava/babel-preset-stage-4": "1.1.0",
-        "@ava/babel-preset-transform-test-files": "3.0.0",
-        "@ava/write-file-atomic": "2.2.0",
-        "@concordance/react": "1.0.0",
-        "@ladjs/time-require": "0.1.4",
-        "ansi-escapes": "3.1.0",
-        "ansi-styles": "3.2.1",
-        "arr-flatten": "1.1.0",
-        "array-union": "1.0.2",
-        "array-uniq": "1.0.3",
-        "arrify": "1.0.1",
-        "auto-bind": "1.2.0",
-        "ava-init": "0.2.1",
-        "babel-core": "6.26.3",
-        "babel-generator": "6.26.1",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "bluebird": "3.5.1",
-        "caching-transform": "1.0.1",
-        "chalk": "2.4.1",
-        "chokidar": "1.7.0",
-        "clean-stack": "1.3.0",
-        "clean-yaml-object": "0.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-spinners": "1.3.1",
-        "cli-truncate": "1.1.0",
-        "co-with-promise": "4.6.0",
-        "code-excerpt": "2.1.1",
-        "common-path-prefix": "1.0.0",
-        "concordance": "3.0.0",
-        "convert-source-map": "1.5.1",
-        "core-assert": "0.2.1",
-        "currently-unhandled": "0.4.1",
-        "debug": "3.1.0",
-        "dot-prop": "4.2.0",
-        "empower-core": "0.6.2",
-        "equal-length": "1.0.1",
-        "figures": "2.0.0",
-        "find-cache-dir": "1.0.0",
-        "fn-name": "2.0.1",
-        "get-port": "3.2.0",
-        "globby": "6.1.0",
-        "has-flag": "2.0.0",
-        "hullabaloo-config-manager": "1.1.1",
-        "ignore-by-default": "1.0.1",
-        "import-local": "0.1.1",
-        "indent-string": "3.2.0",
-        "is-ci": "1.1.0",
-        "is-generator-fn": "1.0.0",
-        "is-obj": "1.0.1",
-        "is-observable": "1.1.0",
-        "is-promise": "2.1.0",
-        "last-line-stream": "1.0.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.debounce": "4.0.8",
-        "lodash.difference": "4.5.0",
-        "lodash.flatten": "4.4.0",
-        "loud-rejection": "1.6.0",
-        "make-dir": "1.3.0",
-        "matcher": "1.1.0",
-        "md5-hex": "2.0.0",
-        "meow": "3.7.0",
-        "ms": "2.0.0",
-        "multimatch": "2.1.0",
-        "observable-to-promise": "0.5.0",
-        "option-chain": "1.0.0",
-        "package-hash": "2.0.0",
-        "pkg-conf": "2.1.0",
-        "plur": "2.1.2",
-        "pretty-ms": "3.1.0",
-        "require-precompiled": "0.1.0",
-        "resolve-cwd": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "slash": "1.0.0",
-        "source-map-support": "0.5.6",
-        "stack-utils": "1.0.1",
-        "strip-ansi": "4.0.0",
-        "strip-bom-buf": "1.0.0",
-        "supertap": "1.0.0",
-        "supports-color": "5.4.0",
-        "trim-off-newlines": "1.0.1",
-        "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.5.0"
+        "@ava/babel-preset-stage-4": "^1.1.0",
+        "@ava/babel-preset-transform-test-files": "^3.0.0",
+        "@ava/write-file-atomic": "^2.2.0",
+        "@concordance/react": "^1.0.0",
+        "@ladjs/time-require": "^0.1.4",
+        "ansi-escapes": "^3.0.0",
+        "ansi-styles": "^3.1.0",
+        "arr-flatten": "^1.0.1",
+        "array-union": "^1.0.1",
+        "array-uniq": "^1.0.2",
+        "arrify": "^1.0.0",
+        "auto-bind": "^1.1.0",
+        "ava-init": "^0.2.0",
+        "babel-core": "^6.17.0",
+        "babel-generator": "^6.26.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "bluebird": "^3.0.0",
+        "caching-transform": "^1.0.0",
+        "chalk": "^2.0.1",
+        "chokidar": "^1.4.2",
+        "clean-stack": "^1.1.1",
+        "clean-yaml-object": "^0.1.0",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^1.0.0",
+        "cli-truncate": "^1.0.0",
+        "co-with-promise": "^4.6.0",
+        "code-excerpt": "^2.1.1",
+        "common-path-prefix": "^1.0.0",
+        "concordance": "^3.0.0",
+        "convert-source-map": "^1.5.1",
+        "core-assert": "^0.2.0",
+        "currently-unhandled": "^0.4.1",
+        "debug": "^3.0.1",
+        "dot-prop": "^4.1.0",
+        "empower-core": "^0.6.1",
+        "equal-length": "^1.0.0",
+        "figures": "^2.0.0",
+        "find-cache-dir": "^1.0.0",
+        "fn-name": "^2.0.0",
+        "get-port": "^3.0.0",
+        "globby": "^6.0.0",
+        "has-flag": "^2.0.0",
+        "hullabaloo-config-manager": "^1.1.0",
+        "ignore-by-default": "^1.0.0",
+        "import-local": "^0.1.1",
+        "indent-string": "^3.0.0",
+        "is-ci": "^1.0.7",
+        "is-generator-fn": "^1.0.0",
+        "is-obj": "^1.0.0",
+        "is-observable": "^1.0.0",
+        "is-promise": "^2.1.0",
+        "last-line-stream": "^1.0.0",
+        "lodash.clonedeepwith": "^4.5.0",
+        "lodash.debounce": "^4.0.3",
+        "lodash.difference": "^4.3.0",
+        "lodash.flatten": "^4.2.0",
+        "loud-rejection": "^1.2.0",
+        "make-dir": "^1.0.0",
+        "matcher": "^1.0.0",
+        "md5-hex": "^2.0.0",
+        "meow": "^3.7.0",
+        "ms": "^2.0.0",
+        "multimatch": "^2.1.0",
+        "observable-to-promise": "^0.5.0",
+        "option-chain": "^1.0.0",
+        "package-hash": "^2.0.0",
+        "pkg-conf": "^2.0.0",
+        "plur": "^2.0.0",
+        "pretty-ms": "^3.0.0",
+        "require-precompiled": "^0.1.0",
+        "resolve-cwd": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "semver": "^5.4.1",
+        "slash": "^1.0.0",
+        "source-map-support": "^0.5.0",
+        "stack-utils": "^1.0.1",
+        "strip-ansi": "^4.0.0",
+        "strip-bom-buf": "^1.0.0",
+        "supertap": "^1.0.0",
+        "supports-color": "^5.0.0",
+        "trim-off-newlines": "^1.0.1",
+        "unique-temp-dir": "^1.0.0",
+        "update-notifier": "^2.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2380,11 +2380,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -2405,7 +2405,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -2414,7 +2414,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2425,11 +2425,11 @@
       "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
       "dev": true,
       "requires": {
-        "arr-exclude": "1.0.0",
-        "execa": "0.7.0",
-        "has-yarn": "1.0.0",
-        "read-pkg-up": "2.0.0",
-        "write-pkg": "3.1.0"
+        "arr-exclude": "^1.0.0",
+        "execa": "^0.7.0",
+        "has-yarn": "^1.0.0",
+        "read-pkg-up": "^2.0.0",
+        "write-pkg": "^3.1.0"
       }
     },
     "aws-sign2": {
@@ -2447,8 +2447,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.5.0",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-code-frame": {
@@ -2457,9 +2457,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2474,11 +2474,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2495,25 +2495,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -2533,14 +2533,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -2557,9 +2557,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -2568,10 +2568,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -2580,9 +2580,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -2591,11 +2591,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -2604,8 +2604,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -2614,8 +2614,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -2624,9 +2624,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -2635,11 +2635,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -2648,8 +2648,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -2658,7 +2658,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -2667,7 +2667,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-espower": {
@@ -2676,13 +2676,13 @@
       "integrity": "sha512-/+SRpy7pKgTI28oEHfn1wkuM5QFAdRq8WNsOOih1dVrdV6A/WbNbRZyl0eX5eyDgtb0lOE27PeDFuCX2j8OxVg==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babylon": "6.18.0",
-        "call-matcher": "1.0.1",
-        "core-js": "2.5.6",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.8.0",
-        "estraverse": "4.2.0"
+        "babel-generator": "^6.1.0",
+        "babylon": "^6.1.0",
+        "call-matcher": "^1.0.0",
+        "core-js": "^2.0.0",
+        "espower-location-detector": "^1.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.1.1"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -2715,9 +2715,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -2726,7 +2726,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -2735,9 +2735,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -2746,10 +2746,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -2758,12 +2758,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -2772,7 +2772,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -2781,9 +2781,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -2792,9 +2792,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -2803,9 +2803,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -2814,8 +2814,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-register": {
@@ -2824,13 +2824,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.6",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "source-map-support": {
@@ -2839,7 +2839,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -2850,8 +2850,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -2860,11 +2860,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -2873,15 +2873,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "debug": {
@@ -2901,10 +2901,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -2923,13 +2923,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2937,7 +2937,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2945,7 +2945,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2953,7 +2953,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2961,9 +2961,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2974,7 +2974,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -3001,13 +3001,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.4.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3034,8 +3034,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3044,7 +3044,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3054,7 +3054,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -3063,16 +3063,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3080,7 +3080,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -3118,7 +3118,7 @@
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
-        "long": "3.2.0"
+        "long": "~3"
       }
     },
     "cache-base": {
@@ -3126,15 +3126,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "cacheable-request": {
@@ -3166,9 +3166,9 @@
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
+        "md5-hex": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "write-file-atomic": "^1.1.4"
       },
       "dependencies": {
         "md5-hex": {
@@ -3177,7 +3177,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "write-file-atomic": {
@@ -3186,9 +3186,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -3199,10 +3199,10 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.6",
-        "deep-equal": "1.0.1",
-        "espurify": "1.8.0",
-        "estraverse": "4.2.0"
+        "core-js": "^2.0.0",
+        "deep-equal": "^1.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.0.0"
       }
     },
     "call-me-maybe": {
@@ -3221,7 +3221,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -3241,8 +3241,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "capture-stack-trace": {
@@ -3261,7 +3261,7 @@
       "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
       "dev": true,
       "requires": {
-        "underscore-contrib": "0.3.0"
+        "underscore-contrib": "~0.3.0"
       }
     },
     "center-align": {
@@ -3271,8 +3271,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -3281,9 +3281,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -3297,10 +3297,10 @@
       "resolved": "https://registry.npmjs.org/checkpoint-stream/-/checkpoint-stream-0.1.1.tgz",
       "integrity": "sha1-WQiFEfviO20sHoLq8C8oRZZn9jc=",
       "requires": {
-        "events-intercept": "2.0.0",
-        "pumpify": "1.5.1",
-        "split-array-stream": "1.0.3",
-        "through2": "2.0.3"
+        "events-intercept": "^2.0.0",
+        "pumpify": "^1.3.5",
+        "split-array-stream": "^1.0.0",
+        "through2": "^2.0.3"
       },
       "dependencies": {
         "split-array-stream": {
@@ -3308,8 +3308,8 @@
           "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
           "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
           "requires": {
-            "async": "2.6.1",
-            "is-stream-ended": "0.1.4"
+            "async": "^2.4.0",
+            "is-stream-ended": "^0.1.0"
           }
         }
       }
@@ -3320,15 +3320,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.2.4",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -3337,7 +3337,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -3352,7 +3352,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -3374,10 +3374,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3385,7 +3385,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -3414,7 +3414,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -3429,8 +3429,8 @@
       "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
       "dev": true,
       "requires": {
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "slice-ansi": "^1.0.0",
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3451,8 +3451,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3461,7 +3461,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3477,9 +3477,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone-response": {
@@ -3488,7 +3488,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -3502,7 +3502,7 @@
       "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "1.0.0"
+        "pinkie-promise": "^1.0.0"
       }
     },
     "code-excerpt": {
@@ -3511,7 +3511,7 @@
       "integrity": "sha512-tJLhH3EpFm/1x7heIW0hemXJTUU5EWl2V0EIX558jp05Mt1U6DVryCgkp3l37cxqs+DNbNgxG43SkwJXpQ14Jw==",
       "dev": true,
       "requires": {
-        "convert-to-spaces": "1.0.2"
+        "convert-to-spaces": "^1.0.1"
       }
     },
     "code-point-at": {
@@ -3526,7 +3526,7 @@
       "dev": true,
       "requires": {
         "argv": "0.0.2",
-        "request": "2.87.0",
+        "request": "^2.81.0",
         "urlgrey": "0.4.4"
       }
     },
@@ -3535,8 +3535,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -3545,7 +3545,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -3570,7 +3570,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -3606,10 +3606,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "concordance": {
@@ -3618,17 +3618,17 @@
       "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
       "dev": true,
       "requires": {
-        "date-time": "2.1.0",
-        "esutils": "2.0.2",
-        "fast-diff": "1.1.2",
-        "function-name-support": "0.2.0",
-        "js-string-escape": "1.0.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.flattendeep": "4.4.0",
-        "lodash.merge": "4.6.1",
-        "md5-hex": "2.0.0",
-        "semver": "5.5.0",
-        "well-known-symbols": "1.0.0"
+        "date-time": "^2.1.0",
+        "esutils": "^2.0.2",
+        "fast-diff": "^1.1.1",
+        "function-name-support": "^0.2.0",
+        "js-string-escape": "^1.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flattendeep": "^4.4.0",
+        "lodash.merge": "^4.6.0",
+        "md5-hex": "^2.0.0",
+        "semver": "^5.3.0",
+        "well-known-symbols": "^1.0.0"
       },
       "dependencies": {
         "date-time": {
@@ -3637,7 +3637,7 @@
           "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
           "dev": true,
           "requires": {
-            "time-zone": "1.0.0"
+            "time-zone": "^1.0.0"
           }
         }
       }
@@ -3648,12 +3648,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "convert-hrtime": {
@@ -3691,8 +3691,8 @@
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
       "dev": true,
       "requires": {
-        "buf-compare": "1.0.1",
-        "is-error": "2.2.1"
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
       }
     },
     "core-js": {
@@ -3710,7 +3710,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -3719,9 +3719,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-random-string": {
@@ -3736,7 +3736,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -3745,7 +3745,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -3753,7 +3753,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-time": {
@@ -3786,7 +3786,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "dedent": {
@@ -3818,8 +3818,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -3827,8 +3827,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3836,7 +3836,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3844,7 +3844,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3852,9 +3852,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3865,13 +3865,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -3880,12 +3880,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -3906,7 +3906,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         }
       }
@@ -3916,7 +3916,7 @@
       "resolved": "https://registry.npmjs.org/delay/-/delay-2.0.0.tgz",
       "integrity": "sha1-kRLq3APk7H4AKXM3iW8nO72R+uU=",
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "delayed-stream": {
@@ -3930,7 +3930,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -3949,8 +3949,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "1.0.1",
-        "path-type": "3.0.0"
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
       }
     },
     "doctrine": {
@@ -3959,7 +3959,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "dom-serializer": {
@@ -3968,8 +3968,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3992,7 +3992,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -4001,8 +4001,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -4010,7 +4010,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer3": {
@@ -4024,10 +4024,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "eastasianwidth": {
@@ -4041,7 +4041,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -4049,7 +4049,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "empower": {
@@ -4057,8 +4057,8 @@
       "resolved": "https://registry.npmjs.org/empower/-/empower-1.2.3.tgz",
       "integrity": "sha1-bw2nNEf07dg4/sXGAxOoi6XLhSs=",
       "requires": {
-        "core-js": "2.5.6",
-        "empower-core": "0.6.2"
+        "core-js": "^2.0.0",
+        "empower-core": "^0.6.2"
       }
     },
     "empower-assert": {
@@ -4067,7 +4067,7 @@
       "integrity": "sha512-Ylck0Q6p8y/LpNzYeBccaxAPm2ZyuqBgErgZpO9KT0HuQWF0sJckBKCLmgS1/DEXEiyBi9XtYh3clZm5cAdARw==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.2.0"
       }
     },
     "empower-core": {
@@ -4076,7 +4076,7 @@
       "integrity": "sha1-Wt71ZgiOMfuoC6CjbfR9cJQWkUQ=",
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.6"
+        "core-js": "^2.0.0"
       }
     },
     "end-of-stream": {
@@ -4084,7 +4084,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "ent": {
@@ -4110,7 +4110,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -4119,9 +4119,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-error": {
@@ -4136,9 +4136,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -4147,12 +4147,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -4161,11 +4161,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -4174,8 +4174,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -4184,10 +4184,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escallmatch": {
@@ -4196,8 +4196,8 @@
       "integrity": "sha1-UAmdhugJGwkt+N37w/mm+wWgJNA=",
       "dev": true,
       "requires": {
-        "call-matcher": "1.0.1",
-        "esprima": "2.7.3"
+        "call-matcher": "^1.0.0",
+        "esprima": "^2.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -4220,11 +4220,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -4248,10 +4248,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -4260,44 +4260,44 @@
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
-        "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.8",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4318,7 +4318,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4329,7 +4329,7 @@
       "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
       "dev": true,
       "requires": {
-        "get-stdin": "5.0.1"
+        "get-stdin": "^5.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -4346,10 +4346,10 @@
       "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
       "dev": true,
       "requires": {
-        "ignore": "3.3.8",
-        "minimatch": "3.0.4",
-        "resolve": "1.7.1",
-        "semver": "5.5.0"
+        "ignore": "^3.3.6",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.3",
+        "semver": "^5.4.1"
       },
       "dependencies": {
         "resolve": {
@@ -4358,7 +4358,7 @@
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -4369,8 +4369,8 @@
       "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       }
     },
     "eslint-scope": {
@@ -4379,8 +4379,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -4395,16 +4395,16 @@
       "integrity": "sha512-F4TY1qYJB1aUyzB03NsZksZzUQmQoEBaTUjRJGR30GxbkbjKI41NhCyYjrF+bGgWN7x/ZsczYppRpz/0WdI0ug==",
       "dev": true,
       "requires": {
-        "array-find": "1.0.0",
-        "escallmatch": "1.5.0",
-        "escodegen": "1.9.1",
-        "escope": "3.6.0",
-        "espower-location-detector": "1.0.0",
-        "espurify": "1.8.0",
-        "estraverse": "4.2.0",
-        "source-map": "0.5.7",
-        "type-name": "2.0.2",
-        "xtend": "4.0.1"
+        "array-find": "^1.0.0",
+        "escallmatch": "^1.5.0",
+        "escodegen": "^1.7.0",
+        "escope": "^3.3.0",
+        "espower-location-detector": "^1.0.0",
+        "espurify": "^1.3.0",
+        "estraverse": "^4.1.0",
+        "source-map": "^0.5.0",
+        "type-name": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "espower-loader": {
@@ -4413,11 +4413,11 @@
       "integrity": "sha1-7bRsPFmga6yOpzppXIblxaC8gto=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.5.1",
-        "espower-source": "2.2.0",
-        "minimatch": "3.0.4",
-        "source-map-support": "0.4.18",
-        "xtend": "4.0.1"
+        "convert-source-map": "^1.1.0",
+        "espower-source": "^2.0.0",
+        "minimatch": "^3.0.0",
+        "source-map-support": "^0.4.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "source-map-support": {
@@ -4426,7 +4426,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -4437,10 +4437,10 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "1.2.4",
-        "path-is-absolute": "1.0.1",
-        "source-map": "0.5.7",
-        "xtend": "4.0.1"
+        "is-url": "^1.2.1",
+        "path-is-absolute": "^1.0.0",
+        "source-map": "^0.5.0",
+        "xtend": "^4.0.0"
       }
     },
     "espower-source": {
@@ -4449,17 +4449,17 @@
       "integrity": "sha1-fgBSVa5HtcE2RIZEs/PYAtUD91I=",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-es7-plugin": "1.1.7",
-        "convert-source-map": "1.5.1",
-        "empower-assert": "1.1.0",
-        "escodegen": "1.9.1",
-        "espower": "2.1.1",
-        "estraverse": "4.2.0",
-        "merge-estraverse-visitors": "1.0.0",
-        "multi-stage-sourcemap": "0.2.1",
-        "path-is-absolute": "1.0.1",
-        "xtend": "4.0.1"
+        "acorn": "^5.0.0",
+        "acorn-es7-plugin": "^1.0.10",
+        "convert-source-map": "^1.1.1",
+        "empower-assert": "^1.0.0",
+        "escodegen": "^1.6.1",
+        "espower": "^2.0.0",
+        "estraverse": "^4.0.0",
+        "merge-estraverse-visitors": "^1.0.0",
+        "multi-stage-sourcemap": "^0.2.1",
+        "path-is-absolute": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -4476,8 +4476,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -4499,7 +4499,7 @@
       "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
       "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
       "requires": {
-        "core-js": "2.5.6"
+        "core-js": "^2.0.0"
       }
     },
     "esquery": {
@@ -4508,7 +4508,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -4517,7 +4517,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -4537,8 +4537,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "events-intercept": {
@@ -4552,13 +4552,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -4566,13 +4566,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -4588,7 +4588,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -4596,7 +4596,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4607,7 +4607,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -4616,11 +4616,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.0.0",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -4629,7 +4629,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -4647,7 +4647,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4662,8 +4662,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4671,7 +4671,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -4682,9 +4682,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4692,14 +4692,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4707,7 +4707,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -4715,7 +4715,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4723,7 +4723,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4731,7 +4731,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4739,9 +4739,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4767,12 +4767,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "2.2.1",
-        "@nodelib/fs.stat": "1.0.2",
-        "glob-parent": "3.1.0",
-        "is-glob": "4.0.0",
-        "merge2": "1.2.2",
-        "micromatch": "3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.0.1",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.1",
+        "micromatch": "^3.1.10"
       }
     },
     "fast-json-stable-stringify": {
@@ -4792,7 +4792,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4801,8 +4801,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -4817,8 +4817,8 @@
       "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
       "dev": true,
       "requires": {
-        "is-object": "1.0.1",
-        "merge-descriptors": "1.0.1"
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
       }
     },
     "fill-range": {
@@ -4826,10 +4826,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4837,7 +4837,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4848,9 +4848,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.3.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-up": {
@@ -4859,7 +4859,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -4868,10 +4868,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "fn-name": {
@@ -4885,7 +4885,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
       "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "for-in": {
@@ -4899,7 +4899,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -4917,9 +4917,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "formidable": {
@@ -4933,7 +4933,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "from2": {
@@ -4942,8 +4942,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -4952,9 +4952,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -4969,8 +4969,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4996,8 +4996,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -5010,7 +5010,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5074,7 +5074,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -5089,14 +5089,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -5105,12 +5105,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -5125,7 +5125,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -5134,7 +5134,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -5143,8 +5143,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5163,7 +5163,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -5177,7 +5177,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5190,8 +5190,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -5200,7 +5200,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -5223,9 +5223,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5234,16 +5234,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -5252,8 +5252,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -5268,8 +5268,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -5278,10 +5278,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5300,7 +5300,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5321,8 +5321,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5343,10 +5343,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5363,13 +5363,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -5378,7 +5378,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5421,9 +5421,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5432,7 +5432,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -5440,7 +5440,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5455,13 +5455,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -5476,7 +5476,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -5508,8 +5508,8 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
       "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "requires": {
-        "axios": "0.18.0",
-        "extend": "3.0.1",
+        "axios": "^0.18.0",
+        "extend": "^3.0.1",
         "retry-axios": "0.3.2"
       }
     },
@@ -5552,7 +5552,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -5560,12 +5560,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -5574,8 +5574,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -5584,7 +5584,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -5599,7 +5599,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -5609,8 +5609,8 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -5618,7 +5618,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -5634,7 +5634,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -5648,13 +5648,13 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.0.0",
-        "fast-glob": "2.2.2",
-        "glob": "7.1.2",
-        "ignore": "3.3.8",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
       }
     },
     "google-auth-library": {
@@ -5662,13 +5662,13 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.5.0.tgz",
       "integrity": "sha512-xpibA/hkq4waBcpIkSJg4GiDAqcBWjJee3c47zj7xP3RQ0A9mc8MP3Vc9sc8SGRoDYA0OszZxTjW7SbcC4pJIA==",
       "requires": {
-        "axios": "0.18.0",
-        "gcp-metadata": "0.6.3",
-        "gtoken": "2.3.0",
-        "jws": "3.1.5",
-        "lodash.isstring": "4.0.1",
-        "lru-cache": "4.1.3",
-        "retry-axios": "0.3.2"
+        "axios": "^0.18.0",
+        "gcp-metadata": "^0.6.3",
+        "gtoken": "^2.3.0",
+        "jws": "^3.1.4",
+        "lodash.isstring": "^4.0.1",
+        "lru-cache": "^4.1.2",
+        "retry-axios": "^0.3.2"
       }
     },
     "google-auto-auth": {
@@ -5676,10 +5676,10 @@
       "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
       "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
       "requires": {
-        "async": "2.6.1",
-        "gcp-metadata": "0.6.3",
-        "google-auth-library": "1.5.0",
-        "request": "2.87.0"
+        "async": "^2.3.0",
+        "gcp-metadata": "^0.6.1",
+        "google-auth-library": "^1.3.1",
+        "request": "^2.79.0"
       }
     },
     "google-gax": {
@@ -5687,16 +5687,16 @@
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-0.16.1.tgz",
       "integrity": "sha512-eP7UUkKvaHmmvCrr+rxzkIOeEKOnXmoib7/AkENDAuqlC9T2+lWlzwpthDRnitQcV8SblDMzsk73YPMPCDwPyQ==",
       "requires": {
-        "duplexify": "3.6.0",
-        "extend": "3.0.1",
-        "globby": "8.0.1",
-        "google-auto-auth": "0.10.1",
-        "google-proto-files": "0.15.1",
-        "grpc": "1.11.3",
-        "is-stream-ended": "0.1.4",
-        "lodash": "4.17.10",
-        "protobufjs": "6.8.6",
-        "through2": "2.0.3"
+        "duplexify": "^3.5.4",
+        "extend": "^3.0.0",
+        "globby": "^8.0.0",
+        "google-auto-auth": "^0.10.0",
+        "google-proto-files": "^0.15.0",
+        "grpc": "^1.10.0",
+        "is-stream-ended": "^0.1.0",
+        "lodash": "^4.17.2",
+        "protobufjs": "^6.8.0",
+        "through2": "^2.0.3"
       }
     },
     "google-p12-pem": {
@@ -5704,8 +5704,8 @@
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "requires": {
-        "node-forge": "0.7.5",
-        "pify": "3.0.0"
+        "node-forge": "^0.7.4",
+        "pify": "^3.0.0"
       }
     },
     "google-proto-files": {
@@ -5713,9 +5713,9 @@
       "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-0.15.1.tgz",
       "integrity": "sha512-ebtmWgi/ooR5Nl63qRVZZ6VLM6JOb5zTNxTT/ZAU8yfMOdcauoOZNNMOVg0pCmTjqWXeuuVbgPP0CwO5UHHzBQ==",
       "requires": {
-        "globby": "7.1.1",
-        "power-assert": "1.5.0",
-        "protobufjs": "6.8.6"
+        "globby": "^7.1.1",
+        "power-assert": "^1.4.4",
+        "protobufjs": "^6.8.0"
       },
       "dependencies": {
         "globby": {
@@ -5723,12 +5723,12 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "requires": {
-            "array-union": "1.0.2",
-            "dir-glob": "2.0.0",
-            "glob": "7.1.2",
-            "ignore": "3.3.8",
-            "pify": "3.0.0",
-            "slash": "1.0.0"
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
           }
         }
       }
@@ -5739,23 +5739,23 @@
       "integrity": "sha512-giadqJpXIwjY+ZsuWys8p2yjZGhOHiU4hiJHjS/oeCxw1u8vANQz3zPlrxW2Zw/siCXsSMI3hvzWGcnFyujyAg==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "0.7.0",
-        "cacheable-request": "2.1.4",
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "into-stream": "3.1.0",
-        "is-retry-allowed": "1.1.0",
-        "isurl": "1.0.0",
-        "lowercase-keys": "1.0.1",
-        "mimic-response": "1.0.0",
-        "p-cancelable": "0.3.0",
-        "p-timeout": "2.0.1",
-        "pify": "3.0.0",
-        "safe-buffer": "5.1.2",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "3.0.0",
-        "url-to-options": "1.0.1"
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
       },
       "dependencies": {
         "prepend-http": {
@@ -5770,7 +5770,7 @@
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "dev": true,
           "requires": {
-            "prepend-http": "2.0.0"
+            "prepend-http": "^2.0.0"
           }
         }
       }
@@ -5792,10 +5792,10 @@
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.11.3.tgz",
       "integrity": "sha512-7fJ40USpnP7hxGK0uRoEhJz6unA5VUdwInfwAY2rK2+OVxdDJSdTZQ/8/M+1tW68pHZYgHvg2ohvJ+clhW3ANg==",
       "requires": {
-        "lodash": "4.17.10",
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0",
-        "protobufjs": "5.0.3"
+        "lodash": "^4.15.0",
+        "nan": "^2.0.0",
+        "node-pre-gyp": "^0.10.0",
+        "protobufjs": "^5.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5814,8 +5814,8 @@
           "version": "1.1.4",
           "bundled": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -5826,7 +5826,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5873,7 +5873,7 @@
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -5884,26 +5884,26 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -5918,15 +5918,15 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5941,7 +5941,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -5952,7 +5952,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5963,15 +5963,15 @@
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -5995,33 +5995,33 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.19",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.1",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.2"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -6032,18 +6032,18 @@
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -6058,7 +6058,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -6073,8 +6073,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -6090,40 +6090,40 @@
           "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
           "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
           "requires": {
-            "ascli": "1.0.1",
-            "bytebuffer": "5.0.1",
-            "glob": "7.1.2",
-            "yargs": "3.32.0"
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
           }
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -6150,23 +6150,23 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -6177,13 +6177,13 @@
           "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -6200,7 +6200,7 @@
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -6216,13 +6216,13 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
           }
         }
       }
@@ -6232,11 +6232,11 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "requires": {
-        "axios": "0.18.0",
-        "google-p12-pem": "1.0.2",
-        "jws": "3.1.5",
-        "mime": "2.3.1",
-        "pify": "3.0.0"
+        "axios": "^0.18.0",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.4",
+        "mime": "^2.2.0",
+        "pify": "^3.0.0"
       }
     },
     "handlebars": {
@@ -6245,10 +6245,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -6263,7 +6263,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -6278,8 +6278,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -6288,7 +6288,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -6315,7 +6315,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "1.4.2"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-value": {
@@ -6323,9 +6323,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -6333,8 +6333,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6342,7 +6342,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6365,8 +6365,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -6381,12 +6381,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.2",
-        "domutils": "1.7.0",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-cache-semantics": {
@@ -6400,9 +6400,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "hullabaloo-config-manager": {
@@ -6411,20 +6411,20 @@
       "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "es6-error": "4.1.1",
-        "graceful-fs": "4.1.11",
-        "indent-string": "3.2.0",
-        "json5": "0.5.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.clonedeepwith": "4.5.0",
-        "lodash.isequal": "4.5.0",
-        "lodash.merge": "4.6.1",
-        "md5-hex": "2.0.0",
-        "package-hash": "2.0.0",
-        "pkg-dir": "2.0.0",
-        "resolve-from": "3.0.0",
-        "safe-buffer": "5.1.2"
+        "dot-prop": "^4.1.0",
+        "es6-error": "^4.0.2",
+        "graceful-fs": "^4.1.11",
+        "indent-string": "^3.1.0",
+        "json5": "^0.5.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.clonedeepwith": "^4.5.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.merge": "^4.6.0",
+        "md5-hex": "^2.0.0",
+        "package-hash": "^2.0.0",
+        "pkg-dir": "^2.0.0",
+        "resolve-from": "^3.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "iconv-lite": {
@@ -6433,7 +6433,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -6459,8 +6459,8 @@
       "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -6485,8 +6485,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6506,8 +6506,8 @@
       "integrity": "sha512-STx5orGQU1gfrkoI/fMU7lX6CSP7LBGO10gXNgOZhwKhUqbtNjCkYSewJtNnLmWP1tAGN6oyEpG1HFPw5vpa5Q==",
       "dev": true,
       "requires": {
-        "moment": "2.22.1",
-        "sanitize-html": "1.18.2"
+        "moment": "^2.14.1",
+        "sanitize-html": "^1.13.0"
       }
     },
     "inquirer": {
@@ -6516,20 +6516,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6550,8 +6550,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -6560,7 +6560,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6571,7 +6571,7 @@
       "integrity": "sha1-LHsDFGvB1GvyENCgOXxckatMorA=",
       "dev": true,
       "requires": {
-        "espower-loader": "1.2.2"
+        "espower-loader": "^1.0.0"
       }
     },
     "into-stream": {
@@ -6580,8 +6580,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0",
-        "p-is-promise": "1.1.0"
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
       }
     },
     "invariant": {
@@ -6590,7 +6590,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -6614,7 +6614,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6622,7 +6622,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6639,7 +6639,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6653,7 +6653,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -6662,7 +6662,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -6670,7 +6670,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6678,7 +6678,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6688,9 +6688,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6712,7 +6712,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-error": {
@@ -6737,7 +6737,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -6745,7 +6745,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator-fn": {
@@ -6759,7 +6759,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-installed-globally": {
@@ -6768,8 +6768,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-npm": {
@@ -6783,7 +6783,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6791,7 +6791,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6813,7 +6813,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-odd": {
@@ -6821,7 +6821,7 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
       "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
       "requires": {
-        "is-number": "4.0.0"
+        "is-number": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -6843,7 +6843,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -6852,7 +6852,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -6866,7 +6866,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -6971,8 +6971,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "1.4.1",
-        "is-object": "1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jest-docblock": {
@@ -6999,8 +6999,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "js2xmlparser": {
@@ -7009,7 +7009,7 @@
       "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
       "dev": true,
       "requires": {
-        "xmlcreate": "1.0.2"
+        "xmlcreate": "^1.0.1"
       }
     },
     "jsbn": {
@@ -7025,17 +7025,17 @@
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
-        "bluebird": "3.5.1",
-        "catharsis": "0.8.9",
-        "escape-string-regexp": "1.0.5",
-        "js2xmlparser": "3.0.0",
-        "klaw": "2.0.0",
-        "marked": "0.3.19",
-        "mkdirp": "0.5.1",
-        "requizzle": "0.2.1",
-        "strip-json-comments": "2.0.1",
+        "bluebird": "~3.5.0",
+        "catharsis": "~0.8.9",
+        "escape-string-regexp": "~1.0.5",
+        "js2xmlparser": "~3.0.0",
+        "klaw": "~2.0.0",
+        "marked": "~0.3.6",
+        "mkdirp": "~0.5.1",
+        "requizzle": "~0.2.1",
+        "strip-json-comments": "~2.0.1",
         "taffydb": "2.6.2",
-        "underscore": "1.8.3"
+        "underscore": "~1.8.3"
       },
       "dependencies": {
         "babylon": {
@@ -7097,7 +7097,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -7124,7 +7124,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -7132,8 +7132,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "1.1.6",
-        "safe-buffer": "5.1.2"
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "keyv": {
@@ -7156,7 +7156,7 @@
       "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "last-line-stream": {
@@ -7165,7 +7165,7 @@
       "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
       "dev": true,
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "latest-version": {
@@ -7174,7 +7174,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -7189,7 +7189,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -7198,8 +7198,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -7208,10 +7208,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7228,19 +7228,14 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-    },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -7356,7 +7351,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -7365,8 +7360,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -7380,8 +7375,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -7390,7 +7385,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "map-cache": {
@@ -7409,7 +7404,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "marked": {
@@ -7424,7 +7419,7 @@
       "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.4"
       }
     },
     "math-random": {
@@ -7439,7 +7434,7 @@
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "0.1.1"
+        "md5-o-matic": "^0.1.1"
       }
     },
     "md5-o-matic": {
@@ -7454,7 +7449,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "meow": {
@@ -7463,16 +7458,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -7481,8 +7476,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -7491,11 +7486,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "minimist": {
@@ -7510,7 +7505,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -7519,9 +7514,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -7542,7 +7537,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -7551,9 +7546,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -7562,8 +7557,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -7572,7 +7567,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -7589,7 +7584,7 @@
       "integrity": "sha1-65aDOLXe1c7tgs7AMH3sui2OqZQ=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "merge-stream": {
@@ -7597,7 +7592,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "merge2": {
@@ -7621,19 +7616,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.9",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "mime": {
@@ -7651,7 +7646,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -7671,7 +7666,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -7685,8 +7680,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -7694,7 +7689,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -7755,7 +7750,7 @@
       "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
       "dev": true,
       "requires": {
-        "source-map": "0.1.43"
+        "source-map": "^0.1.34"
       },
       "dependencies": {
         "source-map": {
@@ -7764,7 +7759,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -7775,10 +7770,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       }
     },
     "mute-stream": {
@@ -7797,18 +7792,18 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
       "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-odd": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "natural-compare": {
@@ -7829,11 +7824,11 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "node-forge": {
@@ -7847,10 +7842,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -7859,7 +7854,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-url": {
@@ -7868,9 +7863,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "2.0.0",
-        "query-string": "5.1.1",
-        "sort-keys": "2.0.0"
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       },
       "dependencies": {
         "prepend-http": {
@@ -7887,7 +7882,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -7901,33 +7896,33 @@
       "integrity": "sha512-PUFq1PSsx5OinSk5g5aaZygcDdI3QQT5XUlbR9QRMihtMS6w0Gm8xj4BxmKeeAlpQXC5M2DIhH16Y+KejceivQ==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.3",
-        "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.4.0",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.1.0",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.2.1",
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.2",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.10.0",
+        "istanbul-lib-report": "^1.1.3",
+        "istanbul-lib-source-maps": "^1.2.3",
+        "istanbul-reports": "^1.4.0",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.1.0",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.2.0",
         "yargs": "11.1.0",
-        "yargs-parser": "8.1.0"
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -7935,9 +7930,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -7960,7 +7955,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -8013,9 +8008,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -8023,14 +8018,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.10",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -8038,7 +8033,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -8046,8 +8041,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.6",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -8055,11 +8050,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.10"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -8067,15 +8062,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.10"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -8083,10 +8078,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -8104,13 +8099,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -8118,7 +8113,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -8126,7 +8121,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -8134,7 +8129,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -8142,9 +8137,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -8164,7 +8159,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -8173,16 +8168,16 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8190,7 +8185,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -8205,15 +8200,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8228,9 +8223,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -8245,8 +8240,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -8254,11 +8249,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "class-utils": {
@@ -8266,10 +8261,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -8277,7 +8272,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "isobject": {
@@ -8293,8 +8288,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -8316,8 +8311,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "commondir": {
@@ -8355,8 +8350,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.3",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -8387,7 +8382,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "define-property": {
@@ -8395,8 +8390,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -8404,7 +8399,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -8412,7 +8407,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -8420,9 +8415,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -8442,7 +8437,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -8450,7 +8445,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -8468,13 +8463,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -8482,9 +8477,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             }
           }
@@ -8494,13 +8489,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -8508,7 +8503,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -8516,7 +8511,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -8526,8 +8521,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -8535,7 +8530,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -8545,14 +8540,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -8560,7 +8555,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -8568,7 +8563,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -8576,7 +8571,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -8584,7 +8579,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -8592,9 +8587,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "kind-of": {
@@ -8609,10 +8604,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8620,7 +8615,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -8630,9 +8625,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -8640,7 +8635,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -8653,8 +8648,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fragment-cache": {
@@ -8662,7 +8657,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "fs.realpath": {
@@ -8690,12 +8685,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -8713,10 +8708,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -8724,7 +8719,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -8734,7 +8729,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -8747,9 +8742,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -8764,8 +8759,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -8773,7 +8768,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -8781,7 +8776,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -8791,7 +8786,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8811,8 +8806,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -8825,7 +8820,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -8838,7 +8833,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-arrayish": {
@@ -8856,7 +8851,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-data-descriptor": {
@@ -8864,7 +8859,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -8872,9 +8867,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -8894,7 +8889,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -8907,7 +8902,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-odd": {
@@ -8915,7 +8910,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "4.0.0"
+            "is-number": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -8930,7 +8925,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -8980,7 +8975,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -8988,13 +8983,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.1",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "semver": "5.5.0"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.2.0",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -9002,10 +8997,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -9013,7 +9008,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -9023,11 +9018,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.2",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -9045,7 +9040,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.11"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -9063,7 +9058,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -9077,7 +9072,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -9085,11 +9080,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -9097,8 +9092,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -9123,7 +9118,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -9131,8 +9126,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "map-cache": {
@@ -9145,7 +9140,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "md5-hex": {
@@ -9153,7 +9148,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -9166,7 +9161,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -9174,7 +9169,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -9189,19 +9184,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9221,7 +9216,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -9234,8 +9229,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -9243,7 +9238,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -9266,18 +9261,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-odd": "^2.0.0",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -9302,10 +9297,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "npm-run-path": {
@@ -9313,7 +9308,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -9331,9 +9326,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -9341,7 +9336,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -9351,7 +9346,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -9366,7 +9361,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -9381,7 +9376,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -9389,8 +9384,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -9403,9 +9398,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -9418,7 +9413,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "1.0.0"
+            "p-try": "^1.0.0"
           }
         },
         "p-locate": {
@@ -9426,7 +9421,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.2.0"
+            "p-limit": "^1.1.0"
           }
         },
         "p-try": {
@@ -9439,7 +9434,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "pascalcase": {
@@ -9452,7 +9447,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -9475,9 +9470,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -9495,7 +9490,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -9503,7 +9498,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -9511,8 +9506,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -9532,9 +9527,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -9542,8 +9537,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -9551,8 +9546,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -9567,8 +9562,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "repeat-element": {
@@ -9586,7 +9581,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -9620,7 +9615,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -9628,7 +9623,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-regex": {
@@ -9636,7 +9631,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "semver": {
@@ -9654,10 +9649,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9665,7 +9660,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9675,7 +9670,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -9698,14 +9693,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.1",
-            "use": "3.1.0"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -9713,7 +9708,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -9721,7 +9716,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9731,9 +9726,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -9741,7 +9736,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -9749,7 +9744,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -9757,7 +9752,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -9765,9 +9760,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "isobject": {
@@ -9787,7 +9782,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           }
         },
         "source-map": {
@@ -9800,11 +9795,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.1.1",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.0.0",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-url": {
@@ -9817,12 +9812,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -9830,8 +9825,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -9844,8 +9839,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -9858,7 +9853,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "static-extend": {
@@ -9866,8 +9861,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -9875,7 +9870,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -9885,8 +9880,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -9899,7 +9894,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -9909,7 +9904,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -9917,7 +9912,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -9935,11 +9930,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "3.1.10",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^3.1.8",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -9957,16 +9952,16 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -9974,7 +9969,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -9984,13 +9979,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -9998,7 +9993,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "extend-shallow": {
@@ -10006,7 +10001,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -10014,7 +10009,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "kind-of": "3.2.2"
+                    "kind-of": "^3.0.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -10022,7 +10017,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                       }
                     }
                   }
@@ -10032,7 +10027,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "kind-of": "3.2.2"
+                    "kind-of": "^3.0.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -10040,7 +10035,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                       }
                     }
                   }
@@ -10050,9 +10045,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "0.1.6",
-                    "is-data-descriptor": "0.1.4",
-                    "kind-of": "5.1.0"
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
                   }
                 },
                 "kind-of": {
@@ -10067,14 +10062,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
@@ -10082,7 +10077,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "extend-shallow": {
@@ -10090,7 +10085,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -10100,10 +10095,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -10111,7 +10106,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -10121,7 +10116,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -10129,7 +10124,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -10137,9 +10132,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             },
             "is-number": {
@@ -10147,7 +10142,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -10155,7 +10150,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -10175,19 +10170,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
               }
             }
           }
@@ -10202,7 +10197,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "to-regex": {
@@ -10210,10 +10205,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "to-regex-range": {
@@ -10221,8 +10216,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           },
           "dependencies": {
             "is-number": {
@@ -10230,7 +10225,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             }
           }
@@ -10246,9 +10241,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -10257,9 +10252,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -10276,10 +10271,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10287,7 +10282,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "set-value": {
@@ -10295,10 +10290,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
               }
             }
           }
@@ -10308,8 +10303,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
@@ -10317,9 +10312,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -10354,7 +10349,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -10369,8 +10364,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "which": {
@@ -10378,7 +10373,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -10402,8 +10397,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -10411,7 +10406,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -10419,9 +10414,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -10436,9 +10431,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -10456,18 +10451,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -10485,9 +10480,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "strip-ansi": {
@@ -10495,7 +10490,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             },
             "yargs-parser": {
@@ -10503,7 +10498,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               }
             }
           }
@@ -10513,7 +10508,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -10541,9 +10536,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -10551,7 +10546,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -10559,7 +10554,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -10574,7 +10569,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.omit": {
@@ -10583,8 +10578,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -10592,7 +10587,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "observable-to-promise": {
@@ -10601,8 +10596,8 @@
       "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
       "dev": true,
       "requires": {
-        "is-observable": "0.2.0",
-        "symbol-observable": "1.2.0"
+        "is-observable": "^0.2.0",
+        "symbol-observable": "^1.0.4"
       },
       "dependencies": {
         "is-observable": {
@@ -10611,7 +10606,7 @@
           "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
           "dev": true,
           "requires": {
-            "symbol-observable": "0.2.4"
+            "symbol-observable": "^0.2.2"
           },
           "dependencies": {
             "symbol-observable": {
@@ -10629,7 +10624,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -10638,7 +10633,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -10647,8 +10642,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "option-chain": {
@@ -10663,12 +10658,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -10695,7 +10690,7 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -10733,7 +10728,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -10742,7 +10737,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-queue": {
@@ -10756,7 +10751,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -10771,10 +10766,10 @@
       "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "lodash.flattendeep": "4.4.0",
-        "md5-hex": "2.0.0",
-        "release-zalgo": "1.0.0"
+        "graceful-fs": "^4.1.11",
+        "lodash.flattendeep": "^4.4.0",
+        "md5-hex": "^2.0.0",
+        "release-zalgo": "^1.0.0"
       }
     },
     "package-json": {
@@ -10783,10 +10778,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "got": {
@@ -10795,17 +10790,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.1",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
           }
         }
       }
@@ -10816,10 +10811,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -10834,7 +10829,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -10845,7 +10840,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -10915,7 +10910,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "performance-now": {
@@ -10940,7 +10935,7 @@
       "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
       "dev": true,
       "requires": {
-        "pinkie": "1.0.0"
+        "pinkie": "^1.0.0"
       }
     },
     "pkg-conf": {
@@ -10949,8 +10944,8 @@
       "integrity": "sha1-ISZRTKbyq/69FoWW3xi6V4Z/AFg=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "load-json-file": "4.0.0"
+        "find-up": "^2.0.0",
+        "load-json-file": "^4.0.0"
       },
       "dependencies": {
         "load-json-file": {
@@ -10959,10 +10954,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "parse-json": {
@@ -10971,8 +10966,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -10983,7 +10978,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "plur": {
@@ -10992,7 +10987,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.4.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "pluralize": {
@@ -11012,9 +11007,9 @@
       "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "source-map": "0.6.1",
-        "supports-color": "5.4.0"
+        "chalk": "^2.4.1",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.4.0"
       },
       "dependencies": {
         "source-map": {
@@ -11030,11 +11025,11 @@
       "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.5.0.tgz",
       "integrity": "sha512-WaWSw+Ts283o6dzxW1BxIxoaHok7aSSGx4SaR6dW62Pk31ynv9DERDieuZpPYv5XaJ+H+zdcOaJQ+PvlasAOVw==",
       "requires": {
-        "define-properties": "1.1.2",
-        "empower": "1.2.3",
-        "power-assert-formatter": "1.4.1",
-        "universal-deep-strict-equal": "1.2.2",
-        "xtend": "4.0.1"
+        "define-properties": "^1.1.2",
+        "empower": "^1.2.3",
+        "power-assert-formatter": "^1.3.1",
+        "universal-deep-strict-equal": "^1.2.1",
+        "xtend": "^4.0.0"
       }
     },
     "power-assert-context-formatter": {
@@ -11042,8 +11037,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.1.1.tgz",
       "integrity": "sha1-7bo1LT7YpgMRTWZyZazOYNaJzN8=",
       "requires": {
-        "core-js": "2.5.6",
-        "power-assert-context-traversal": "1.1.1"
+        "core-js": "^2.0.0",
+        "power-assert-context-traversal": "^1.1.1"
       }
     },
     "power-assert-context-reducer-ast": {
@@ -11051,11 +11046,11 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.1.2.tgz",
       "integrity": "sha1-SEqZ4m9Jc/+IMuXFzHVnAuYJQXQ=",
       "requires": {
-        "acorn": "4.0.13",
-        "acorn-es7-plugin": "1.1.7",
-        "core-js": "2.5.6",
-        "espurify": "1.8.0",
-        "estraverse": "4.2.0"
+        "acorn": "^4.0.0",
+        "acorn-es7-plugin": "^1.0.12",
+        "core-js": "^2.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.2.0"
       }
     },
     "power-assert-context-traversal": {
@@ -11063,8 +11058,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.1.1.tgz",
       "integrity": "sha1-iMq8oNE7Y1nwfT0+ivppkmRXftk=",
       "requires": {
-        "core-js": "2.5.6",
-        "estraverse": "4.2.0"
+        "core-js": "^2.0.0",
+        "estraverse": "^4.1.0"
       }
     },
     "power-assert-formatter": {
@@ -11072,13 +11067,13 @@
       "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
       "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
       "requires": {
-        "core-js": "2.5.6",
-        "power-assert-context-formatter": "1.1.1",
-        "power-assert-context-reducer-ast": "1.1.2",
-        "power-assert-renderer-assertion": "1.1.1",
-        "power-assert-renderer-comparison": "1.1.1",
-        "power-assert-renderer-diagram": "1.1.2",
-        "power-assert-renderer-file": "1.1.1"
+        "core-js": "^2.0.0",
+        "power-assert-context-formatter": "^1.0.7",
+        "power-assert-context-reducer-ast": "^1.0.7",
+        "power-assert-renderer-assertion": "^1.0.7",
+        "power-assert-renderer-comparison": "^1.0.7",
+        "power-assert-renderer-diagram": "^1.0.7",
+        "power-assert-renderer-file": "^1.0.7"
       }
     },
     "power-assert-renderer-assertion": {
@@ -11086,8 +11081,8 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.1.1.tgz",
       "integrity": "sha1-y/wOd+AIao+Wrz8djme57n4ozpg=",
       "requires": {
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1"
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.1.1"
       }
     },
     "power-assert-renderer-base": {
@@ -11100,11 +11095,11 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.1.1.tgz",
       "integrity": "sha1-10Odl9hRVr5OMKAPL7WnJRTOPAg=",
       "requires": {
-        "core-js": "2.5.6",
-        "diff-match-patch": "1.0.1",
-        "power-assert-renderer-base": "1.1.1",
-        "stringifier": "1.3.0",
-        "type-name": "2.0.2"
+        "core-js": "^2.0.0",
+        "diff-match-patch": "^1.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "stringifier": "^1.3.0",
+        "type-name": "^2.0.1"
       }
     },
     "power-assert-renderer-diagram": {
@@ -11112,10 +11107,10 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.1.2.tgz",
       "integrity": "sha1-ZV+PcRk1qbbVQbhjJ2VHF8Y3qYY=",
       "requires": {
-        "core-js": "2.5.6",
-        "power-assert-renderer-base": "1.1.1",
-        "power-assert-util-string-width": "1.1.1",
-        "stringifier": "1.3.0"
+        "core-js": "^2.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.1.1",
+        "stringifier": "^1.3.0"
       }
     },
     "power-assert-renderer-file": {
@@ -11123,7 +11118,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.1.1.tgz",
       "integrity": "sha1-o34rvReMys0E5427eckv40kzxec=",
       "requires": {
-        "power-assert-renderer-base": "1.1.1"
+        "power-assert-renderer-base": "^1.1.1"
       }
     },
     "power-assert-util-string-width": {
@@ -11131,7 +11126,7 @@
       "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.1.1.tgz",
       "integrity": "sha1-vmWet5N/3S5smncmjar2S9W3xZI=",
       "requires": {
-        "eastasianwidth": "0.1.1"
+        "eastasianwidth": "^0.1.1"
       }
     },
     "prelude-ls": {
@@ -11164,8 +11159,8 @@
       "integrity": "sha1-6crJx2v27lL+lC3ZxsQhMVOxKIE=",
       "dev": true,
       "requires": {
-        "parse-ms": "1.0.1",
-        "plur": "2.1.2"
+        "parse-ms": "^1.0.0",
+        "plur": "^2.1.2"
       },
       "dependencies": {
         "parse-ms": {
@@ -11198,19 +11193,19 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.6.tgz",
       "integrity": "sha512-eH2OTP9s55vojr3b7NBaF9i4WhWPkv/nq55nznWNp/FomKrLViprUcqnBjHph2tFQ+7KciGPTPsVWGz0SOhL0Q==",
       "requires": {
-        "@protobufjs/aspromise": "1.1.2",
-        "@protobufjs/base64": "1.1.2",
-        "@protobufjs/codegen": "2.0.4",
-        "@protobufjs/eventemitter": "1.1.0",
-        "@protobufjs/fetch": "1.1.0",
-        "@protobufjs/float": "1.0.2",
-        "@protobufjs/inquire": "1.1.0",
-        "@protobufjs/path": "1.1.2",
-        "@protobufjs/pool": "1.1.0",
-        "@protobufjs/utf8": "1.1.0",
-        "@types/long": "3.0.32",
-        "@types/node": "8.10.17",
-        "long": "4.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^3.0.32",
+        "@types/node": "^8.9.4",
+        "long": "^4.0.0"
       },
       "dependencies": {
         "long": {
@@ -11226,9 +11221,9 @@
       "integrity": "sha512-fQr3VQrbdzHrdaDn3XuisVoJlJNDJizHAvUXw9IuXRR8BpV2x0N7LsCxrpJkeKfPbNjiNU/V5vc008cI0TmzzQ==",
       "dev": true,
       "requires": {
-        "fill-keys": "1.0.2",
-        "module-not-found-error": "1.0.1",
-        "resolve": "1.5.0"
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.5.0"
       },
       "dependencies": {
         "resolve": {
@@ -11237,7 +11232,7 @@
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -11252,8 +11247,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -11261,9 +11256,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -11282,9 +11277,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "randomatic": {
@@ -11293,9 +11288,9 @@
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -11312,10 +11307,10 @@
       "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.5.1",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -11332,9 +11327,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -11343,7 +11338,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -11360,8 +11355,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -11369,13 +11364,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -11384,10 +11379,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "redent": {
@@ -11396,8 +11391,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       },
       "dependencies": {
         "indent-string": {
@@ -11406,7 +11401,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         }
       }
@@ -11429,7 +11424,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -11437,8 +11432,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -11453,9 +11448,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -11464,8 +11459,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
-        "safe-buffer": "5.1.2"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -11474,7 +11469,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -11489,7 +11484,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "release-zalgo": {
@@ -11498,7 +11493,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "4.1.1"
+        "es6-error": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -11523,7 +11518,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -11531,26 +11526,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -11577,8 +11572,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -11595,7 +11590,7 @@
       "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
       "dev": true,
       "requires": {
-        "underscore": "1.6.0"
+        "underscore": "~1.6.0"
       },
       "dependencies": {
         "underscore": {
@@ -11618,7 +11613,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -11638,7 +11633,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "1.0.1"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -11647,8 +11642,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -11666,8 +11661,8 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "requires": {
-        "request": "2.87.0",
-        "through2": "2.0.3"
+        "request": "^2.81.0",
+        "through2": "^2.0.0"
       }
     },
     "right-align": {
@@ -11677,7 +11672,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -11686,7 +11681,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -11695,7 +11690,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -11710,7 +11705,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -11723,7 +11718,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -11744,16 +11739,16 @@
       "integrity": "sha512-52ThA+Z7h6BnvpSVbURwChl10XZrps5q7ytjTwWcIe9bmJwnVP6cpEVK2NvDOUhGupoqAvNbUz3cpnJDp4+/pg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "htmlparser2": "3.9.2",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.escaperegexp": "4.1.2",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.mergewith": "4.6.1",
-        "postcss": "6.0.22",
-        "srcset": "1.0.0",
-        "xtend": "4.0.1"
+        "chalk": "^2.3.0",
+        "htmlparser2": "^3.9.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.0",
+        "postcss": "^6.0.14",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "semver": {
@@ -11768,7 +11763,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.0.3"
       }
     },
     "serialize-error": {
@@ -11794,10 +11789,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -11805,7 +11800,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -11816,7 +11811,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -11837,13 +11832,13 @@
       "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
-        "nise": "1.3.3",
-        "supports-color": "5.4.0",
-        "type-detect": "4.0.8"
+        "@sinonjs/formatio": "^2.0.0",
+        "diff": "^3.1.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.2.0",
+        "nise": "^1.2.0",
+        "supports-color": "^5.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "slash": {
@@ -11857,7 +11852,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -11879,14 +11874,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -11902,7 +11897,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -11910,7 +11905,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -11920,9 +11915,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -11930,7 +11925,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -11938,7 +11933,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -11946,7 +11941,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -11954,9 +11949,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -11966,7 +11961,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -11974,7 +11969,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -11985,7 +11980,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-map": {
@@ -11998,11 +11993,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -12011,8 +12006,8 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -12034,8 +12029,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -12050,8 +12045,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -12065,7 +12060,7 @@
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
       "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
       "requires": {
-        "is-stream-ended": "0.1.4"
+        "is-stream-ended": "^0.1.4"
       }
     },
     "split-string": {
@@ -12073,7 +12068,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -12088,8 +12083,8 @@
       "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3",
-        "number-is-nan": "1.0.1"
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
       }
     },
     "sshpk": {
@@ -12097,14 +12092,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -12123,8 +12118,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12132,7 +12127,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -12143,7 +12138,7 @@
       "integrity": "sha512-5QkxGCWGMbeQ+PXqI2N7ES6kW4IimvbMQBCKvZbekaEpf3InckVHiIXdCJbZsKUjLE7a3jha2cTEJqtOGGcVMw==",
       "dev": true,
       "requires": {
-        "isnumber": "1.0.0"
+        "isnumber": "~1.0.0"
       }
     },
     "stream-events": {
@@ -12151,7 +12146,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
       "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
       "requires": {
-        "stubs": "3.0.0"
+        "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
@@ -12181,9 +12176,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -12191,7 +12186,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringifier": {
@@ -12199,9 +12194,9 @@
       "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.3.0.tgz",
       "integrity": "sha1-3vGDQvaTPbDy2/yaoCF1tEjBeVk=",
       "requires": {
-        "core-js": "2.5.6",
-        "traverse": "0.6.6",
-        "type-name": "2.0.2"
+        "core-js": "^2.0.0",
+        "traverse": "^0.6.6",
+        "type-name": "^2.0.1"
       }
     },
     "strip-ansi": {
@@ -12209,7 +12204,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -12224,7 +12219,7 @@
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.1"
       }
     },
     "strip-eof": {
@@ -12239,7 +12234,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -12259,16 +12254,16 @@
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.2",
-        "formidable": "1.2.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.2",
-        "readable-stream": "2.3.6"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
       },
       "dependencies": {
         "mime": {
@@ -12285,11 +12280,11 @@
       "integrity": "sha512-HZJ3geIMPgVwKk2VsmO5YHqnnJYl6bV5A9JW2uzqV43WmpgliNEYbuvukfor7URpaqpxuw3CfZ3ONdVbZjCgIA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "indent-string": "3.2.0",
-        "js-yaml": "3.11.0",
-        "serialize-error": "2.1.0",
-        "strip-ansi": "4.0.0"
+        "arrify": "^1.0.1",
+        "indent-string": "^3.2.0",
+        "js-yaml": "^3.10.0",
+        "serialize-error": "^2.1.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12304,7 +12299,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12315,8 +12310,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.3"
+        "methods": "~1.1.2",
+        "superagent": "^3.0.0"
       }
     },
     "supports-color": {
@@ -12325,7 +12320,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -12348,12 +12343,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12374,8 +12369,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -12384,7 +12379,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12401,7 +12396,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "text-encoding": {
@@ -12427,8 +12422,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "time-span": {
@@ -12437,7 +12432,7 @@
       "integrity": "sha1-52JKN5F6SXKdvzt8R8W3mUQOUy8=",
       "dev": true,
       "requires": {
-        "convert-hrtime": "2.0.0"
+        "convert-hrtime": "^2.0.0"
       }
     },
     "time-zone": {
@@ -12458,7 +12453,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-fast-properties": {
@@ -12472,7 +12467,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -12480,7 +12475,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -12490,10 +12485,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -12501,8 +12496,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -12510,7 +12505,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse": {
@@ -12541,7 +12536,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12556,7 +12551,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -12582,9 +12577,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "camelcase": {
@@ -12601,8 +12596,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -12627,9 +12622,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -12676,10 +12671,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12687,7 +12682,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -12695,10 +12690,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -12709,7 +12704,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unique-temp-dir": {
@@ -12718,8 +12713,8 @@
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1",
-        "os-tmpdir": "1.0.2",
+        "mkdirp": "^0.5.1",
+        "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
       }
     },
@@ -12728,9 +12723,9 @@
       "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
       "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
       "requires": {
-        "array-filter": "1.0.0",
+        "array-filter": "^1.0.0",
         "indexof": "0.0.1",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.0"
       }
     },
     "universalify": {
@@ -12744,8 +12739,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -12753,9 +12748,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -12787,16 +12782,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "urix": {
@@ -12810,7 +12805,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -12830,7 +12825,7 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       }
     },
     "util-deprecate": {
@@ -12849,8 +12844,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -12858,9 +12853,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "well-known-symbols": {
@@ -12875,7 +12870,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -12890,7 +12885,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12911,8 +12906,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -12921,7 +12916,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -12942,8 +12937,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -12957,7 +12952,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -12966,9 +12961,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "write-json-file": {
@@ -12977,12 +12972,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "5.0.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "pify": "3.0.0",
-        "sort-keys": "2.0.0",
-        "write-file-atomic": "2.3.0"
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
       },
       "dependencies": {
         "detect-indent": {
@@ -12999,8 +12994,8 @@
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
       "dev": true,
       "requires": {
-        "sort-keys": "2.0.0",
-        "write-json-file": "2.3.0"
+        "sort-keys": "^2.0.0",
+        "write-json-file": "^2.2.0"
       }
     },
     "xdg-basedir": {
@@ -13036,18 +13031,18 @@
       "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "dev": true,
       "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13062,9 +13057,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -13079,9 +13074,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "string-width": {
@@ -13090,8 +13085,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -13100,7 +13095,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -13111,7 +13106,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "google-gax": "^0.16.0",
     "google-proto-files": "^0.15.0",
     "is": "^3.1.0",
-    "lodash.chunk": "^4.2.0",
     "lodash.flatten": "^4.4.0",
     "lodash.merge": "^4.6.1",
     "lodash.snakecase": "^4.1.1",

--- a/src/codec.js
+++ b/src/codec.js
@@ -118,7 +118,7 @@ codec.generateToJSONFromRow = generateToJSONFromRow;
  * @private
  */
 function decode(value, field) {
-  function decodeValue_(decoded, type, options) {
+  function decodeValue_(decoded, type) {
     if (is.null(decoded)) {
       return null;
     }

--- a/src/codec.js
+++ b/src/codec.js
@@ -122,9 +122,6 @@ function decode(value, field) {
     if (is.null(decoded)) {
       return null;
     }
-    if (type === undefined) {
-      return decoded;
-    }
 
     switch (type.code) {
       case 'BYTES': {

--- a/src/codec.js
+++ b/src/codec.js
@@ -122,6 +122,9 @@ function decode(value, field) {
     if (is.null(decoded)) {
       return null;
     }
+    if (type === undefined) {
+      return decoded;
+    }
 
     switch (type.code) {
       case 'BYTES': {

--- a/src/codec.js
+++ b/src/codec.js
@@ -118,7 +118,7 @@ codec.generateToJSONFromRow = generateToJSONFromRow;
  * @private
  */
 function decode(value, field) {
-  function decodeValue_(decoded, type) {
+  function decodeValue_(decoded, type, options) {
     if (is.null(decoded)) {
       return null;
     }
@@ -176,7 +176,7 @@ function decode(value, field) {
     return decoded;
   }
 
-  return decodeValue_(commonGrpc.Service.decodeValue_(value), field.type);
+  return decodeValue_(value, field.type);
 }
 
 codec.decode = decode;

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -104,7 +104,7 @@ function partialResultStream(requestFn, options) {
         return;
       }
 
-      formattedRows = builder.toJSONnobuild(formattedRows);
+      formattedRows = builder.toJSON(formattedRows);
       if (options.json) {
         formattedRows = formattedRows.map(exec('toJSON', options.jsonOptions));
       }

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -74,7 +74,6 @@ function partialResultStream(requestFn, options) {
 
   var userStream = streamEvents(
     through.obj(function(row, _, next) {
-      //console.log("rowcount:" + row.values.length + " firstid:" + row.values[0].stringValue)
       var formattedRows = [];
 
       if (row.metadata) {
@@ -86,15 +85,12 @@ function partialResultStream(requestFn, options) {
         return;
       }
 
-      if (row.values[0].stringValue.endsWith('9197')) {
-        console.log('magic off error')
-      }
       // Use RowBuilder to construct rows returning rows as complete.
-      if (builder == undefined){
+      if (builder === undefined) {
         builder = new RowBuilder(metadata, rowChunks.concat(row));
       } else {
-        builder.chunks = builder.chunks.concat(row)
-        builder.metadata = metadata
+        builder.chunks = builder.chunks.concat(row);
+        builder.metadata = metadata;
       }
       // Build the chunks to rows.
       builder.build();
@@ -103,12 +99,12 @@ function partialResultStream(requestFn, options) {
       formattedRows = formattedRows.concat(builder.collectRows());
 
       // This isn't likely, but we could have zero rows. Continue if so.
-      if (is.empty(formattedRows)){
+      if (is.empty(formattedRows)) {
         next();
         return;
       }
 
-      formattedRows = builder.toJSONnobuild(formattedRows)
+      formattedRows = builder.toJSONnobuild(formattedRows);
       if (options.json) {
         formattedRows = formattedRows.map(exec('toJSON', options.jsonOptions));
       }

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -64,7 +64,7 @@ function partialResultStream(requestFn, options) {
   var batchAndSplitOnTokenStream = checkpointStream.obj({
     maxQueued: 10,
     isCheckpointFn: function(row) {
-      return Buffer.isBuffer(row.resumeToken);
+      return is.defined(row.resumeToken);
     },
   });
 
@@ -84,7 +84,10 @@ function partialResultStream(requestFn, options) {
       // large rows and/or large values. If we are missing the resumeToken
       // this is likely due to the PartialResultSet hitting size restrictions.
       // In this case it is also necessary to combine this with the next obj.
-      if (!row.resumeToken || row.resumeToken.length === 0) {
+      if (
+        (!row.resumeToken || row.resumeToken.length === 0) &&
+        row.values.length % metadata.rowType.fields.length !== 0
+      ) {
         rowChunks.push(row);
         next();
         return;

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -17,7 +17,6 @@
 'use strict';
 
 var checkpointStream = require('checkpoint-stream');
-var chunk = require('lodash.chunk');
 var eventsIntercept = require('events-intercept');
 var exec = require('methmeth');
 var extend = require('extend');
@@ -27,7 +26,6 @@ var split = require('split-array-stream').split;
 var streamEvents = require('stream-events');
 var through = require('through2');
 
-var codec = require('./codec.js');
 var RowBuilder = require('./row-builder.js');
 
 /**
@@ -68,16 +66,10 @@ function partialResultStream(requestFn, options) {
     },
   });
 
-  var rowChunks = [];
-  var metadata;
   var builder;
 
   var userStream = streamEvents(
     through.obj(function(row, _, next) {
-      if (row.metadata) {
-        metadata = row.metadata;
-      }
-
       if (is.empty(row.values)) {
         next();
         return;
@@ -85,7 +77,7 @@ function partialResultStream(requestFn, options) {
 
       // Use RowBuilder to construct and return complete, formatted rows.
       if (!builder) {
-        builder = new RowBuilder(metadata);
+        builder = new RowBuilder(row.metadata);
       }
 
       builder.addRow(row);

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -77,7 +77,7 @@ function partialResultStream(requestFn, options) {
 
       // Use RowBuilder to construct and return complete, formatted rows.
       if (!builder) {
-        builder = new RowBuilder(row.metadata);
+        builder = new RowBuilder(row.metadata.rowType.fields);
       }
 
       builder.addRow(row);

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -103,7 +103,7 @@ function partialResultStream(requestFn, options) {
         // Stop using json on these rows.
         builder.build();
         formattedRows = formattedRows.concat(builder.rows);
-        if(formattedRows[formattedRows.length -1].length != metadata.rowType.field.length){
+        if(formattedRows[formattedRows.length -1].length != metadata.rowType.fields.length){
           console.log("incomplete final row");
           rowChunks.push(formattedRows.splice(-1));
         } else {

--- a/src/partial-result-stream.js
+++ b/src/partial-result-stream.js
@@ -86,6 +86,9 @@ function partialResultStream(requestFn, options) {
         return;
       }
 
+      if (row.values[0].stringValue.endsWith('9197')) {
+        console.log('magic off error')
+      }
       // Use RowBuilder to construct rows returning rows as complete.
       if (builder == undefined){
         builder = new RowBuilder(metadata, rowChunks.concat(row));

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -150,6 +150,20 @@ RowBuilder.prototype.build = function() {
 
     previousChunk = chunk;
   });
+
+  // remove chunks that are now in rows.
+  if (this.chunks.length > 0){
+    var lastChunk = this.chunks.splice(-1)[0];
+    this.chunks.length = 0
+    // if the last chunk was chunked, strip off just that value and add the chunk
+    // back to be processed in the next build
+    if (lastChunk.chunkedValue){
+      lastChunk.values = lastChunk.values.splice(-1);
+      this.chunks = [ lastChunk ];
+      // There is a partial row added to rows. Remove this.
+      this.rows.pop()
+    }
+  }
 };
 
 /**

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -29,8 +29,8 @@ function RowBuilder(metadata, chunks) {
   this.metadata = metadata;
   this.fields = this.metadata.rowType.fields;
   this.chunks = chunks;
-  this.rows = [[]]
-  
+  this.rows = [[]];
+
   Object.defineProperty(this, 'currentRow', {
     get: function() {
       return this.rows[this.rows.length - 1];
@@ -38,25 +38,27 @@ function RowBuilder(metadata, chunks) {
   });
 }
 
-/** 
+/**
  * Return complete rows and remove from builder
  */
-RowBuilder.prototype.collectRows = function(){
-  var partialRow
-  if(!is.empty(this.rows) &&
-     this.rows[this.rows.length -1].length != this.metadata.rowType.fields.length){
+RowBuilder.prototype.collectRows = function() {
+  var partialRow;
+  if (
+    !is.empty(this.rows) &&
+    this.rows[this.rows.length - 1].length !==
+      this.metadata.rowType.fields.length
+  ) {
+    // Don't return the partial row. Hold onto it for the next iteration
     partialRow = this.rows.splice(-1);
-    // console.log("incomplete final row in formatted rows");
-    // console.log(partialRow)
   }
-  var rowsToReturn = this.rows
-  if (partialRow){
+  var rowsToReturn = this.rows;
+  if (partialRow) {
     this.rows = partialRow;
   } else {
     this.rows = [[]];
   }
   return rowsToReturn;
-}
+};
 
 /**
  * Extracts value from chunk.
@@ -154,11 +156,6 @@ RowBuilder.prototype.build = function() {
   var previousChunk;
 
   this.chunks.forEach(function(chunk) {
-    // chunk.values.forEach(val => {
-    //   if (val.stringValue.endsWith('account_created_on_      9197')) {
-    //     console.log('magic off error')
-    //   } 
-    // })
     if (previousChunk && previousChunk.chunkedValue) {
       var type = self.fields[self.currentRow.length - 1].type;
       var merged = RowBuilder.merge(
@@ -176,16 +173,15 @@ RowBuilder.prototype.build = function() {
   });
 
   // As chunks are now in rows, remove them
-  this.chunks.length = 0
+  this.chunks.length = 0;
 
   // Examine the last chunk. If it was 'chunked' strip that off and place it
   // back to be processed in the next build
-  if (previousChunk && previousChunk.chunkedValue){
+  if (previousChunk && previousChunk.chunkedValue) {
     previousChunk.values = previousChunk.values.splice(-1);
-    this.chunks = [ previousChunk ];
+    this.chunks = [previousChunk];
     // There is a partial row added to rows. Remove this.
-    // TODO: This may not be needed
-    this.currentRow.pop() // the partial row need this to build the row
+    this.currentRow.pop();
   }
 };
 
@@ -225,8 +221,7 @@ RowBuilder.prototype.toJSON = function() {
   });
 };
 
-RowBuilder.prototype.toJSONnobuild = function (rows) {
-
+RowBuilder.prototype.toJSONnobuild = function(rows) {
   var fields = this.fields;
 
   return rows.map(function(values) {

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -26,13 +26,9 @@ var is = require('is');
  * @private
  * @class
  */
-function RowBuilder(fields, initial_chunks = undefined) {
+function RowBuilder(fields) {
   this.fields = fields;
   this.chunks = [];
-  if (initial_chunks) {
-    this.chunks = initial_chunks;
-  }
-
   this.rows = [[]];
 
   Object.defineProperty(this, 'currentRow', {
@@ -48,9 +44,7 @@ function RowBuilder(fields, initial_chunks = undefined) {
 RowBuilder.getValue = function(obj) {
   var value = obj;
 
-  if (obj && obj.kind === 'listValue') {
-    return obj.listValue.values.map(v => RowBuilder.getValue(v));
-  } else if (obj && obj.kind) {
+  if (obj && obj.kind) {
     value = commonGrpc.Service.decodeValue_(obj);
   }
 
@@ -72,10 +66,6 @@ RowBuilder.formatValue = function(field, value) {
 
   if (field.code === 'ARRAY') {
     return value.map(function(value) {
-      //if value isn't set, just return it as is.
-      if (value === undefined || value === {}) {
-        return value;
-      }
       return RowBuilder.formatValue(field.arrayElementType, value);
     });
   }
@@ -178,7 +168,6 @@ RowBuilder.prototype.build = function() {
  * Flush already complete rows.
  */
 RowBuilder.prototype.flush = function() {
-  this.build();
   var rowsToReturn = this.rows;
 
   if (
@@ -198,9 +187,6 @@ RowBuilder.prototype.flush = function() {
  * Transforms values into JSON format.
  */
 RowBuilder.prototype.toJSON = function(rows) {
-  if (rows === undefined) {
-    rows = this.flush();
-  }
   var fields = this.fields;
 
   return rows.map(function(values) {

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -188,40 +188,7 @@ RowBuilder.prototype.build = function() {
 /**
  * Transforms values into JSON format.
  */
-RowBuilder.prototype.toJSON = function() {
-  this.build();
-
-  var fields = this.fields;
-
-  return this.rows.map(function(values) {
-    var formattedRow = [];
-    var serializedRow = {};
-
-    values.forEach(function(value, index) {
-      var field = fields[index];
-
-      var column = {
-        name: field.name,
-        value: RowBuilder.formatValue(field.type, value),
-      };
-
-      formattedRow.push(column);
-
-      if (column.name) {
-        serializedRow[column.name] = column.value;
-      }
-    });
-
-    Object.defineProperty(formattedRow, 'toJSON', {
-      enumerable: false,
-      value: codec.generateToJSONFromRow(formattedRow),
-    });
-
-    return formattedRow;
-  });
-};
-
-RowBuilder.prototype.toJSONnobuild = function(rows) {
+RowBuilder.prototype.toJSON = function(rows) {
   var fields = this.fields;
 
   return rows.map(function(values) {

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -75,7 +75,7 @@ RowBuilder.formatValue = function(field, value) {
   }
 
   return field.structType.fields.reduce(function(struct, field, index) {
-    struct[field.name] = RowBuilder.formatValue(field.type, value[index]);
+    struct[field.name] = RowBuilder.formatValue(field, value[index]);
     return struct;
   }, {});
 };

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -178,7 +178,7 @@ RowBuilder.prototype.flush = function() {
 
   if (!is.empty(this.rows[0]) && this.currentRow.length !== this.fields.length) {
     // Don't return the partial row. Hold onto it for the next iteration.
-    this.rows = [this.rows.splice(-1)];
+    this.rows = this.rows.splice(-1);
   } else {
     this.rows = [[]];
   }

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -43,7 +43,8 @@ function RowBuilder(metadata, chunks) {
  */
 RowBuilder.prototype.collectRows = function(){
   var partialRow
-  if(this.rows[this.rows.length -1].length != this.metadata.rowType.fields.length){
+  if(!is.empty(this.rows) &&
+     this.rows[this.rows.length -1].length != this.metadata.rowType.fields.length){
     console.log("incomplete final row in formatted rows");
     partialRow = this.rows.splice(-1);
     console.log(partialRow)
@@ -193,6 +194,38 @@ RowBuilder.prototype.toJSON = function() {
   var fields = this.fields;
 
   return this.rows.map(function(values) {
+    var formattedRow = [];
+    var serializedRow = {};
+
+    values.forEach(function(value, index) {
+      var field = fields[index];
+
+      var column = {
+        name: field.name,
+        value: RowBuilder.formatValue(field.type, value),
+      };
+
+      formattedRow.push(column);
+
+      if (column.name) {
+        serializedRow[column.name] = column.value;
+      }
+    });
+
+    Object.defineProperty(formattedRow, 'toJSON', {
+      enumerable: false,
+      value: codec.generateToJSONFromRow(formattedRow),
+    });
+
+    return formattedRow;
+  });
+};
+
+RowBuilder.prototype.toJSONnobuild = function (rows) {
+
+  var fields = this.fields;
+
+  return rows.map(function(values) {
     var formattedRow = [];
     var serializedRow = {};
 

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -45,13 +45,13 @@ RowBuilder.prototype.collectRows = function(){
   var partialRow
   if(!is.empty(this.rows) &&
      this.rows[this.rows.length -1].length != this.metadata.rowType.fields.length){
-    console.log("incomplete final row in formatted rows");
     partialRow = this.rows.splice(-1);
-    console.log(partialRow)
+    // console.log("incomplete final row in formatted rows");
+    // console.log(partialRow)
   }
   var rowsToReturn = this.rows
   if (partialRow){
-    this.rows = [ partialRow ];
+    this.rows = partialRow;
   } else {
     this.rows = [[]];
   }
@@ -154,11 +154,11 @@ RowBuilder.prototype.build = function() {
   var previousChunk;
 
   this.chunks.forEach(function(chunk) {
-    chunk.values.forEach(val => {
-      if (val.stringValue.endsWith('account_creted_on_      9197')) {
-        console.log('magic off error')
-      }
-    })
+    // chunk.values.forEach(val => {
+    //   if (val.stringValue.endsWith('account_created_on_      9197')) {
+    //     console.log('magic off error')
+    //   } 
+    // })
     if (previousChunk && previousChunk.chunkedValue) {
       var type = self.fields[self.currentRow.length - 1].type;
       var merged = RowBuilder.merge(
@@ -175,19 +175,17 @@ RowBuilder.prototype.build = function() {
     previousChunk = chunk;
   });
 
-  // remove chunks that are now in rows.
-  if (this.chunks.length > 0){
-    var lastChunk = this.chunks.splice(-1)[0];
-    this.chunks.length = 0
-    // if the last chunk was chunked, strip off just that value and add the chunk
-    // back to be processed in the next build
-    if (lastChunk.chunkedValue){
-      lastChunk.values = lastChunk.values.splice(-1);
-      this.chunks = [ lastChunk ];
-      // There is a partial row added to rows. Remove this.
-      // TODO: This may not be needed
-      this.currentRow.pop() // the partial row need this to build the row
-    }
+  // As chunks are now in rows, remove them
+  this.chunks.length = 0
+
+  // Examine the last chunk. If it was 'chunked' strip that off and place it
+  // back to be processed in the next build
+  if (previousChunk && previousChunk.chunkedValue){
+    previousChunk.values = previousChunk.values.splice(-1);
+    this.chunks = [ previousChunk ];
+    // There is a partial row added to rows. Remove this.
+    // TODO: This may not be needed
+    this.currentRow.pop() // the partial row need this to build the row
   }
 };
 

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -42,7 +42,17 @@ function RowBuilder(fields) {
  * Extracts value from chunk.
  */
 RowBuilder.getValue = function(obj) {
-  return commonGrpc.Service.decodeValue_(obj);
+  var value = obj;
+
+  if (obj && obj.kind) {
+    value = commonGrpc.Service.decodeValue_(obj);
+  }
+
+  if (value && value.values) {
+    value = value.values;
+  }
+
+  return value;
 };
 
 /**
@@ -166,9 +176,9 @@ RowBuilder.prototype.build = function() {
 RowBuilder.prototype.flush = function() {
   var rowsToReturn = this.rows;
 
-  if (!is.empty(this.rows) && this.currentRow.length !== this.fields.length) {
+  if (!is.empty(this.rows[0]) && this.currentRow.length !== this.fields.length) {
     // Don't return the partial row. Hold onto it for the next iteration.
-    this.rows = this.rows.splice(-1);
+    this.rows = [this.rows.splice(-1)];
   } else {
     this.rows = [[]];
   }

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -29,14 +29,32 @@ function RowBuilder(metadata, chunks) {
   this.metadata = metadata;
   this.fields = this.metadata.rowType.fields;
   this.chunks = chunks;
-
-  this.rows = [[]];
-
+  this.rows = [[]]
+  
   Object.defineProperty(this, 'currentRow', {
     get: function() {
       return this.rows[this.rows.length - 1];
     },
   });
+}
+
+/** 
+ * Return complete rows and remove from builder
+ */
+RowBuilder.prototype.collectRows = function(){
+  var partialRow
+  if(this.rows[this.rows.length -1].length != this.metadata.rowType.fields.length){
+    console.log("incomplete final row in formatted rows");
+    partialRow = this.rows.splice(-1);
+    console.log(partialRow)
+  }
+  var rowsToReturn = this.rows
+  if (partialRow){
+    this.rows = [ partialRow ];
+  } else {
+    this.rows = [[]];
+  }
+  return rowsToReturn;
 }
 
 /**

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -141,8 +141,9 @@ RowBuilder.prototype.build = function() {
   this.chunks.forEach(function(chunk) {
     // If we have a chunk to merge, merge the values now.
     if (self.pendingChunk) {
+      var currentColumn = self.currentRow.length % self.fields.length
       var merged = RowBuilder.merge(
-        self.fields[self.currentRow.length].type,
+        self.fields[currentColumn].type,
         self.pendingChunk,
         chunk.values.shift()
       );

--- a/src/row-builder.js
+++ b/src/row-builder.js
@@ -154,6 +154,11 @@ RowBuilder.prototype.build = function() {
   var previousChunk;
 
   this.chunks.forEach(function(chunk) {
+    chunk.values.forEach(val => {
+      if (val.stringValue.endsWith('account_creted_on_      9197')) {
+        console.log('magic off error')
+      }
+    })
     if (previousChunk && previousChunk.chunkedValue) {
       var type = self.fields[self.currentRow.length - 1].type;
       var merged = RowBuilder.merge(
@@ -180,7 +185,8 @@ RowBuilder.prototype.build = function() {
       lastChunk.values = lastChunk.values.splice(-1);
       this.chunks = [ lastChunk ];
       // There is a partial row added to rows. Remove this.
-      this.rows.pop()
+      // TODO: This may not be needed
+      this.currentRow.pop() // the partial row need this to build the row
     }
   }
 };

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -2247,7 +2247,7 @@ describe('Spanner', function() {
             });
         });
 
-        it.skip('should read large datasets', function(done) {
+        it.only('should read large datasets', function(done) {
           table.read(
             {
               keys: [expectedRow.Key],
@@ -2261,8 +2261,10 @@ describe('Spanner', function() {
             },
             function(err, rows) {
               assert.ifError(err);
+              console.log(rows)
 
               var row = rows[0].toJSON();
+
 
               assert.strictEqual(row.Key, expectedRow.Key);
               assert.strictEqual(row.StringValue, expectedRow.StringValue);
@@ -2279,7 +2281,7 @@ describe('Spanner', function() {
           );
         });
 
-        it.only('should query large datasets', function(done) {
+        it.skip('should query large datasets', function(done) {
           var query = {
             sql: 'SELECT * FROM ' + table.name + ' WHERE Key = @key',
             params: {

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -2247,7 +2247,7 @@ describe('Spanner', function() {
             });
         });
 
-        it('should read large datasets', function(done) {
+        it.skip('should read large datasets', function(done) {
           table.read(
             {
               keys: [expectedRow.Key],
@@ -2279,7 +2279,7 @@ describe('Spanner', function() {
           );
         });
 
-        it('should query large datasets', function(done) {
+        it.only('should query large datasets', function(done) {
           var query = {
             sql: 'SELECT * FROM ' + table.name + ' WHERE Key = @key',
             params: {

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -2264,7 +2264,6 @@ describe('Spanner', function() {
 
               var row = rows[0].toJSON();
 
-
               assert.strictEqual(row.Key, expectedRow.Key);
               assert.strictEqual(row.StringValue, expectedRow.StringValue);
               assert.deepEqual(row.StringArray, expectedRow.StringArray);

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -2261,7 +2261,6 @@ describe('Spanner', function() {
             },
             function(err, rows) {
               assert.ifError(err);
-              console.log(rows)
 
               var row = rows[0].toJSON();
 

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -2247,7 +2247,7 @@ describe('Spanner', function() {
             });
         });
 
-        it.only('should read large datasets', function(done) {
+        it('should read large datasets', function(done) {
           table.read(
             {
               keys: [expectedRow.Key],
@@ -2280,7 +2280,7 @@ describe('Spanner', function() {
           );
         });
 
-        it.skip('should query large datasets', function(done) {
+        it('should query large datasets', function(done) {
           var query = {
             sql: 'SELECT * FROM ' + table.name + ' WHERE Key = @key',
             params: {

--- a/test/codec.js
+++ b/test/codec.js
@@ -213,17 +213,11 @@ describe('codec', function() {
       };
     });
 
-    it('should return the value from the common decoder', function() {
+    it('should return the same value if not a special type', function() {
       var value = {};
-      var defaultDecodedValue = {};
-
-      FakeGrpcService.decodeValue_ = function(value_) {
-        assert.strictEqual(value_, value);
-        return defaultDecodedValue;
-      };
 
       var decoded = codec.decode(value, BYPASS_FIELD);
-      assert.strictEqual(decoded, defaultDecodedValue);
+      assert.strictEqual(decoded, value);
     });
 
     it('should return null values as null', function() {

--- a/test/partial-result-stream.js
+++ b/test/partial-result-stream.js
@@ -74,13 +74,28 @@ describe('PartialResultStream', function() {
   var partialResultStream;
 
   var RESULT_WITH_TOKEN = {
+    metadata: {
+      rowType: {
+        fields: [],
+      },
+    },
     resumeToken: '...',
     values: [{}],
   };
   var RESULT_WITHOUT_TOKEN = {
+    metadata: {
+      rowType: {
+        fields: [],
+      },
+    },
     values: [{}],
   };
   var RESULT_WITHOUT_VALUE = {
+    metadata: {
+      rowType: {
+        fields: [],
+      },
+    },
     resumeToken: '...',
     values: [],
   };
@@ -105,7 +120,7 @@ describe('PartialResultStream', function() {
     });
   });
 
-  describe.only('stream', function() {
+  describe('stream', function() {
     beforeEach(function() {
       FakeRowBuilderOverrides.addRow = function(row) {
         this.row = row;
@@ -178,11 +193,12 @@ describe('PartialResultStream', function() {
 
     describe('RowBuilder', function() {
       it('should create a RowBuiler instance', function(done) {
-        var metadata = {};
-        var row = extend({metadata}, RESULT_WITH_TOKEN);
+        var fields = [];
+        var row = extend(true, {}, RESULT_WITH_TOKEN);
+        row.metadata.rowType.fields = fields;
 
         FakeRowBuilderOverrides.addRow = function() {
-          assert.strictEqual(this.calledWith_[0], metadata);
+          assert.strictEqual(this.calledWith_[0], fields);
           done();
         };
 

--- a/test/row-builder.js
+++ b/test/row-builder.js
@@ -23,8 +23,12 @@ var util = require('@google-cloud/common').util;
 
 var codec = require('../src/codec');
 
+var decodeOverride;
 var generateToJSONFromRowOverride;
 var fakeCodec = {
+  decode: function() {
+    return (decodeOverride || codec.decode).apply(null, arguments);
+  },
   generateToJSONFromRow: function() {
     return (generateToJSONFromRowOverride || codec.generateToJSONFromRow).apply(
       null,
@@ -33,26 +37,20 @@ var fakeCodec = {
   },
 };
 
+function FakeGrpcService() {}
+
 describe('RowBuilder', function() {
   var RowBuilder;
   var RowBuilderCached;
   var rowBuilder;
 
-  var METADATA = {
-    rowType: {
-      fields: [],
-    },
-  };
-  var FIELDS = METADATA.rowType.fields;
-
-  var CHUNKS = [
-    {
-      metadata: METADATA,
-    },
-  ];
+  var FIELDS = [{}, {}];
 
   before(function() {
     RowBuilder = proxyquire('../src/row-builder.js', {
+      '@google-cloud/common-grpc': {
+        Service: FakeGrpcService,
+      },
       './codec.js': fakeCodec,
     });
 
@@ -60,9 +58,11 @@ describe('RowBuilder', function() {
   });
 
   beforeEach(function() {
+    FakeGrpcService.decodeValue_ = util.noop;
+    decodeOverride = null;
     generateToJSONFromRowOverride = null;
     extend(RowBuilder, RowBuilderCached);
-    rowBuilder = new RowBuilder(FIELDS, CHUNKS);
+    rowBuilder = new RowBuilder(FIELDS);
   });
 
   describe('acceptance tests', function() {
@@ -70,10 +70,10 @@ describe('RowBuilder', function() {
 
     TESTS.forEach(function(test) {
       it('should pass acceptance test: ' + test.name, function() {
-        var metadata = JSON.parse(test.chunks[0]).metadata;
+        var fields = JSON.parse(test.chunks[0]).metadata.rowType.fields;
         var chunkJson = JSON.parse('[' + test.chunks.join() + ']');
-        var builder = new RowBuilder(metadata.rowType.fields, chunkJson);
-
+        var builder = new RowBuilder(fields);
+        builder.addRow(chunkJson);
         builder.build();
 
         assert.deepEqual(builder.rows, test.result.value);
@@ -82,16 +82,16 @@ describe('RowBuilder', function() {
   });
 
   describe('instantiation', function() {
-    it('should localize chunks', function() {
-      assert.strictEqual(rowBuilder.chunks, CHUNKS);
+    it('should localize fields', function() {
+      assert.strictEqual(rowBuilder.fields, FIELDS);
+    });
+
+    it('should correctly initialize a chunks array', function() {
+      assert.deepEqual(rowBuilder.chunks, []);
     });
 
     it('should correctly initialize a rows array', function() {
       assert.deepEqual(rowBuilder.rows, [[]]);
-    });
-
-    it('should localize fields', function() {
-      assert.strictEqual(rowBuilder.fields, CHUNKS[0].metadata.rowType.fields);
     });
 
     it('should return the last row when accessing currentRow', function() {
@@ -112,26 +112,37 @@ describe('RowBuilder', function() {
       assert.strictEqual(RowBuilder.getValue(value), value);
     });
 
-    it('should detect value objects', function() {
+    it('should decode using GrpcService module', function() {
       var value = {
         kind: 'stringValue',
-        stringValue: 'hi',
       };
-      var val = RowBuilder.getValue(value);
-      assert.strictEqual(val, value.stringValue);
+
+      var expectedValue = {};
+
+      FakeGrpcService.decodeValue_ = function() {
+        return expectedValue;
+      };
+
+      assert.strictEqual(RowBuilder.getValue(value), expectedValue);
     });
 
-    it('should detect value objects containing arrays', function() {
+    it('should return value from arrays', function() {
       var value = {
         kind: 'listValue',
         listValue: {
-          values: [
-            {kind: 'stringValue', stringValue: 'hello'},
-            {kind: 'stringValue', stringValue: 'world'},
-          ],
+          values: [],
         },
       };
-      assert.notStrictEqual(RowBuilder.getValue(value), ['hello', 'world']);
+
+      var expectedValue = {};
+
+      FakeGrpcService.decodeValue_ = function() {
+        return {
+          values: expectedValue,
+        };
+      };
+
+      assert.strictEqual(RowBuilder.getValue(value), expectedValue);
     });
 
     it('should accept null values', function() {
@@ -149,9 +160,16 @@ describe('RowBuilder', function() {
       };
 
       var value = [{}];
+      var decodedValue = {};
+
+      decodeOverride = function(value_, field_) {
+        assert.strictEqual(value_, value[0]);
+        assert.strictEqual(field_, field.arrayElementType);
+        return decodedValue;
+      };
 
       var formattedValue = RowBuilder.formatValue(field, value);
-      assert.strictEqual(formattedValue[0], value[0]);
+      assert.deepStrictEqual(formattedValue, [decodedValue]);
     });
 
     it('should return null if value is NULL_VALUE', function() {
@@ -166,15 +184,22 @@ describe('RowBuilder', function() {
       assert.strictEqual(formattedValue, null);
     });
 
-    it('should return the original value if not an array', function() {
+    it('should return decoded value if not an array or struct', function() {
       var field = {
-        code: 'NOT_STRUCT_OR_ARRAY', // so it returns original value
+        code: 'NOT_STRUCT_OR_ARRAY',
       };
 
       var value = [{}];
+      var decodedValue = {};
+
+      decodeOverride = function(value_, field_) {
+        assert.strictEqual(value_, value);
+        assert.strictEqual(field_, field);
+        return decodedValue;
+      };
 
       var formattedValue = RowBuilder.formatValue(field, value);
-      assert.strictEqual(formattedValue[0], value[0]);
+      assert.strictEqual(formattedValue, decodedValue);
     });
 
     it('should iterate a struct', function() {
@@ -191,10 +216,17 @@ describe('RowBuilder', function() {
       };
 
       var value = [{}];
+      var decodedValue = {};
+
+      decodeOverride = function(value_, field_) {
+        assert.strictEqual(value_, value[0]);
+        assert.strictEqual(field_, field.structType.fields[0]);
+        return decodedValue;
+      };
 
       var formattedValue = RowBuilder.formatValue(field, value);
-      assert.deepEqual(formattedValue, {
-        fieldName: value[0],
+      assert.deepStrictEqual(formattedValue, {
+        fieldName: decodedValue,
       });
     });
   });
@@ -315,6 +347,17 @@ describe('RowBuilder', function() {
     });
   });
 
+  describe('addRow', function() {
+    it('should combine row with chunks', function() {
+      rowBuilder.chunks = [];
+
+      var row = {};
+      rowBuilder.addRow(row);
+
+      assert.deepStrictEqual(rowBuilder.chunks, [row]);
+    });
+  });
+
   describe('append', function() {
     var ROWS = [[{}, {}], [{}, {}]];
 
@@ -353,13 +396,15 @@ describe('RowBuilder', function() {
   });
 
   describe('build', function() {
-    it('should append values from a chunk', function(done) {
+    beforeEach(function() {
       rowBuilder.chunks = [
         {
           values: [{}],
         },
       ];
+    });
 
+    it('should append values from a chunk', function(done) {
       rowBuilder.append = function(value) {
         assert.strictEqual(this, rowBuilder);
         assert.strictEqual(value, rowBuilder.chunks[0].values[0]);
@@ -408,19 +453,55 @@ describe('RowBuilder', function() {
 
       rowBuilder.build();
 
-      //assert.strictEqual(mergedValues, rowBuilder.rows[1].values[1]);
       assert.strictEqual(mergedValues[0], rowBuilder.rows[1][1]);
+    });
+
+    it('should remove chunks', function() {
+      rowBuilder.build();
+      assert.deepStrictEqual(rowBuilder.chunks, []);
+    });
+  });
+
+  describe('flush', function() {
+    var ROWS = [[]];
+
+    for (var i = 0; i < FIELDS.length; i++) {
+      ROWS[0].push({});
+    }
+
+    beforeEach(function() {
+      rowBuilder.rows = ROWS;
+    });
+
+    it('should return rows', function() {
+      var expectedRows = rowBuilder.rows;
+      assert.deepStrictEqual(rowBuilder.flush(), expectedRows);
+    });
+
+    it('should reset rows', function() {
+      rowBuilder.flush();
+      assert.deepEqual(rowBuilder.rows, [[]]);
+    });
+
+    it('should retain a partial row', function() {
+      var partialRow = [{partial: true}];
+      rowBuilder.rows = rowBuilder.rows.concat(partialRow);
+
+      assert.deepStrictEqual(rowBuilder.flush(), ROWS);
+      assert.deepStrictEqual(rowBuilder.rows, partialRow);
     });
   });
 
   describe('toJSON', function() {
-    beforeEach(function() {
-      rowBuilder.build = util.noop;
-    });
+    var ROWS = [[{}]];
 
-    it('should run build', function(done) {
-      rowBuilder.build = done;
-      rowBuilder.toJSON();
+    beforeEach(function() {
+      rowBuilder.fields = [
+        {
+          name: 'fieldName',
+          type: {},
+        },
+      ];
     });
 
     it('should format the values', function() {
@@ -428,22 +509,13 @@ describe('RowBuilder', function() {
         formatted: true,
       };
 
-      rowBuilder.fields = [
-        {
-          name: 'fieldName',
-          type: {},
-        },
-      ];
-
-      rowBuilder.rows = [[{}]];
-
       RowBuilder.formatValue = function(field, value) {
         assert.strictEqual(field, rowBuilder.fields[0]);
-        assert.notStrictEqual(value, {});
+        assert.strictEqual(value, ROWS[0][0]);
         return formattedValue;
       };
 
-      var rows = rowBuilder.toJSON();
+      var rows = rowBuilder.toJSON(ROWS);
       var row = rows[0];
 
       assert.deepEqual(row, [
@@ -473,16 +545,9 @@ describe('RowBuilder', function() {
           return formattedValue;
         };
 
-        rowBuilder.fields = [
-          {
-            name: 'fieldName',
-            type: {},
-          },
-        ];
-
         rowBuilder.rows = [[{}]];
 
-        FORMATTED_ROW = rowBuilder.toJSON()[0];
+        FORMATTED_ROW = rowBuilder.toJSON(ROWS)[0];
       });
 
       it('should assign a toJSON method', function() {

--- a/test/row-builder.js
+++ b/test/row-builder.js
@@ -19,7 +19,6 @@
 var assert = require('assert');
 var extend = require('extend');
 var proxyquire = require('proxyquire');
-var util = require('@google-cloud/common').util;
 
 var codec = require('../src/codec');
 
@@ -433,17 +432,12 @@ describe('RowBuilder', function() {
     it('should retain a trailing chunked value', function() {
       var partialChunk = {
         chunkedValue: true,
-        values: [
-          {},
-          {partial: true},
-        ],
+        values: [{}, {partial: true}],
       };
 
       var expectedRetainedChunk = {
         chunkedValue: true,
-        values: [
-          {partial: true},
-        ]
+        values: [{partial: true}],
       };
 
       rowBuilder.chunks.push(partialChunk);


### PR DESCRIPTION
Fixes #180 and #198 by reworking the way we process streamed rows from PartialResultStream on Spanner. The high-level difference is this

1) use RowBuilder for all streams. We had two code paths previously
2) do not block on returning until we have a non-chunked row. We can hold the final value of a chunked segment and begin returning other data
3) handle partial segments. Occasionally we will get a partial row and shouldn't try to send that to the user.

#### To Dos

- [x] Unit tests