### PR TITLE
feat: use es style imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Google APIs Client Libraries, in [Client Libraries Explained][explained].
 
 ```javascript
 // Imports the Google Cloud client library
-const Spanner = require('@google-cloud/spanner');
+const {Spanner} = require('@google-cloud/spanner');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/batch.js
+++ b/samples/batch.js
@@ -18,7 +18,7 @@
 function createQueryPartitions(instanceId, databaseId, identifier, projectId) {
   // [START spanner_batch_client]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -63,7 +63,7 @@ function executePartition(
 ) {
   // [START spanner_batch_execute_partitions]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/crud.js
+++ b/samples/crud.js
@@ -18,7 +18,7 @@
 function updateData(instanceId, databaseId, projectId) {
   // [START spanner_update_data]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -62,7 +62,7 @@ function updateData(instanceId, databaseId, projectId) {
 function insertData(instanceId, databaseId, projectId) {
   // [START spanner_insert_data]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -121,7 +121,7 @@ function insertData(instanceId, databaseId, projectId) {
 function queryData(instanceId, databaseId, projectId) {
   // [START spanner_query_data]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -171,7 +171,7 @@ function queryData(instanceId, databaseId, projectId) {
 function readData(instanceId, databaseId, projectId) {
   // [START spanner_read_data]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -226,7 +226,7 @@ function readData(instanceId, databaseId, projectId) {
 function readStaleData(instanceId, databaseId, projectId) {
   // [START spanner_read_stale_data]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/indexing.js
+++ b/samples/indexing.js
@@ -18,7 +18,7 @@
 function createIndex(instanceId, databaseId, projectId) {
   // [START spanner_create_index]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -68,7 +68,7 @@ function createStoringIndex(instanceId, databaseId, projectId) {
   // https://cloud.google.com/spanner/docs/secondary-indexes#storing_clause
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -121,7 +121,7 @@ function queryDataWithIndex(
 ) {
   // [START spanner_query_data_with_index]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -182,7 +182,7 @@ function queryDataWithIndex(
 function readDataWithIndex(instanceId, databaseId, projectId) {
   // [START spanner_read_data_with_index]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -239,7 +239,7 @@ function readDataWithStoringIndex(instanceId, databaseId, projectId) {
   // https://cloud.google.com/spanner/docs/secondary-indexes#storing_clause
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -17,7 +17,7 @@
 
 // [START spanner_quickstart]
 // Imports the Google Cloud client library
-const Spanner = require('@google-cloud/spanner');
+const {Spanner} = require('@google-cloud/spanner');
 
 // Your Google Cloud Platform project ID
 const projectId = 'YOUR_PROJECT_ID';

--- a/samples/schema.js
+++ b/samples/schema.js
@@ -18,7 +18,7 @@
 function createDatabase(instanceId, databaseId, projectId) {
   // [START spanner_create_database]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -76,7 +76,7 @@ function createDatabase(instanceId, databaseId, projectId) {
 function addColumn(instanceId, databaseId, projectId) {
   // [START spanner_add_column]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -126,7 +126,7 @@ function queryDataWithNewColumn(instanceId, databaseId, projectId) {
   //    ALTER TABLE Albums ADD COLUMN MarketingBudget INT64
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/struct.js
+++ b/samples/struct.js
@@ -18,7 +18,7 @@
 function writeDataForStructQueries(instanceId, databaseId, projectId) {
   // [START spanner_write_data_for_struct_queries]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment and update the following lines before running the sample.
@@ -81,7 +81,7 @@ function queryDataWithStruct(instanceId, databaseId, projectId) {
 
   // [START spanner_query_data_with_struct]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -131,7 +131,7 @@ function queryDataWithStruct(instanceId, databaseId, projectId) {
 
 function queryWithArrayofStruct(instanceId, databaseId, projectId) {
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -225,7 +225,7 @@ function queryWithArrayofStruct(instanceId, databaseId, projectId) {
 function queryStructField(instanceId, databaseId, projectId) {
   // [START spanner_field_access_on_struct_parameters]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -278,7 +278,7 @@ function queryStructField(instanceId, databaseId, projectId) {
 function queryNestedStructField(instanceId, databaseId, projectId) {
   // [START spanner_field_access_on_nested_struct_parameters]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -48,7 +48,9 @@ test.cb(`should query a table`, t => {
   };
 
   proxyquire(`../quickstart`, {
-    '@google-cloud/spanner': sinon.stub().returns(spannerMock),
+    '@google-cloud/spanner': {
+      Spanner: sinon.stub().returns(spannerMock),
+    },
   });
 
   t.deepEqual(spannerMock.instance.getCall(0).args, [`my-instance`]);

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -17,7 +17,7 @@
 
 const path = require(`path`);
 const request = require(`request`);
-const Spanner = require(`@google-cloud/spanner`);
+const {Spanner} = require(`@google-cloud/spanner`);
 const test = require(`ava`);
 const tools = require(`@google-cloud/nodejs-repo-tools`);
 

--- a/samples/timestamp.js
+++ b/samples/timestamp.js
@@ -18,7 +18,7 @@
 function createTableWithTimestamp(instanceId, databaseId, projectId) {
   // [START spanner_create_table_with_timestamp_column]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -70,7 +70,7 @@ function createTableWithTimestamp(instanceId, databaseId, projectId) {
 function insertWithTimestamp(instanceId, databaseId, projectId) {
   // [START spanner_insert_data_with_timestamp_column]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -134,7 +134,7 @@ function insertWithTimestamp(instanceId, databaseId, projectId) {
 function queryTableWithTimestamp(instanceId, databaseId, projectId) {
   // [START spanner_query_new_table_with_timestamp_column]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -186,7 +186,7 @@ function queryTableWithTimestamp(instanceId, databaseId, projectId) {
 function addTimestampColumn(instanceId, databaseId, projectId) {
   // [START spanner_add_timestamp_column]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -249,7 +249,7 @@ function updateWithTimestamp(instanceId, databaseId, projectId) {
   // [END_EXCLUDE]
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -316,7 +316,7 @@ function queryWithTimestamp(instanceId, databaseId, projectId) {
   // [END_EXCLUDE]
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/samples/transaction.js
+++ b/samples/transaction.js
@@ -18,7 +18,7 @@
 function readOnlyTransaction(instanceId, databaseId, projectId) {
   // [START spanner_read_only_transaction]
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
@@ -101,7 +101,7 @@ function readWriteTransaction(instanceId, databaseId, projectId) {
   // addColumn and updateData samples first (in that order).
 
   // Imports the Google Cloud client library
-  const Spanner = require('@google-cloud/spanner');
+  const {Spanner} = require('@google-cloud/spanner');
 
   /**
    * TODO(developer): Uncomment the following lines before running the sample.

--- a/src/batch-transaction.js
+++ b/src/batch-transaction.js
@@ -52,7 +52,7 @@ class BatchTransaction extends Transaction {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -242,7 +242,7 @@ class BatchTransaction extends Transaction {
    * @returns {ReadableStream} A readable stream that emits rows.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -296,7 +296,7 @@ class BatchTransaction extends Transaction {
    * @returns {TransactionIdentifier}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');

--- a/src/database.js
+++ b/src/database.js
@@ -97,7 +97,7 @@ const TransactionRequest = require('./transaction-request');
  *     configuration options or custom pool interface.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  * const instance = spanner.instance('my-instance');
  * const database = instance.database('my-database');
@@ -114,7 +114,7 @@ class Database extends ServiceObject {
        * @returns {Promise<CreateDatabaseResponse>}
        *
        * @example
-       * const Spanner = require('@google-cloud/spanner');
+       * const {Spanner} = require('@google-cloud/spanner');
        * const spanner = new Spanner();
        * const instance = spanner.instance('my-instance');
        * const database = instance.database('my-database');
@@ -163,7 +163,7 @@ class Database extends ServiceObject {
        * @returns {Promise<DatabaseExistsResponse>}
        *
        * @example
-       * const Spanner = require('@google-cloud/spanner');
+       * const {Spanner} = require('@google-cloud/spanner');
        * const spanner = new Spanner();
        *
        * const instance = spanner.instance('my-instance');
@@ -214,7 +214,7 @@ class Database extends ServiceObject {
    * @returns {BatchTransaction} A batch transaction object.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -248,7 +248,7 @@ class Database extends ServiceObject {
    * @returns {Promise}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -351,7 +351,7 @@ class Database extends ServiceObject {
    * @returns {Promise<CreateSessionResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -428,7 +428,7 @@ class Database extends ServiceObject {
    * @returns {Promise<CreateTableResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -510,7 +510,7 @@ class Database extends ServiceObject {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -573,7 +573,7 @@ class Database extends ServiceObject {
    * @returns {Promise<GetDatabaseResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -641,7 +641,7 @@ class Database extends ServiceObject {
    * @returns {Promise<GetDatabaseMetadataResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -700,7 +700,7 @@ class Database extends ServiceObject {
    * @returns {Promise<GetSchemaResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -784,7 +784,7 @@ class Database extends ServiceObject {
    * @returns {Promise<GetSessionsResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -865,7 +865,7 @@ class Database extends ServiceObject {
    * @returns {Promise<GetTransactionResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1031,7 +1031,7 @@ class Database extends ServiceObject {
    * @returns {Promise<RunResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1172,7 +1172,7 @@ class Database extends ServiceObject {
    * @returns {ReadableStream} A readable stream that emits rows.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1348,7 +1348,7 @@ class Database extends ServiceObject {
    *     of a transaction.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1466,7 +1466,7 @@ class Database extends ServiceObject {
    *
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1520,7 +1520,7 @@ class Database extends ServiceObject {
    * @return {Table} A Table object.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -1556,7 +1556,7 @@ class Database extends ServiceObject {
    * @returns {Promise<LongRunningOperationResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');

--- a/src/index.js
+++ b/src/index.js
@@ -162,10 +162,6 @@ const gapic = Object.freeze({
  * @param {ClientConfig} [options] Configuration options.
  */
 function Spanner(options) {
-  if (!(this instanceof Spanner)) {
-    return new Spanner(options);
-  }
-
   options = options || {};
 
   this.clients_ = new Map();
@@ -232,7 +228,7 @@ Spanner.COMMIT_TIMESTAMP = 'spanner.commit_timestamp()';
  * @see {@link Spanner#date}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const date = Spanner.date('08-20-1969');
  */
 Spanner.date = function(value) {
@@ -248,7 +244,7 @@ Spanner.date = function(value) {
  * @see {@link Spanner#float}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const float = Spanner.float(10);
  */
 Spanner.float = function(value) {
@@ -264,7 +260,7 @@ Spanner.float = function(value) {
  * @see {@link Spanner#int}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const int = Spanner.int(10);
  */
 Spanner.int = function(value) {
@@ -278,7 +274,7 @@ Spanner.int = function(value) {
  * @returns {object}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const struct = Spanner.struct({
  *   user: 'bob',
  *   age: 32
@@ -331,7 +327,7 @@ Spanner.struct = function(value) {
  * @returns {Promise<CreateInstanceResponse>}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * const config = {
@@ -474,7 +470,7 @@ Spanner.prototype.createInstance = function(name, config, callback) {
  * @returns {Promise<GetInstancesResponse>}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * spanner.getInstances(function(err, instances) {
@@ -550,7 +546,7 @@ Spanner.prototype.getInstances = function(query, callback) {
  *     instances.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * spanner.getInstancesStream()
@@ -617,7 +613,7 @@ Spanner.prototype.getInstancesStream = paginator.streamify('getInstances');
  * @returns {Promise<GetInstanceConfigsResponse>}
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * spanner.getInstanceConfigs(function(err, instanceConfigs) {
@@ -681,7 +677,7 @@ Spanner.prototype.getInstanceConfigs = function(query, callback) {
  * @returns {ReadableStream} A readable stream that emits instance configs.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * spanner.getInstanceConfigsStream()
@@ -722,7 +718,7 @@ Spanner.prototype.getInstanceConfigsStream = function(query) {
  * @returns {Instance} An Instance object.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  * const instance = spanner.instance('my-instance');
  */
@@ -749,7 +745,7 @@ Spanner.prototype.instance = function(name) {
  * @returns {Operation} An Operation object.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  * const operation = spanner.operation('operation-name');
  */
@@ -893,7 +889,7 @@ promisifyAll(Spanner, {
  * npm install --save @google-cloud/spanner
  *
  * @example <caption>Import the client library</caption>
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  *
  * @example <caption>Create a client that uses <a href="https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application">Application Default Credentials (ADC)</a>:</caption>
  * const client = new Spanner();
@@ -908,7 +904,7 @@ promisifyAll(Spanner, {
  * region_tag:spanner_quickstart
  * Full quickstart example:
  */
-module.exports = Spanner;
+module.exports.Spanner = Spanner;
 
 /**
  * {@link Instance} class.

--- a/src/instance.js
+++ b/src/instance.js
@@ -37,7 +37,7 @@ const Database = require('./database');
  * @param {string} name Name of the instance.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  * const instance = spanner.instance('my-instance');
  */
@@ -59,7 +59,7 @@ class Instance extends common.ServiceObject {
        * @returns {Promise<CreateInstanceResponse>}
        *
        * @example
-       * const Spanner = require('@google-cloud/spanner');
+       * const {Spanner} = require('@google-cloud/spanner');
        * const spanner = new Spanner();
        *
        * const instance = spanner.instance('my-instance');
@@ -108,7 +108,7 @@ class Instance extends common.ServiceObject {
        * @returns {Promise<InstanceExistsResponse>}
        *
        * @example
-       * const Spanner = require('@google-cloud/spanner');
+       * const {Spanner} = require('@google-cloud/spanner');
        * const spanner = new Spanner();
        *
        * const instance = spanner.instance('my-instance');
@@ -179,7 +179,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<CreateDatabaseResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -278,7 +278,7 @@ class Instance extends common.ServiceObject {
    * @return {Database} A Database object.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -315,7 +315,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<DeleteInstanceResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -389,7 +389,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<GetInstanceResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -469,7 +469,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<GetDatabasesResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -551,7 +551,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<GetInstanceMetadataResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -593,7 +593,7 @@ class Instance extends common.ServiceObject {
    * @returns {Promise<LongRunningOperationResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -678,7 +678,7 @@ class Instance extends common.ServiceObject {
  *     instances.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * const instance = spanner.instance('my-instance');

--- a/src/session.js
+++ b/src/session.js
@@ -39,7 +39,7 @@ const Transaction = require('./transaction');
  *     assumed you are going to create it.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * const instance = spanner.instance('my-instance');

--- a/src/table.js
+++ b/src/table.js
@@ -31,7 +31,7 @@ const TransactionRequest = require('./transaction-request');
  * @param {string} name Name of the table.
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * const instance = spanner.instance('my-instance');
@@ -78,7 +78,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<CreateTableResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -136,7 +136,7 @@ class Table extends TransactionRequest {
    * @returns {ReadableStream}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -217,7 +217,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<LongRunningOperationResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -265,7 +265,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -317,7 +317,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -423,7 +423,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<TableReadResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -541,7 +541,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -583,7 +583,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -629,7 +629,7 @@ class Table extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');

--- a/src/transaction-request.js
+++ b/src/transaction-request.js
@@ -72,7 +72,7 @@ class TransactionRequest {
    * @returns {ReadableStream} A readable stream that emits rows.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -229,7 +229,7 @@ class TransactionRequest {
    *     composite key, provide an array within this array. See the example below.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -309,7 +309,7 @@ class TransactionRequest {
    *     into this table.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -418,7 +418,7 @@ class TransactionRequest {
    * @returns {Promise<TransactionRequestReadResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -549,7 +549,7 @@ class TransactionRequest {
    *     into this table.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -604,7 +604,7 @@ class TransactionRequest {
    *     into this table.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -645,7 +645,7 @@ class TransactionRequest {
    *     into this table.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -102,7 +102,7 @@ const RetryInfo = protoFilesRoot.lookup('google.rpc.RetryInfo');
  * @param {TransactionOptions} [options] [Transaction options](https://cloud.google.com/spanner/docs/timestamp-bounds).
  *
  * @example
- * const Spanner = require('@google-cloud/spanner');
+ * const {Spanner} = require('@google-cloud/spanner');
  * const spanner = new Spanner();
  *
  * const instance = spanner.instance('my-instance');
@@ -223,7 +223,7 @@ class Transaction extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -287,7 +287,7 @@ class Transaction extends TransactionRequest {
    *     transaction has ended.
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -428,7 +428,7 @@ class Transaction extends TransactionRequest {
    * @returns {Promise<BasicResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -494,7 +494,7 @@ class Transaction extends TransactionRequest {
    * @returns {Promise<RunResponse>}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');
@@ -593,7 +593,7 @@ class Transaction extends TransactionRequest {
    * @returns {ReadableStream}
    *
    * @example
-   * const Spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    * const spanner = new Spanner();
    *
    * const instance = spanner.instance('my-instance');

--- a/src/v1/database_admin_client.js
+++ b/src/v1/database_admin_client.js
@@ -295,7 +295,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -383,7 +383,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -446,7 +446,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -547,7 +547,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -621,7 +621,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -718,7 +718,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -761,7 +761,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -820,7 +820,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -877,7 +877,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.
@@ -935,7 +935,7 @@ class DatabaseAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.DatabaseAdminClient({
    *   // optional auth parameters.

--- a/src/v1/instance_admin_client.js
+++ b/src/v1/instance_admin_client.js
@@ -319,7 +319,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -408,7 +408,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -453,7 +453,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -538,7 +538,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -646,7 +646,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -691,7 +691,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -780,7 +780,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -933,7 +933,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -1041,7 +1041,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -1095,7 +1095,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -1152,7 +1152,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.
@@ -1210,7 +1210,7 @@ class InstanceAdminClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.InstanceAdminClient({
    *   // optional auth parameters.

--- a/src/v1/spanner_client.js
+++ b/src/v1/spanner_client.js
@@ -264,7 +264,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -312,7 +312,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -387,7 +387,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -485,7 +485,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -526,7 +526,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -628,7 +628,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -729,7 +729,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -828,7 +828,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -927,7 +927,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -980,7 +980,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -1058,7 +1058,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -1115,7 +1115,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -1210,7 +1210,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.
@@ -1296,7 +1296,7 @@ class SpannerClient {
    *
    * @example
    *
-   * const spanner = require('@google-cloud/spanner');
+   * const {Spanner} = require('@google-cloud/spanner');
    *
    * var client = new spanner.v1.SpannerClient({
    *   // optional auth parameters.

--- a/system-test/spanner.js
+++ b/system-test/spanner.js
@@ -24,7 +24,7 @@ const extend = require('extend');
 const is = require('is');
 const uuid = require('uuid');
 
-const Spanner = require('../');
+const {Spanner} = require('../');
 
 const PREFIX = 'gcloud-tests-';
 const spanner = new Spanner({projectId: process.env.GCLOUD_PROJECT});

--- a/test/index.js
+++ b/test/index.js
@@ -115,7 +115,7 @@ describe('Spanner', function() {
       './codec.js': fakeCodec,
       './instance.js': FakeInstance,
       './v1': fakeV1,
-    });
+    }).Spanner;
   });
 
   beforeEach(function() {
@@ -148,12 +148,6 @@ describe('Spanner', function() {
 
     it('should streamify the correct methods', function() {
       assert.strictEqual(spanner.getInstancesStream, 'getInstances');
-    });
-
-    it('should work without new', function() {
-      assert.doesNotThrow(function() {
-        Spanner(OPTIONS);
-      });
     });
 
     it('should create an auth instance from google-auth-library', function() {


### PR DESCRIPTION
BREAKING CHANGE: The import syntax for this library has changed to be [es module](https://nodejs.org/api/esm.html) compliant. 

### Old code
```js
const spanner = require('@google-cloud/spanner')();
// or 
const Spanner = require('@google-cloud/spanner');
const spanner = new Spanner();
```

### New code
```js
const {Spanner} = require('@google-cloud/spanner');
const spanner = new Spanner();
```
