### PR TITLE
chore(typescript): add types for spanner gapic

### DIFF
--- a/src/v1/database_admin_client.d.ts
+++ b/src/v1/database_admin_client.d.ts
@@ -1,0 +1,227 @@
+/*!
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {EventEmitter} from 'events';
+import {CallOptions, GrpcClientOptions} from 'google-gax';
+import {ClientReadableStream, ServiceError} from 'grpc';
+import {common as protobuf} from 'protobufjs';
+
+declare class DatabaseAdminClient {
+  static servicePath: string;
+  static port: number;
+  static scopes: string[];
+
+  constructor(opts: GrpcClientOptions);
+
+  getProjectId(callback: DatabaseAdminClient.GetProjectIdCallback): void;
+
+  listDatabases(request: DatabaseAdminClient.ListDatabasesRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<DatabaseAdminClient.ListDatabasesPaginated | DatabaseAdminClient.ListDatabasesUnpaginated>;
+  listDatabases(request: DatabaseAdminClient.ListDatabasesRequest, callback: DatabaseAdminClient.ListDatabasesCallback): void;
+  listDatabases(request: DatabaseAdminClient.ListDatabasesRequest, options: CallOptions, callback: DatabaseAdminClient.ListDatabasesCallback): void;
+
+  listDatabasesStream(request: DatabaseAdminClient.ListDatabasesRequest, options?: CallOptions): ClientReadableStream<DatabaseAdminClient.Database>;
+
+  createDatabase(request: DatabaseAdminClient.CreateDatabaseRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.Operation]>;
+  createDatabase(request: DatabaseAdminClient.CreateDatabaseRequest, callback: DatabaseAdminClient.CreateDatabaseCallback): void;
+  createDatabase(request: DatabaseAdminClient.CreateDatabaseRequest, options: CallOptions, callback: DatabaseAdminClient.CreateDatabaseCallback): void;
+
+  getDatabase(request: DatabaseAdminClient.GetDatabaseRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.Database]>;
+  getDatabase(request: DatabaseAdminClient.GetDatabaseRequest, callback: DatabaseAdminClient.GetDatabaseCallback): void;
+  getDatabase(request: DatabaseAdminClient.GetDatabaseRequest, options: CallOptions, callback: DatabaseAdminClient.GetDatabaseCallback): void;
+
+  updateDatabaseDdl(request: DatabaseAdminClient.UpdateDatabaseDdlRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.Operation]>;
+  updateDatabaseDdl(request: DatabaseAdminClient.UpdateDatabaseDdlRequest, callback: DatabaseAdminClient.UpdateDatabaseDdlCallback): void;
+  updateDatabaseDdl(request: DatabaseAdminClient.UpdateDatabaseDdlRequest, options: CallOptions, callback: DatabaseAdminClient.UpdateDatabaseDdlCallback): void;
+
+  dropDatabase(request: DatabaseAdminClient.DropDatabaseRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<protobuf.IEmpty>;
+  dropDatabase(request: DatabaseAdminClient.DropDatabaseRequest, callback: DatabaseAdminClient.DropDatabaseCallback): void;
+  dropDatabase(request: DatabaseAdminClient.DropDatabaseRequest, options: CallOptions, callback: DatabaseAdminClient.DropDatabaseCallback): void;
+
+  getDatabaseDdl(request: DatabaseAdminClient.GetDatabaseDdlRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.GetDatabaseDdlResponse]>;
+  getDatabaseDdl(request: DatabaseAdminClient.GetDatabaseDdlRequest, callback: DatabaseAdminClient.GetDatabaseDdlCallback): void;
+  getDatabaseDdl(request: DatabaseAdminClient.GetDatabaseDdlRequest, options: CallOptions, callback: DatabaseAdminClient.GetDatabaseDdlCallback): void;
+
+  setIamPolicy(request: DatabaseAdminClient.SetIamPolicyRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.Policy]>;
+  setIamPolicy(request: DatabaseAdminClient.SetIamPolicyRequest, callback: DatabaseAdminClient.SetIamPolicyCallback): void;
+  setIamPolicy(request: DatabaseAdminClient.SetIamPolicyRequest, options: CallOptions, callback: DatabaseAdminClient.SetIamPolicyCallback): void;
+
+  getIamPolicy(request: DatabaseAdminClient.GetIamPolicyRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.Policy]>;
+  getIamPolicy(request: DatabaseAdminClient.GetIamPolicyRequest, callback: DatabaseAdminClient.GetIamPolicyCallback): void;
+  getIamPolicy(request: DatabaseAdminClient.GetIamPolicyRequest, options: CallOptions, callback: DatabaseAdminClient.GetIamPolicyCallback): void;
+
+  testIamPermissions(request: DatabaseAdminClient.TestIamPermissionsRequest, options?: CallOptions): DatabaseAdminClient.CancelablePromise<[DatabaseAdminClient.TestIamPermissionsResponse]>;
+  testIamPermissions(request: DatabaseAdminClient.TestIamPermissionsRequest, callback: DatabaseAdminClient.TestIamPermissionsCallback): void;
+  testIamPermissions(request: DatabaseAdminClient.TestIamPermissionsRequest, options: CallOptions, callback: DatabaseAdminClient.TestIamPermissionsCallback): void;
+
+  instancePath(project: string, instance: string): string;
+
+  databasePath(project: string, instance: string, database: string): string;
+
+  matchProjectFromInstanceName(instanceName: string): string;
+
+  matchInstanceFromInstanceName(instanceName: string): string;
+
+  matchProjectFromDatabaseName(databaseName: string): string;
+
+  matchInstanceFromDatabaseName(databaseName: string): string;
+
+  matchDatabaseFromDatabaseName(databaseName: string): string;
+}
+
+declare namespace DatabaseAdminClient {
+  interface CancelablePromise<T> extends Promise<T> {
+    cancel(): void;
+  }
+
+  interface GetProjectIdCallback {
+    (error: null | Error, projectId: string): void;
+  }
+
+  enum State {
+    STATE_UNSPECIFIED,
+    CREATING,
+    READY
+  }
+
+  interface Database {
+    name: string;
+    state: State;
+  }
+
+  interface ListDatabasesRequest {
+    parent: string;
+    pageSize: number;
+    pageToken: string;
+  }
+
+  interface ListDatabasesResponse {
+    databases: Database[];
+    nextPageToken?: string;
+  }
+
+  type ListDatabasesPaginated = [Database[]];
+  type ListDatabasesUnpaginated = [Database[], null | ListDatabasesRequest, ListDatabasesResponse];
+
+  interface ListDatabasesCallback {
+    (error: null | ServiceError, databases: Database[], nextQuery?: ListDatabasesRequest, response?: ListDatabasesResponse): void;
+  }
+
+  interface CreateDatabaseRequest {
+    parent: string;
+    createStatement: string;
+    extraStatements?: string[];
+  }
+
+  interface CreateDatabaseMetadata {
+    database: string;
+  }
+
+  interface CreateDatabaseCallback {
+    (error: null | ServiceError, operation: Operation): void;
+  }
+
+  interface GetDatabaseRequest {
+    name: string;
+  }
+
+  interface GetDatabaseCallback {
+    (error: null | ServiceError, database: Database): void;
+  }
+
+  interface UpdateDatabaseDdlRequest {
+    database: string;
+    statements: string[];
+    operationId?: string;
+  }
+
+  interface UpdateDatabaseDdlMetadata {
+    database: string;
+    statements: string[];
+    commitTimestamps: protobuf.ITimestamp[];
+  }
+
+  interface UpdateDatabaseDdlCallback {
+    (error: null | ServiceError, operation: Operation): void;
+  }
+
+  interface DropDatabaseRequest {
+    database: string;
+  }
+
+  interface DropDatabaseCallback {
+    (error: null | ServiceError): void
+  }
+
+  interface GetDatabaseDdlRequest {
+    database: string;
+  }
+
+  interface GetDatabaseDdlResponse {
+    statements: string[];
+  }
+
+  interface GetDatabaseDdlCallback {
+    (error: null | ServiceError, response: GetDatabaseDdlResponse): void;
+  }
+
+  interface Binding {
+    role: string;
+    members: string[];
+  }
+
+  interface Policy {
+    version: number;
+    bindings: Binding[];
+    etag: string;
+  }
+
+  interface SetIamPolicyRequest {
+    resource: string;
+    policy: Policy;
+  }
+
+  interface SetIamPolicyCallback {
+    (error: null | ServiceError, policy: Policy): void;
+  }
+
+  interface GetIamPolicyRequest {
+    resource: string;
+  }
+
+  interface GetIamPolicyCallback {
+    (error: null | ServiceError, policy: Policy): void;
+  }
+
+  interface TestIamPermissionsRequest {
+    resource: string;
+    permissions: string[];
+  }
+
+  interface TestIamPermissionsResponse {
+    permissions: string[];
+  }
+
+  interface TestIamPermissionsCallback {
+    (error: null | ServiceError, response: TestIamPermissionsResponse): void;
+  }
+
+  interface Operation extends EventEmitter {
+    cancel(): Promise<void>
+    getOperation(): Promise<{}>
+    getOperation(callback: (err?: Error) => void): void;
+    promise(): Promise<void>
+  }
+}

--- a/src/v1/index.d.ts
+++ b/src/v1/index.d.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {DatabaseAdminClient} from './database_admin_client';
+export {InstanceAdminClient} from './instance_admin_client';
+export {SpannerClient} from './spanner_client';

--- a/src/v1/instance_admin_client.d.ts
+++ b/src/v1/instance_admin_client.d.ts
@@ -1,0 +1,264 @@
+/*!
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {EventEmitter} from 'events';
+import {CallOptions, GrpcClientOptions} from 'google-gax';
+import {ClientReadableStream, ServiceError} from 'grpc';
+import {common as protobuf} from 'protobufjs';
+
+declare class InstanceAdminClient {
+  static servicePath: string;
+  static port: number;
+  static scopes: string[];
+
+  constructor(opts: GrpcClientOptions);
+
+  getProjectId(callback: InstanceAdminClient.GetProjectIdCallback): void;
+
+  listInstanceConfigs(request: InstanceAdminClient.ListInstanceConfigsRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<InstanceAdminClient.ListInstanceConfigsPaginated | InstanceAdminClient.ListInstanceConfigsUnpaginated>;
+  listInstanceConfigs(request: InstanceAdminClient.ListInstanceConfigsRequest, callback: InstanceAdminClient.ListInstanceConfigsCallback): void;
+  listInstanceConfigs(request: InstanceAdminClient.ListInstanceConfigsRequest, options: CallOptions, callback: InstanceAdminClient.ListInstanceConfigsCallback): void;
+
+  listInstanceConfigsStream(request: InstanceAdminClient.ListInstanceConfigsRequest, options?: CallOptions): ClientReadableStream<InstanceAdminClient.InstanceConfig>
+
+  getInstanceConfig(request: InstanceAdminClient.GetInstanceConfigRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.InstanceConfig]>;
+  getInstanceConfig(request: InstanceAdminClient.GetInstanceConfigRequest, callback: InstanceAdminClient.GetInstanceConfigCallback): void;
+  getInstanceConfig(request: InstanceAdminClient.GetInstanceConfigRequest, options: CallOptions, callback: InstanceAdminClient.GetInstanceConfigCallback): void;
+
+  listInstance(request: InstanceAdminClient.ListInstancesRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<InstanceAdminClient.ListInstancesPaginated | InstanceAdminClient.ListInstancesUnpaginated>;
+  listInstance(request: InstanceAdminClient.ListInstancesRequest, callback: InstanceAdminClient.ListInstancesCallback): void;
+  listInstance(request: InstanceAdminClient.ListInstancesRequest, options: CallOptions, callback: InstanceAdminClient.ListInstancesCallback): void;
+
+  listInstanceStream(request: InstanceAdminClient.ListInstancesRequest, options?: CallOptions): ClientReadableStream<InstanceAdminClient.Instance>;
+
+  getInstance(request: InstanceAdminClient.GetInstanceRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.Instance]>;
+  getInstance(request: InstanceAdminClient.GetInstanceRequest, callback: InstanceAdminClient.GetInstanceCallback): void;
+  getInstance(request: InstanceAdminClient.GetInstanceRequest, options: CallOptions, callback: InstanceAdminClient.GetInstanceCallback): void;
+
+  createInstance(request: InstanceAdminClient.CreateInstanceRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.Operation]>;
+  createInstance(request: InstanceAdminClient.CreateInstanceRequest, callback: InstanceAdminClient.CreateInstanceCallback): void;
+  createInstance(request: InstanceAdminClient.CreateInstanceRequest, options: CallOptions, callback: InstanceAdminClient.CreateInstanceCallback): void;
+
+  updateInstance(request: InstanceAdminClient.UpdateInstanceRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.Operation]>;
+  updateInstance(request: InstanceAdminClient.UpdateInstanceRequest, callback: InstanceAdminClient.UpdateInstanceCallback): void;
+  updateInstance(request: InstanceAdminClient.UpdateInstanceRequest, options: CallOptions, callback: InstanceAdminClient.UpdateInstanceCallback): void;
+
+  deleteInstance(request: InstanceAdminClient.DeleteInstanceRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<protobuf.IEmpty>;
+  deleteInstance(request: InstanceAdminClient.DeleteInstanceRequest, callback: InstanceAdminClient.DeleteInstanceCallback): void;
+  deleteInstance(request: InstanceAdminClient.DeleteInstanceRequest, options: CallOptions, callback: InstanceAdminClient.DeleteInstanceCallback): void;
+
+  setIamPolicy(request: InstanceAdminClient.SetIamPolicyRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.Policy]>;
+  setIamPolicy(request: InstanceAdminClient.SetIamPolicyRequest, callback: InstanceAdminClient.SetIamPolicyCallback): void;
+  setIamPolicy(request: InstanceAdminClient.SetIamPolicyRequest, options: CallOptions, callback: InstanceAdminClient.SetIamPolicyCallback): void;
+
+  getIamPolicy(request: InstanceAdminClient.GetIamPolicyRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.Policy]>;
+  getIamPolicy(request: InstanceAdminClient.GetIamPolicyRequest, callback: InstanceAdminClient.GetIamPolicyCallback): void;
+  getIamPolicy(request: InstanceAdminClient.GetIamPolicyRequest, options: CallOptions, callback: InstanceAdminClient.GetIamPolicyCallback): void;
+
+  testIamPermissions(request: InstanceAdminClient.TestIamPermissionsRequest, options?: CallOptions): InstanceAdminClient.CancelablePromise<[InstanceAdminClient.TestIamPermissionsResponse]>;
+  testIamPermissions(request: InstanceAdminClient.TestIamPermissionsRequest, callback: InstanceAdminClient.TestIamPermissionsCallback): void;
+  testIamPermissions(request: InstanceAdminClient.TestIamPermissionsRequest, options: CallOptions, callback: InstanceAdminClient.TestIamPermissionsCallback): void;
+
+  projectPath(project: string): string;
+
+  instanceConfigPath(project: string, instanceConfig: string): string;
+
+  instancePath(project: string, instance: string): string;
+
+  matchProjectFromProjectName(projectName: string): string;
+
+  matchProjectFromInstanceConfigName(instanceConfigName: string): string;
+
+  matchInstanceConfigFromInstanceConfigName(instanceConfigName: string): string;
+
+  matchProjectFromInstanceName(instanceName: string): string;
+
+  matchInstanceFromInstanceName(instanceName: string): string;
+}
+
+declare namespace InstanceAdminClient {
+  interface CancelablePromise<T> extends Promise<T> {
+    cancel(): void;
+  }
+
+  interface GetProjectIdCallback {
+    (error: null | Error, projectId: string): void;
+  }
+
+  interface InstanceConfig {
+    name: string;
+    displayName: string
+  }
+
+  interface ListInstanceConfigsRequest {
+    parent: string;
+    pageSize?: number;
+    pageToken?: string;
+  }
+
+  interface ListInstanceConfigsResponse {
+    instanceConfigs: InstanceConfig[];
+    nextPageToken?: string;
+  }
+
+  type ListInstanceConfigsPaginated = [InstanceConfig[]];
+  type ListInstanceConfigsUnpaginated = [InstanceConfig[], null | ListInstanceConfigsRequest, ListInstanceConfigsResponse];
+
+  interface ListInstanceConfigsCallback {
+    (error: null | ServiceError, instanceConfigs: InstanceConfig[], nextQuery?: ListInstanceConfigsRequest, response?: ListInstanceConfigsResponse): void;
+  }
+
+  interface GetInstanceConfigRequest {
+    name: string;
+  }
+
+  interface GetInstanceConfigCallback {
+    (error: null | ServiceError, instanceConfig: InstanceConfig): void;
+  }
+
+  enum State {
+    STATE_UNSPECIFIED,
+    CREATING,
+    READY
+  }
+
+  interface Instance {
+    name: string;
+    config: string;
+    displayName: string;
+    nodeCount: number;
+    state: State;
+    labels: Array<[string, string]>;
+  }
+
+  interface ListInstancesRequest {
+    parent: string;
+    pageSize?: number;
+    pageToken?: string;
+    filter?: string;
+  }
+
+  interface ListInstancesResponse {
+    instances: Instance[];
+    nextPageToken: string;
+  }
+
+  type ListInstancesPaginated = [Instance[]];
+  type ListInstancesUnpaginated = [Instance[], null | ListInstancesRequest, ListInstancesResponse];
+
+  interface ListInstancesCallback {
+    (error: null | ServiceError, instances: Instance[], nextQuery?: ListInstancesRequest, response?: ListInstancesResponse): void;
+  }
+
+  interface GetInstanceRequest {
+    name: string;
+  }
+
+  interface GetInstanceCallback {
+    (error: null | ServiceError, instance: Instance): void;
+  }
+
+  interface CreateInstanceRequest {
+    parent: string;
+    instanceId: string;
+    instance: Instance;
+  }
+
+  interface CreateInstanceMetadata {
+    instance: Instance;
+    startTime: protobuf.ITimestamp;
+    cancelTime: protobuf.ITimestamp;
+    endTime: protobuf.ITimestamp;
+  }
+
+  interface CreateInstanceCallback {
+    (error: null | ServiceError, operation: Operation): void;
+  }
+
+  interface UpdateInstanceRequest {
+    instance: Instance;
+    fieldMask: {
+      paths: string[];
+    };
+  }
+
+  interface UpdateInstanceMetadata {
+    instance: Instance;
+    startTime: protobuf.ITimestamp;
+    cancelTime: protobuf.ITimestamp;
+    endTime: protobuf.ITimestamp;
+  }
+
+  interface UpdateInstanceCallback {
+    (error: null | ServiceError, operation: Operation): void;
+  }
+
+  interface DeleteInstanceRequest {
+    name: string;
+  }
+
+  interface DeleteInstanceCallback {
+    (error: null | ServiceError): void;
+  }
+
+  interface Binding {
+    role: string;
+    members: string[];
+  }
+
+  interface Policy {
+    version: number;
+    bindings: Binding[];
+    etag: string;
+  }
+
+  interface SetIamPolicyRequest {
+    resource: string;
+    policy: Policy;
+  }
+
+  interface SetIamPolicyCallback {
+    (error: null | ServiceError, policy: Policy): void;
+  }
+
+  interface GetIamPolicyRequest {
+    resource: string;
+  }
+
+  interface GetIamPolicyCallback {
+    (error: null | ServiceError, policy: Policy): void;
+  }
+
+  interface TestIamPermissionsRequest {
+    resource: string;
+    permissions: string[];
+  }
+
+  interface TestIamPermissionsResponse {
+    permissions: string[];
+  }
+
+  interface TestIamPermissionsCallback {
+    (error: null | ServiceError, response: TestIamPermissionsResponse): void;
+  }
+
+  interface Operation extends EventEmitter {
+    cancel(): Promise<void>
+    getOperation(): Promise<{}>
+    getOperation(callback: (err?: Error) => void): void;
+    promise(): Promise<void>
+  }
+}

--- a/src/v1/spanner_client.d.ts
+++ b/src/v1/spanner_client.d.ts
@@ -1,0 +1,409 @@
+/*!
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CallOptions, GrpcClientOptions} from 'google-gax';
+import {ClientReadableStream, ServiceError} from 'grpc';
+import {common as protobuf} from 'protobufjs';
+
+declare class SpannerClient {
+  static servicePath: string;
+  static port: number;
+  static scopes: string[];
+
+  constructor(opts: GrpcClientOptions);
+
+  getProjectId(callback: SpannerClient.GetProjectIdCallback): void;
+
+  createSession(request: SpannerClient.CreateSessionRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.Session]>;
+  createSession(request: SpannerClient.CreateSessionRequest, callback: SpannerClient.CreateSessionCallback): void;
+  createSession(request: SpannerClient.CreateSessionRequest, options: CallOptions, callback: SpannerClient.CreateSessionCallback): void;
+
+  getSession(request: SpannerClient.GetSessionRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.Session]>;
+  getSession(request: SpannerClient.GetSessionRequest, callback: SpannerClient.GetSessionCallback): void;
+  getSession(request: SpannerClient.GetSessionRequest, options: CallOptions, callback: SpannerClient.GetSessionCallback): void;
+
+  listSessions(request: SpannerClient.ListSessionsRequest, options?: CallOptions): SpannerClient.CancelablePromise<SpannerClient.ListSessionsPaginated | SpannerClient.ListSessionsUnpaginated>;
+  listSessions(request: SpannerClient.ListSessionsRequest, callback: SpannerClient.ListSessionsCallback): void;
+  listSessions(request: SpannerClient.ListSessionsRequest, options: CallOptions, callback: SpannerClient.ListSessionsCallback): void;
+
+  listSessionsStream(request: SpannerClient.ListSessionsRequest, options?: CallOptions): ClientReadableStream<SpannerClient.Session>;
+
+  deleteSession(request: SpannerClient.DeleteSessionRequest, options?: CallOptions): SpannerClient.CancelablePromise<protobuf.IEmpty>;
+  deleteSession(request: SpannerClient.DeleteSessionRequest, callback: SpannerClient.DeleteSessionCallback): void;
+  deleteSession(request: SpannerClient.DeleteSessionRequest, options: CallOptions, callback: SpannerClient.DeleteSessionCallback): void;
+
+  executeSql(request: SpannerClient.ExecuteSqlRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.ResultSet]>;
+  executeSql(request: SpannerClient.ExecuteSqlRequest, callback: SpannerClient.ExecuteSqlCallback): void;
+  executeSql(request: SpannerClient.ExecuteSqlRequest, options: CallOptions, callback: SpannerClient.ExecuteSqlCallback): void;
+
+  executeStreamingSql(request: SpannerClient.ExecuteSqlRequest, options?: CallOptions): ClientReadableStream<SpannerClient.PartialResultSet>;
+
+  read(request: SpannerClient.ReadRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.ResultSet]>;
+  read(request: SpannerClient.ReadRequest, callback: SpannerClient.ReadCallback): void;
+  read(request: SpannerClient.ReadRequest, options: CallOptions, callback: SpannerClient.ReadCallback): void;
+
+  streamingRead(request: SpannerClient.ReadRequest, options?: CallOptions): ClientReadableStream<SpannerClient.PartialResultSet>;
+
+  beginTransaction(request: SpannerClient.BeginTransactionRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.Transaction]>;
+  beginTransaction(request: SpannerClient.BeginTransactionRequest, callback: SpannerClient.BeginTransactionCallback): void;
+  beginTransaction(request: SpannerClient.BeginTransactionRequest, options: CallOptions, callback: SpannerClient.BeginTransactionCallback): void;
+
+  commit(request: SpannerClient.CommitRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.CommitResponse]>;
+  commit(request: SpannerClient.CommitRequest, callback: SpannerClient.CommitCallback): void;
+  commit(request: SpannerClient.CommitRequest, options: CallOptions, callback: SpannerClient.CommitCallback): void;
+
+  rollback(request: SpannerClient.RollbackRequest, options?: CallOptions): SpannerClient.CancelablePromise<protobuf.IEmpty>;
+  rollback(request: SpannerClient.RollbackRequest, callback: SpannerClient.RollbackCallback): void;
+  rollback(request: SpannerClient.RollbackRequest, options: CallOptions, callback: SpannerClient.RollbackCallback): void;
+
+  paritionQuery(request: SpannerClient.PartitionQueryRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.PartitionResponse]>;
+  paritionQuery(request: SpannerClient.PartitionQueryRequest, callback: SpannerClient.PartitionQueryCallback): void;
+  paritionQuery(request: SpannerClient.PartitionQueryRequest, options: CallOptions, callback: SpannerClient.PartitionQueryCallback): void;
+
+  partitionRead(request: SpannerClient.PartitionReadRequest, options?: CallOptions): SpannerClient.CancelablePromise<[SpannerClient.PartitionResponse]>;
+  partitionRead(request: SpannerClient.PartitionReadRequest, callback: SpannerClient.PartitionQueryCallback): void;
+  partitionRead(request: SpannerClient.PartitionReadRequest, options: CallOptions, callback: SpannerClient.PartitionQueryCallback): void;
+
+  databasePath(project: string, instance: string, database: string): string;
+
+  sessionPath(project: string, instance: string, database: string, session: string): string;
+
+  matchProjectFromDatabaseName(databaseName: string): string;
+
+  matchInstanceFromDatabaseName(databaseName: string): string;
+
+  matchDatabaseFromDatabaseName(databaseName: string): string;
+
+  matchProjectFromSessionName(sessionName: string): string;
+
+  matchInstanceFromSessionName(sessionName: string): string;
+
+  matchDatabaseFromSessionName(sessionName: string): string;
+
+  matchSessionFromSessionName(sessionName: string): string;
+}
+
+declare namespace SpannerClient {
+  interface CancelablePromise<T> extends Promise<T> {
+    cancel(): void;
+  }
+
+  interface GetProjectIdCallback {
+    (error: null | Error, projectId: string): void;
+  }
+
+  interface CreateSessionRequest {
+    database: string;
+    session?: Session;
+  }
+
+  interface Session {
+    name: string,
+    labels: Array<[string, string]>,
+    createTime?: protobuf.ITimestamp,
+    approximateLastUseTime?: protobuf.ITimestamp,
+  }
+
+  interface CreateSessionCallback {
+    (error: null | ServiceError, session: Session): void;
+  }
+
+  interface GetSessionRequest {
+    name: string;
+  }
+
+  interface GetSessionCallback {
+    (error: null | ServiceError, session: Session): void;
+  }
+
+  interface ListSessionsRequest {
+    database: string;
+    pageSize: number;
+    pageToken: string;
+    filter: string;
+  }
+
+  interface ListSessionsResponse {
+    sessions: Session[];
+    nextPageToken: string;
+  }
+
+  type ListSessionsPaginated = [Session[]];
+  type ListSessionsUnpaginated = [Session[], null | ListSessionsRequest, ListSessionsResponse];
+
+  interface ListSessionsCallback {
+    (error: null | ServiceError, sessions: Session[], nextQuery?: ListSessionsRequest, response?: ListSessionsResponse): void;
+  }
+
+  interface DeleteSessionRequest {
+    name: string;
+  }
+
+  interface DeleteSessionCallback {
+    (error: null | ServiceError): void;
+  }
+
+  enum QueryMode {
+    NORMAL,
+    PLAN,
+    PROFILE
+  }
+
+  interface ExecuteSqlRequest {
+    session: string;
+    transaction?: TransactionSelector;
+    sql: string;
+    params?: protobuf.IStruct;
+    paramTypes: Array<[string, Type]>;
+    resumeToken: Uint8Array | string;
+    queryMode: QueryMode;
+    partitionToken: Uint8Array | string;
+    seqno: number;
+  }
+
+  interface ExecuteSqlCallback {
+    (error: null | ServiceError, results: ResultSet): void;
+  }
+
+  interface PartitionOptions {
+    partitionSizeBytes: number;
+    maxPartitions: number;
+  }
+
+  interface PartitionQueryRequest {
+    session: string;
+    transaction?: TransactionSelector;
+    sql: string;
+    params?: protobuf.IStruct;
+    paramTypes: Array<[string, Type]>;
+    partitionOptions?: PartitionOptions;
+  }
+
+  interface PartitionReadRequest {
+    session: string;
+    transaction?: TransactionSelector;
+    table: string;
+    index: string;
+    columns: string[];
+    keySet?: KeySet;
+    partitionOptions?: PartitionOptions;
+  }
+
+  interface Partition {
+    partitionToken: Uint8Array | string;
+  }
+
+  interface PartitionResponse {
+    partitions: Partition[];
+    transaction?: Transaction;
+  }
+
+  interface PartitionQueryCallback {
+    (error: null | ServiceError, response: PartitionResponse): void;
+  }
+
+  interface ReadRequest {
+    session: string;
+    transaction?: TransactionSelector;
+    table: string;
+    index: string;
+    columns: string[];
+    keySet?: KeySet;
+    limit: number;
+    resumeToken: Uint8Array | string;
+    partitionToken: Uint8Array | string;
+  }
+
+  interface ReadCallback {
+    (error: null | ServiceError, results: ResultSet): void;
+  }
+
+  interface BeginTransactionRequest {
+    session: string;
+    options?: TransactionOptions;
+  }
+
+  interface BeginTransactionCallback {
+    (error: null | ServiceError, transaction: Transaction): void;
+  }
+
+  interface CommitRequest {
+    session: string;
+    transactionId: Uint8Array | string;
+    singleUseTransaction?: TransactionOptions;
+    mutations: Mutation;
+  }
+
+  interface CommitResponse {
+    commitTimestamp?: protobuf.ITimestamp;
+  }
+
+  interface CommitCallback {
+    (error: null | ServiceError, response: CommitResponse): void;
+  }
+
+  interface RollbackRequest {
+    session: string;
+    transactionId: Uint8Array | string;
+  }
+
+  interface RollbackCallback {
+    (error: null|ServiceError): void;
+  }
+
+  interface KeyRange {
+    startClosed?: protobuf.IListValue;
+    startOpen?: protobuf.IListValue;
+    endClosed?: protobuf.IListValue;
+    endOpen?: protobuf.IListValue;
+  }
+
+  interface KeySet {
+    keys: protobuf.IListValue[];
+    ranges: KeyRange[];
+    all: boolean;
+  }
+
+  interface Write {
+    table: string;
+    columns: string[];
+    values: protobuf.IListValue[];
+  }
+
+  interface Delete {
+    table: string;
+    keySet?: KeySet;
+  }
+
+  interface Mutation {
+    insert?: Write;
+    update?: Write;
+    insertOrUpdate?: Write;
+    replace?: Write;
+    delete?: Delete;
+  }
+
+  interface ResultSet {
+    metadata?: ResultSetMetadata;
+    rows: protobuf.IListValue[];
+    stats?: ResultSetStats;
+  }
+
+  interface PartialResultSet {
+    metadata?: ResultSetMetadata;
+    values: protobuf.IValue[];
+    chunkedValue: boolean;
+    resumeToken: Uint8Array | string;
+    stats?: ResultSetStats;
+  }
+
+  interface ResultSetMetadata {
+    rowType?: StructType;
+    transaction?: Transaction;
+  }
+
+  interface ResultSetStats {
+    queryPlan?: QueryPlan;
+    queryStats?: protobuf.IStruct;
+    rowCountExact: number;
+    rowCountLowerBound: number;
+  }
+
+  enum Kind {
+    KIND_UNSPECIFIED,
+    RELATIONAL,
+    SCALAR
+  }
+
+  interface ChildLink {
+    childIndex: number;
+    type: string;
+    variable: string;
+  }
+
+  interface ShortRepresentation {
+    description: string;
+    subqueries: Array<[string, number]>
+  }
+
+  interface PlanNode {
+    index: number;
+    kind: Kind;
+    displayName: string;
+    childLinks: ChildLink[];
+    shortRepresentation?: ShortRepresentation;
+    metadata?: protobuf.IStruct;
+    executionStats?: protobuf.IStruct;
+  }
+
+  interface QueryPlan {
+    planNodes: PlanNode[];
+  }
+
+  interface ReadOnly {
+    strong: boolean;
+    minReadTimestamp?: protobuf.ITimestamp;
+    maxStaleness?: protobuf.IDuration;
+    readTimestamp?: protobuf.ITimestamp;
+    exactStaleness?: protobuf.IDuration;
+    returnReadTimestamp: boolean;
+  }
+
+  interface TransactionOptions {
+    readWrite?: {};
+    partitionedDml?: {};
+    readOnly?: ReadOnly;
+  }
+
+  interface Transaction {
+    id: Uint8Array | string;
+    readTimestamp?: protobuf.ITimestamp;
+  }
+
+  interface TransactionSelector {
+    singleUse?: TransactionOptions;
+    id: Uint8Array | string;
+    begin?: TransactionOptions;
+  }
+
+  enum TypeCode {
+    TYPE_CODE_UNSPECIFIED,
+    BOOL,
+    INT64,
+    FLOAT64,
+    TIMESTAMP,
+    DATE,
+    STRING,
+    BYTES,
+    ARRAY,
+    STRUCT
+  }
+
+  interface Type {
+    code: TypeCode;
+    arrayElementType?: Type;
+    structType?: StructType;
+  }
+
+  interface Field {
+    name: string;
+    type?: Type;
+  }
+
+  interface StructType {
+    fields: Field[];
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "include": [
     "src/*.ts",
+    "src/v1/*.d.ts",
     "src/**/*.js",
     "test/*.ts",
     "system-test/*.ts",


### PR DESCRIPTION
While trying to chip away at improving types, I found myself defining a lot of request/response types and seeing a need for them across multiple files. I thought it might be useful to have definition files for our gapic clients (at least until we start generating them in TypeScript).