### PR TITLE
build: customize synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -8,16 +8,42 @@ logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICGenerator()
 
-# tasks has two product names, and a poorly named artman yaml
-v2beta2_library = gapic.node_library(
-    'spanner', 'v1', config_path='/google/spanner/artman_spanner.yaml')
+spanner = gapic.node_library(
+    'spanner', 'v1',
+    config_path='/google/spanner/artman_spanner.yaml')
+
+spanner_admin_database = gapic.node_library(
+    'spanner-admin-database', 'v1',
+    config_path='/google/spanner/admin/database/artman_spanner_admin_database.yaml')
+
+spanner_admin_instance = gapic.node_library(
+    'spanner-admin-instance', 'v1',
+    config_path='/google/spanner/admin/instance/artman_spanner_admin_instance.yaml')
 
 # Copy all files except for 'README.md' and 'package.json'
-s.copy(v2beta2_library / 'src/v1', excludes="src/v1/index.js")
+s.copy(spanner, excludes=["src/index.js", "README.md", "package.json"])
+s.copy(spanner_admin_database, excludes=["src/v1/index.js", "src/index.js", "README.md", "package.json"])
+s.copy(spanner_admin_instance, excludes=["src/v1/index.js", "src/index.js", "README.md", "package.json"])
+
+# nodejs-spanner is composed of 3 APIs: SpannerClient, SpannerAdminDatabase and
+# SpannerAdminInstance, export all 3 in src/v1/index.js
+s.replace(
+    "src/v1/index.js",
+    "(const SpannerClient = require\('\./spanner_client\'\);)",
+    """const DatabaseAdminClient = require('./database_admin_client');
+const InstanceAdminClient = require('./instance_admin_client');
+\g<1>""")
+
+s.replace(
+    "src/v1/index.js",
+    "(module\.exports\.SpannerClient = SpannerClient;)",
+    """module.exports.DatabaseAdminClient = DatabaseAdminClient;
+module.exports.InstanceAdminClient = InstanceAdminClient;
+\g<1>""")
 
 # '''
 # Node.js specific cleanup
 # '''
-# # prettify and lint
+subprocess.run(['npm', 'ci'])
 subprocess.run(['npm', 'run', 'prettier'])
 subprocess.run(['npm', 'run', 'lint'])


### PR DESCRIPTION
The nodejs-spanner package has 3 API bundled in, so we need to run artman three times to generate all three APIs. That also mean we have 3 exports that need to be combined into `src/v1/index.js`, so we use `s.replace(..`

See https://github.com/googleapis/nodejs-spanner/pull/277#discussion_r207379079 for more context.