### PR TITLE
fix(transaction): accept json options in run/runStream

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -714,6 +714,10 @@ class Transaction extends TransactionRequest {
           transaction: {},
         },
         codec.encodeQuery(query));
+
+    delete reqOpts.json;
+    delete reqOpts.jsonOptions;
+
     if (this.id) {
       reqOpts.transaction.id = this.id;
     } else {
@@ -728,7 +732,10 @@ class Transaction extends TransactionRequest {
         reqOpts: extend({}, reqOpts, {resumeToken}),
       });
     };
-    return partialResultStream(makeRequest);
+    return partialResultStream(makeRequest, {
+      json: query.json,
+      jsonOptions: query.jsonOptions,
+    });
   }
   /**
    * @typedef {array} RunUpdateResponse

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -1160,6 +1160,29 @@ describe('Transaction', () => {
       const makeRequestFn = stream.calledWith_[0];
       makeRequestFn(resumeToken);
     });
+
+    it('should not pass json options to the request', done => {
+      const query = extend({json: true, jsonOptions: {}}, QUERY);
+
+      transaction.requestStream = (options) => {
+        assert.strictEqual(options.reqOpts.json, undefined);
+        assert.strictEqual(options.reqOpts.jsonOptions, undefined);
+        done();
+      };
+
+      const stream = transaction.runStream(query);
+      const makeRequestFn = stream.calledWith_[0];
+      makeRequestFn();
+    });
+
+    it('should pass the json options', () => {
+      const expectedJsonOptions = {json: true, jsonOptions: {a: 'b'}};
+      const query = extend({}, expectedJsonOptions, QUERY);
+      const stream = transaction.runStream(query);
+      const options = stream.calledWith_[1];
+
+      assert.deepStrictEqual(options, expectedJsonOptions);
+    });
   });
 
   describe('runUpdate', () => {


### PR DESCRIPTION
Fixes #374

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
