### PR TITLE
Release nodejs-spanner v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+[npm history][1]
+
+[1]: https://www.npmjs.com/package/nodejs-spanner?activeTab=versions
+
+## v2.0.0
+
+### Implementation Changes
+- fix: perform type check on grpc value (#300)
+- chore: use es classes in a few places (#297)
+- chore: do not use npm ci (#292)
+- chore: split the common module (#289)
+- test: fix strict equal assertions (#287)
+- chore: ignore package-lock.json (#286)
+- chore: use let and const (#283)
+- chore: update renovate config (#281)
+- Re-generate library using /synth.py (#282)
+- chore: use assert.deepStrictEqual instead of assert.deepEqual (#274)
+- chore: require node 8 for samples (#273)
+- test: use strictEqual in tests (#267)
+- use node_library not not internal generate method (#247)
+- Configure Renovate (#239)
+- fix: drop support for node.js 4.x and 9.x (#226)
+
+### New Features
+- add runTransactionAsync method (#294)
+- feature(database): make session pool hot swappable (#243)
+
+### Dependencies
+- fix(deps): update dependency google-gax to ^0.19.0 (#298)
+- chore(deps): update dependency eslint-config-prettier to v3 (#295)
+- fix(deps): update dependency google-gax to ^0.18.0 (#278)
+- chore(deps): update dependency eslint-plugin-node to v7 (#266)
+- refactor: update auth library, common-grpc (#256)
+- fix(deps): update dependency yargs to v12 (#254)
+- chore(deps): update dependency yargs to v12 (#252)
+- chore(deps): update dependency sinon to v6.0.1 (#250)
+- chore(package): update eslint to version 5.0.0 (#240)
+- chore: update sample lockfiles (#246)
+- Update to support google-gax v0.17 (#244)
+- fix(package): update @google-cloud/common-grpc to version 0.7.1 (#235)
+- refactor: drop dependency on safe-buffer (#232)
+- refactor: remove dependency generic-pool (#231)
+- refactor: drop dependency on lodash.flatten (#233)
+- refactor: remove array-uniq as dependency (#227)
+- refactor: remove string-obj-format (#229)
+- refactor: remove methmeth as a dependency (#228)
+- chore: upgrade several dependencies (#221)
+
+### Internal / Testing Changes
+- chore: move mocha options to mocha.opts (#272)
+- refactor: drop repo-tool as an exec wrapper (#248)
+- fix: update linking for samples (#242)
+- Adding Spanner STRUCT param samples (#219)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@
 
 ## v2.0.0
 
+### Breaking Changes
+- Drop support for Node.js v4.x.x and v9.x.x (#226) 
+
+- Use es style imports (#302)
+  The import syntax for this library has changed to be [es module](https://nodejs.org/api/esm.html) compliant. 
+
+  #### Old code
+  ```js
+  const spanner = require('@google-cloud/spanner')();
+  // or 
+  const Spanner = require('@google-cloud/spanner');
+  const spanner = new Spanner();
+  ```
+
+  #### New code
+  ```js
+  const {Spanner} = require('@google-cloud/spanner');
+  const spanner = new Spanner();
+  ```
+
+### New Features
+- add runTransactionAsync method (#294)
+  ```
+  const {Spanner} = require('@google-cloud/spanner');
+  const spanner = new Spanner();
+
+  const instance = spanner.instance('my-instance');
+  const database = instance.database('my-database');
+
+  await database.runTransactionAsync(async (transaction) => {
+      const [rows] = await transaction.run('SELECT * FROM MyTable');
+      const data = rows.map(row => row.thing);
+      await transaction.commit();
+      return data;
+  }).then(data => {
+    // ...
+  });
+  ```
+- feature(database): make session pool hot swappable (#243)
+
 ### Implementation Changes
 - feat: use es style imports (#302)
 - fix: perform type check on grpc value (#300)
@@ -23,10 +63,6 @@
 - use node_library not not internal generate method (#247)
 - Configure Renovate (#239)
 - fix: drop support for node.js 4.x and 9.x (#226)
-
-### New Features
-- add runTransactionAsync method (#294)
-- feature(database): make session pool hot swappable (#243)
 
 ### Dependencies
 - fix(deps): update dependency google-gax to ^0.19.0 (#298)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## v2.0.0
 
 ### Implementation Changes
+- feat: use es style imports (#302)
 - fix: perform type check on grpc value (#300)
 - chore: use es classes in a few places (#297)
 - chore: do not use npm ci (#292)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/spanner",
   "description": "Cloud Spanner Client Library for Node.js",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "author": "Google Inc.",
   "engines": {


### PR DESCRIPTION
This pull request was generated using releasetool.

# Release Notes

### Breaking Changes
- Drop support for Node.js v4.x.x and v9.x.x (#226) 

- Use es style imports (#302)
  The import syntax for this library has changed to be [es module](https://nodejs.org/api/esm.html) compliant. 

  #### Old code
  ```js
  const spanner = require('@google-cloud/spanner')();
  // or 
  const Spanner = require('@google-cloud/spanner');
  const spanner = new Spanner();
  ```

  #### New code
  ```js
  const {Spanner} = require('@google-cloud/spanner');
  const spanner = new Spanner();
  ```

### New Features
- add runTransactionAsync method (#294)
  ```
  const {Spanner} = require('@google-cloud/spanner');
  const spanner = new Spanner();

  const instance = spanner.instance('my-instance');
  const database = instance.database('my-database');

  await database.runTransactionAsync(async (transaction) => {
      const [rows] = await transaction.run('SELECT * FROM MyTable');
      const data = rows.map(row => row.thing);
      await transaction.commit();
      return data;
  }).then(data => {
    // ...
  });
  ```
- feature(database): make session pool hot swappable (#243)

### Implementation Changes
- feat: use es style imports (#302)
- fix: perform type check on grpc value (#300)
- chore: use es classes in a few places (#297)
- chore: do not use npm ci (#292)
- chore: split the common module (#289)
- test: fix strict equal assertions (#287)
- chore: ignore package-lock.json (#286)
- chore: use let and const (#283)
- chore: update renovate config (#281)
- Re-generate library using /synth.py (#282)
- chore: use assert.deepStrictEqual instead of assert.deepEqual (#274)
- chore: require node 8 for samples (#273)
- test: use strictEqual in tests (#267)
- use node_library not not internal generate method (#247)
- Configure Renovate (#239)
- fix: drop support for node.js 4.x and 9.x (#226)

### Dependencies
- fix(deps): update dependency google-gax to ^0.19.0 (#298)
- chore(deps): update dependency eslint-config-prettier to v3 (#295)
- fix(deps): update dependency google-gax to ^0.18.0 (#278)
- chore(deps): update dependency eslint-plugin-node to v7 (#266)
- refactor: update auth library, common-grpc (#256)
- fix(deps): update dependency yargs to v12 (#254)
- chore(deps): update dependency yargs to v12 (#252)
- chore(deps): update dependency sinon to v6.0.1 (#250)
- chore(package): update eslint to version 5.0.0 (#240)
- chore: update sample lockfiles (#246)
- Update to support google-gax v0.17 (#244)
- fix(package): update @google-cloud/common-grpc to version 0.7.1 (#235)
- refactor: drop dependency on safe-buffer (#232)
- refactor: remove dependency generic-pool (#231)
- refactor: drop dependency on lodash.flatten (#233)
- refactor: remove array-uniq as dependency (#227)
- refactor: remove string-obj-format (#229)
- refactor: remove methmeth as a dependency (#228)
- chore: upgrade several dependencies (#221)

### Internal / Testing Changes
- chore: move mocha options to mocha.opts (#272)
- refactor: drop repo-tool as an exec wrapper (#248)
- fix: update linking for samples (#242)
- Adding Spanner STRUCT param samples (#219)

