### PR TITLE
fix transaction async error handling that not thrown the full error

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -1589,7 +1589,7 @@ class Database extends ServiceObject {
                     })
                     .catch(e => {
                       if (e.code === Transaction.ABORTED) throw e;
-                      throw new retry.AbortError(e.message);
+                      throw new retry.AbortError(e);
                     }));
   }
   /**


### PR DESCRIPTION
Throw the full error in runTransactionAsync method instead of e.message.

**Issue:**
If you throw an error in the callback function, after a read for example, the error is misformatted.

**Example:**
```
    await db.runTransactionAsync(async (transaction) => {
      try {
        const [[invoice: { status }]] = await transaction.read('Invoices', {
          columns: ['status', 'invoiceId'],
          keys: [invoiceId],
          json: true,
        });
        if (status === "PAID") {
          const error = new Error('Cannot update Invoice as it is already paid');
          error.code = INVOICE_ALREADY_PAID
          error.status = 403;
          throw error;
        }
        // .......
       await transaction.commit();
      }
      catch (err) {
        // console.log(err.code) is undefined
        // console.log(err.status) is undefined
       next(err);
      }
```

------

Also in version 2.1.0, Transaction.ABORTED is undefined in the error handler (https://github.com/googleapis/nodejs-spanner/blob/master/src/database.ts#L1591), meaning the transaction was never retrieved in case of transient failure. It was fixed in https://github.com/googleapis/nodejs-spanner/pull/408. We should publish a new version whenever it's possible.

- [X] Tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)
