### PR TITLE
feat(timestamp): create new date/timestamp classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@google-cloud/common-grpc": "^0.10.0",
     "@google-cloud/paginator": "^0.1.0",
+    "@google-cloud/precise-date": "^0.1.0",
     "@google-cloud/projectify": "^0.3.0",
     "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.1",

--- a/src/batch-transaction.ts
+++ b/src/batch-transaction.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+import {PreciseDate} from '@google-cloud/precise-date';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as is from 'is';
-import {codec, Timestamp} from './codec';
+import {codec} from './codec';
 import {Snapshot} from './transaction';
 
 /**
@@ -161,7 +162,7 @@ class BatchTransaction extends Snapshot {
 
         if (readTimestamp) {
           this.readTimestampProto = readTimestamp;
-          this.readTimestamp = new Timestamp(readTimestamp);
+          this.readTimestamp = new PreciseDate(readTimestamp);
         }
       }
 

--- a/src/batch-transaction.ts
+++ b/src/batch-transaction.ts
@@ -17,7 +17,7 @@
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as is from 'is';
-import {codec} from './codec';
+import {codec, Timestamp} from './codec';
 import {Snapshot} from './transaction';
 
 /**
@@ -161,7 +161,7 @@ class BatchTransaction extends Snapshot {
 
         if (readTimestamp) {
           this.readTimestampProto = readTimestamp;
-          this.readTimestamp = codec.convertProtoTimestampToDate(readTimestamp);
+          this.readTimestamp = Timestamp.fromProto(readTimestamp);
         }
       }
 

--- a/src/batch-transaction.ts
+++ b/src/batch-transaction.ts
@@ -161,7 +161,7 @@ class BatchTransaction extends Snapshot {
 
         if (readTimestamp) {
           this.readTimestampProto = readTimestamp;
-          this.readTimestamp = Timestamp.fromProto(readTimestamp);
+          this.readTimestamp = new Timestamp(readTimestamp);
         }
       }
 

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {Service} from '@google-cloud/common-grpc';
+import {DateStruct, PreciseDate} from '@google-cloud/precise-date';
 import * as arrify from 'arrify';
 import {CallOptions} from 'google-gax';
 import * as is from 'is';
@@ -77,268 +78,6 @@ export class SpannerDate extends Date {
    */
   static getDateString(date: Date): string {
     return date.toISOString().replace(/T.+/, '');
-  }
-}
-
-/**
- * Date-like object used to represent Cloud Spanner Timestamps.
- *
- * @see Spanner.timestamp
- * @see https://cloud.google.com/spanner/docs/data-types#timestamp-type
- *
- * @class
- * @extends Date
- *
- * @example
- * const timestamp = Spanner.timestamp('2019-02-08T10:34:29.481145231Z');
- *
- * @example <caption>With a `google.protobuf.Timestamp` object</caption>
- * const [seconds, nanos] = process.hrtime();
- * const timestamp = Spanner.timestamp({seconds, nanos});
- *
- * @example <caption>With a Date timestamp</caption>
- * const timestamp = Spanner.timestamp(Date.now());
- */
-export class Timestamp extends Date {
-  private _micros: number;
-  private _nanos: number;
-  constructor(value?: string|number|p.ITimestamp) {
-    const isProto = is.object(value);
-
-    if (typeof value === 'undefined') {
-      value = Date.now();
-    }
-
-    super(isProto ? 0 : value as number);
-
-    this._micros = 0;
-    this._nanos = 0;
-
-    if (isProto) {
-      this._fromProto(value as p.ITimestamp);
-    } else if (Timestamp.isFullISOString(value)) {
-      this._fromISOString(value as string);
-    }
-  }
-  /**
-   * Returns the string value corresponding to the time for the specified
-   * timestamp according to universal time.
-   *
-   * @returns {string} A string representing the nanoseconds elapsed between
-   *     1 January 1970 00:00:00 UTC and the given timestamp.
-   */
-  getFullTimeString(): string {
-    const {seconds, nanos} = this.toProto();
-    return `${seconds}${nanos}`;
-  }
-  /**
-   * Returns a number, between 0 and 999, representing the microseconds of the
-   * timestamp.
-   *
-   * @returns {number}
-   */
-  getMicroseconds(): number {
-    return this._micros;
-  }
-  /**
-   * Returns a number, between 0 and 999, representing the nanoseconds of the
-   * timestamp.
-   *
-   * @returns {number}
-   */
-  getNanoseconds(): number {
-    return this._nanos;
-  }
-  /**
-   * Sets the exact time for the specified timestamp.
-   *
-   * @param {string} nanoseconds A string representing the number of nanoseconds
-   *     since 1 January 1970, 00:00:00 UTC.
-   * @returns {string} A string representing the number of nanoseconds between
-   *     1 January 1970 00:00:00 UTC and the updated date. (effectively, the
-   *     value of the argument).
-   */
-  setFullTime(nanoseconds: string): string {
-    nanoseconds = Timestamp.padLeft(nanoseconds, 10);
-
-    const seconds = Number(nanoseconds.substr(0, nanoseconds.length - 9));
-    const nanos = Number(nanoseconds.substr(-9));
-
-    this.setTime(seconds * 1000);
-    this.setNanoseconds(nanos);
-
-    return this.getFullTimeString();
-  }
-  /**
-   * Sets the microseconds for the specified timestamp.
-   *
-   * @param {number} microseconds A number representing the microseconds.
-   * @returns {number} The number of milliseconds between 1 January 1970
-   *     00:00:00 UTC and the updated timestamp.
-   */
-  setMicroseconds(micros: number): number {
-    if (micros >= 1000) {
-      const ms = Math.floor(micros / 1000);
-      this.setMilliseconds(this.getMilliseconds() + ms);
-      micros -= ms * 1000;
-    }
-    this._micros = micros;
-    return this.getTime();
-  }
-  /**
-   * Sets the nanoseconds for the specified timestamp.
-   *
-   * @param {number} nanoseconds A number representing the nanoseconds.
-   * @returns {number} The number of milliseconds between 1 January 1970
-   *     00:00:00 UTC and the updated timestamp.
-   */
-  setNanoseconds(nanos: number): number {
-    if (nanos >= 1000) {
-      const micros = Math.floor(nanos / 1000);
-      this.setMicroseconds(this._micros + micros);
-      nanos -= micros * 1000;
-    }
-    this._nanos = nanos;
-    return this.getTime();
-  }
-  /**
-   * Sets the Timestamp to the time represented by a number of milliseconds
-   * since January 1, 1970, 00:00:00 UTC. Calling this method will reset both
-   * the microseconds and nanoseconds to 0.
-   *
-   * @param {number} milliseconds An integer representing the number of
-   *     milliseconds since 1 January 1970, 00:00:00 UTC.
-   * @returns {number} The number of milliseconds between
-   *     1 January 1970 00:00:00 UTC and the updated date (effectively, the
-   *     value of the argument).
-   */
-  setTime(milliseconds: number): number {
-    this._micros = 0;
-    this._nanos = 0;
-    return super.setTime(milliseconds);
-  }
-  /**
-   * Returns a RFC 3339 timestamp formatted string.
-   *
-   * @returns {string}
-   */
-  toISOString(): string {
-    const micros = Timestamp.padLeft(this._micros);
-    const nanos = Timestamp.padLeft(this._nanos);
-    const digits = `${micros}${nanos}`.replace(/0+$/, '');
-    return super.toISOString().replace(/z$/i, `${digits}Z`);
-  }
-  /**
-   * Returns the timestamp as a protobuf timestamp.
-   *
-   * @returns {google.protobuf.Timestamp}
-   */
-  toProto(): p.ITimestamp {
-    const seconds = Math.floor(this.getTime() / 1000);
-    const msInNanos = this.getMilliseconds() * 1e6;
-    const microsInNanos = this._micros * 1000;
-    const nanos = this._nanos + msInNanos + microsInNanos;
-    return {seconds, nanos};
-  }
-  /**
-   * Sets time via RFC 3339 timestamp formatted string.
-   *
-   * @private
-   *
-   * @param {string} timestamp The timestamp.
-   */
-  private _fromISOString(timestamp: string): void {
-    let digits = '0';
-
-    timestamp = timestamp.replace(/\.(\d+)/, ($0, $1) => {
-      digits = $1;
-      return '.000';
-    });
-
-    const time = new Date(timestamp).getTime();
-    const nanos = Number(Timestamp.padRight(digits, 9));
-
-    this.setTime(time);
-    this.setNanoseconds(nanos);
-  }
-  /**
-   * Sets time via {@link google.protobuf.Timestamp} object.
-   *
-   * @private
-   *
-   * @param {google.protobuf.Timestamp} timestamp The timestamp.
-   */
-  private _fromProto({seconds = 0, nanos = 0}: p.ITimestamp): void {
-    if (typeof seconds === 'string') {
-      seconds = Number(seconds);
-    } else if (typeof seconds !== 'number') {
-      // tslint:disable-next-line no-any
-      seconds = (seconds as any).toNumber() as number;
-    }
-
-    this.setTime(seconds * 1000);
-    this.setNanoseconds(nanos);
-  }
-  /**
-   * Checks to see if a string is an ISO formatted timestamp.
-   *
-   * @private
-   * @static
-   *
-   * @param {string} value The value to check.
-   * @returns {boolean}
-   */
-  static isFullISOString(value?: unknown): boolean {
-    if (typeof value !== 'string') {
-      return false;
-    }
-
-    const isoReg = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d{4,9}Z/;
-    return isoReg.test(value);
-  }
-  /**
-   * Creates padding for string based on current size and desired size.
-   *
-   * @private
-   * @static
-   *
-   * @param {string} n stringified number to pad.
-   * @param {number} [size=3] Desired string size.
-   * @returns {string}
-   */
-  static getPadding(n: string, size = 3): string {
-    const padding = Math.max(size - n.length, 0);
-    return '0'.repeat(padding);
-  }
-  /**
-   * Pads a number with 0s on the left hand size.
-   * 1 -> 001
-   *
-   * @private
-   * @static
-   *
-   * @param {number|string} n number to pad.
-   * @param {number} [size=3] Desired string size.
-   * @returns {string}
-   */
-  static padLeft(n: number|string, size?: number): string {
-    const padding = Timestamp.getPadding(n.toString(), size);
-    return `${padding}${n}`;
-  }
-  /**
-   * Pads a number with 0s on the right hand size.
-   * 1 -> 100
-   *
-   * @private
-   * @static
-   *
-   * @param {number|string} n number to pad.
-   * @param {number} [size=3] Desired string size.
-   * @returns {string}
-   */
-  static padRight(n: number|string, size?: number): string {
-    const padding = Timestamp.getPadding(n.toString(), size);
-    return `${n}${padding}`;
   }
 }
 
@@ -530,7 +269,7 @@ function decode(value: Value, type: s.Type): Value {
       decoded = new Int(decoded);
       break;
     case s.TypeCode.TIMESTAMP:
-      decoded = new Timestamp(decoded);
+      decoded = new PreciseDate(decoded);
       break;
     case s.TypeCode.DATE:
       decoded = new SpannerDate(decoded);
@@ -818,7 +557,6 @@ export const codec = {
   convertProtoTimestampToDate,
   createTypeObject,
   SpannerDate,
-  Timestamp,
   Float,
   Int,
   convertFieldsToJson,

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -72,7 +72,11 @@ export class SpannerDate extends Date {
   constructor(...dateFields: Array<string|number|undefined>) {
     const yearOrDateString = dateFields[0];
 
-    // JavaScript Date objects will interpret ISO strings as Zulu time,
+    if (!yearOrDateString) {
+      dateFields[0] = new Date().toDateString();
+    }
+
+    // JavaScript Date objects will interpret ISO date strings as Zulu time,
     // but by formatting it, we can infer local time.
     if (/^\d{4}-\d{1,2}-\d{1,2}/.test(yearOrDateString as string)) {
       const [year, month, date] = (yearOrDateString as string).split(/-|T/);

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -232,31 +232,16 @@ export class Timestamp extends Date {
    * @returns {Timestamp}
    */
   static fromISOString(timestamp: string): Timestamp {
-    const instance = new Timestamp(timestamp);
+    let digits = '0';
 
-    // no dot, no digits!
-    if (!timestamp.includes('.')) {
-      return instance;
-    }
-
-    const digits = timestamp.replace(/.+\./, '').match(/^\d{1,9}/);
-    let groups: string[] = [];
-
-    if (digits && digits.length) {
-      groups = digits.pop()!.match(/\d{1,3}/g) as string[];
-    }
-
-    // Date object will parse the ms, so we can toss them
-    groups.shift();
-
-    const [micros = 0, nanos = 0] = groups.map(n => {
-      const padded = Timestamp.padRight(n);
-      return Number(padded);
+    timestamp = timestamp.replace(/\.(\d+)/, ($0, $1) => {
+      digits = $1;
+      return '.000';
     });
 
-    instance.setMicroseconds(micros);
+    const instance = new Timestamp(timestamp);
+    const nanos = Number(Timestamp.padRight(digits, 9));
     instance.setNanoseconds(nanos);
-
     return instance;
   }
   /**
@@ -269,8 +254,6 @@ export class Timestamp extends Date {
    * @returns {Timestamp}
    */
   static fromProto({seconds = 0, nanos = 0}: p.ITimestamp): Timestamp {
-    const instance = new Timestamp();
-
     if (typeof seconds === 'string') {
       seconds = Number(seconds);
     } else if (typeof seconds !== 'number') {
@@ -278,14 +261,8 @@ export class Timestamp extends Date {
       seconds = (seconds as any).toNumber() as number;
     }
 
-    const groups = Timestamp.padLeft(nanos, 9).match(/\d{3}/g);
-    const [ms, micros, ns] = groups!.map(Number);
-
-    instance.setTime(seconds * 1000);
-    instance.setMilliseconds(ms);
-    instance.setMicroseconds(micros);
-    instance.setNanoseconds(ns);
-
+    const instance = new Timestamp(seconds * 1000);
+    instance.setNanoseconds(nanos);
     return instance;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -806,18 +806,8 @@ class Spanner extends Service {
    * @example <caption>With a Date timestamp</caption>
    * const timestamp = Spanner.timestamp(Date.now());
    */
-  static timestamp(timestamp?: string|number|p.ITimestamp): Timestamp {
-    timestamp = timestamp || Date.now();
-
-    if (is.object(timestamp)) {
-      return codec.Timestamp.fromProto(timestamp as p.ITimestamp);
-    }
-
-    if (Timestamp.isISOString(timestamp)) {
-      return codec.Timestamp.fromISOString(timestamp as string);
-    }
-
-    return new codec.Timestamp(timestamp as number);
+  static timestamp(value?: string|number|p.ITimestamp): Timestamp {
+    return new codec.Timestamp(value);
   }
 
   /**
@@ -883,6 +873,7 @@ promisifyAll(Spanner, {
     'instance',
     'int',
     'operation',
+    'timestamp',
   ],
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@
 
 import {Service, Operation} from '@google-cloud/common-grpc';
 import {paginator} from '@google-cloud/paginator';
+import {PreciseDate} from '@google-cloud/precise-date';
 import {replaceProjectIdToken} from '@google-cloud/projectify';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
@@ -28,7 +29,7 @@ import {common as p} from 'protobufjs';
 import * as streamEvents from 'stream-events';
 import * as through from 'through2';
 import {GrpcServiceConfig} from '@google-cloud/common-grpc/build/src/service';
-import {codec, Timestamp} from './codec';
+import {codec} from './codec';
 import {Database} from './database';
 import {Instance} from './instance';
 import {Session} from './session';
@@ -781,6 +782,12 @@ class Spanner extends Service {
   }
 
   /**
+   * Date object with nanosecond precision. Supports all standard Date arguments
+   * in addition to several custom types.
+   * @external PreciseDate
+   * @see {@link https://github.com/googleapis/nodejs-precise-date|PreciseDate}
+   */
+  /**
    * Helper function to get a Cloud Spanner Timestamp object.
    *
    * String timestamps should have a canonical format of
@@ -794,7 +801,7 @@ class Spanner extends Service {
    * @param {string|number|google.protobuf.Timestamp} [timestamp] Either a
    *      RFC 3339 timestamp formatted string or
    *      {@link google.protobuf.Timestamp} object.
-   * @returns {Timestamp}
+   * @returns {external:PreciseDate}
    *
    * @example
    * const timestamp = Spanner.timestamp('2019-02-08T10:34:29.481145231Z');
@@ -806,8 +813,9 @@ class Spanner extends Service {
    * @example <caption>With a Date timestamp</caption>
    * const timestamp = Spanner.timestamp(Date.now());
    */
-  static timestamp(value?: string|number|p.ITimestamp): Timestamp {
-    return new codec.Timestamp(value);
+  static timestamp(value?: string|number|p.ITimestamp): PreciseDate {
+    value = value || Date.now();
+    return new PreciseDate(value as number);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -767,18 +767,32 @@ class Spanner extends Service {
     return stream;
   }
 
+  static date(dateString?: string);
+  static date(year: number, month: number, date: number);
   /**
    * Helper function to get a Cloud Spanner Date object.
    *
-   * @param {string|date} value The date as a string or Date object.
+   * DATE types represent a logical calendar date, independent of time zone.
+   * DATE values do not represent a specific 24-hour period. Rather, a given
+   * DATE value represents a different 24-hour period when interpreted in a
+   * different time zone. Because of this, all values passed to
+   * {@link Spanner.date} will be interpreted as local time.
+   *
+   * To represent an absolute point in time, use {@link Spanner.timestamp}.
+   *
+   * @param {string|number} [date] String representing the date or number
+   *     representing the year.
+   * @param {number} [month] Number representing the month.
+   * @param {number} [date] Number representing the date.
    * @returns {SpannerDate}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
    * const date = Spanner.date('08-20-1969');
    */
-  static date(value?) {
-    return new codec.SpannerDate(value);
+  // tslint:disable-next-line no-any
+  static date(...dateFields: any[]) {
+    return new codec.SpannerDate(...dateFields);
   }
 
   /**

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -272,7 +272,7 @@ export class Snapshot extends EventEmitter {
 
           if (readTimestamp) {
             this.readTimestampProto = readTimestamp;
-            this.readTimestamp = Timestamp.fromProto(readTimestamp);
+            this.readTimestamp = new Timestamp(readTimestamp);
           }
 
           callback!(null, resp);
@@ -1196,7 +1196,7 @@ export class Transaction extends Dml {
 
           if (resp && resp.commitTimestamp) {
             this.commitTimestampProto = resp.commitTimestamp;
-            this.commitTimestamp = Timestamp.fromProto(resp.commitTimestamp);
+            this.commitTimestamp = new Timestamp(resp.commitTimestamp);
           }
 
           callback!(err, resp);

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -518,7 +518,7 @@ describe('Spanner', () => {
 
     describe('timestamps', () => {
       it('should write timestamp values', done => {
-        const date = new Date();
+        const date = Spanner.timestamp();
 
         insert({TimestampValue: date}, (err, row) => {
           assert.ifError(err);
@@ -553,7 +553,7 @@ describe('Spanner', () => {
       });
 
       it('should write timestamp array values', done => {
-        const values = [new Date(), new Date('3-3-1933')];
+        const values = [Spanner.timestamp(), Spanner.timestamp('3-3-1933')];
 
         insert({TimestampArray: values}, (err, row) => {
           assert.ifError(err);
@@ -616,11 +616,10 @@ describe('Spanner', () => {
       it('should accept the commit timestamp placeholder', done => {
         const data = {CommitTimestamp: Spanner.COMMIT_TIMESTAMP};
 
-        insert(data, (err, row, commitResponse) => {
+        insert(data, (err, row, {commitTimestamp}) => {
           assert.ifError(err);
 
-          const timestampFromCommit =
-              fromProtoToDate(commitResponse.commitTimestamp);
+          const timestampFromCommit = Spanner.timestamp(commitTimestamp);
           const timestampFromRead = row.toJSON().CommitTimestamp;
 
           assert.deepStrictEqual(timestampFromCommit, timestampFromRead);
@@ -1311,15 +1310,13 @@ describe('Spanner', () => {
     });
 
     describe('insert & query', () => {
-      const DATE = new Date('1969-08-20');
-
       const ID = generateName('id');
       const NAME = generateName('name');
       const FLOAT = 8.2;
       const INT = 2;
       const INFO = Buffer.from(generateName('info'));
-      const CREATED = new Date();
-      const DOB = Spanner.date(DATE);
+      const CREATED = Spanner.timestamp();
+      const DOB = Spanner.date('1969-08-20');
       const ACCENTS = ['jamaican'];
       const PHONE_NUMBERS = [123123123, 234234234];
       const HAS_GEAR = true;
@@ -1338,10 +1335,6 @@ describe('Spanner', () => {
       };
 
       const EXPECTED_ROW = extend(true, {}, INSERT_ROW);
-      EXPECTED_ROW.DOB = DATE;
-      EXPECTED_ROW.Float = FLOAT;
-      EXPECTED_ROW.Int = INT;
-      EXPECTED_ROW.PhoneNumbers = PHONE_NUMBERS;
 
       before(() => {
         return table.insert(INSERT_ROW);
@@ -2022,7 +2015,7 @@ describe('Spanner', () => {
 
         describe('timestamp', () => {
           it('should bind the value', done => {
-            const timestamp = new Date();
+            const timestamp = Spanner.timestamp();
 
             const query = {
               sql: 'SELECT @v',
@@ -2057,7 +2050,8 @@ describe('Spanner', () => {
           });
 
           it('should bind arrays', done => {
-            const values = [new Date(), new Date('3-3-1999'), null];
+            const values =
+                [Spanner.timestamp(), Spanner.timestamp('3-3-1999'), null];
 
             const query = {
               sql: 'SELECT @v',
@@ -2160,7 +2154,7 @@ describe('Spanner', () => {
           it('should bind arrays', done => {
             const values = [
               Spanner.date(),
-              Spanner.date(new Date('3-3-1999')),
+              Spanner.date('3-3-1999'),
               null,
             ];
 

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -603,10 +603,8 @@ describe('Spanner', () => {
 
         insert({DateArray: values}, (err, row) => {
           assert.ifError(err);
-
-          const returnedValues = row.toJSON().DateArray.map(Spanner.date);
-          assert.deepStrictEqual(returnedValues, values);
-
+          const {DateArray} = row.toJSON();
+          assert.deepStrictEqual(DateArray, values);
           done();
         });
       });

--- a/test/batch-transaction.ts
+++ b/test/batch-transaction.ts
@@ -42,9 +42,16 @@ const fakePfy = extend({}, pfy, {
   },
 });
 
+class FakeTimestamp {
+  static fromProto(proto: object) {
+    return new FakeTimestamp();
+  }
+}
+
 // tslint:disable-next-line no-any
 const fakeCodec: any = {
   encode: util.noop,
+  Timestamp: FakeTimestamp,
   Int() {},
   Float() {},
   SpannerDate() {},
@@ -79,11 +86,12 @@ describe('BatchTransaction', () => {
   const SESSION: any = {};
 
   before(() => {
-    BatchTransaction = proxyquire('../src/batch-transaction.js', {
-                         '@google-cloud/promisify': fakePfy,
-                         './codec.js': {codec: fakeCodec},
-                         './transaction.js': {Snapshot: FakeTransaction},
-                       }).BatchTransaction;
+    BatchTransaction =
+        proxyquire('../src/batch-transaction.js', {
+          '@google-cloud/promisify': fakePfy,
+          './codec.js': {codec: fakeCodec, Timestamp: FakeTimestamp},
+          './transaction.js': {Snapshot: FakeTransaction},
+        }).BatchTransaction;
   });
 
   beforeEach(() => {
@@ -219,7 +227,7 @@ describe('BatchTransaction', () => {
       });
 
       REQUEST.callsFake((_, callback) => callback(null, response));
-      sandbox.stub(fakeCodec, 'convertProtoTimestampToDate')
+      sandbox.stub(FakeTimestamp, 'fromProto')
           .withArgs(TIMESTAMP)
           .returns(fakeTimestamp);
 

--- a/test/batch-transaction.ts
+++ b/test/batch-transaction.ts
@@ -89,8 +89,9 @@ describe('BatchTransaction', () => {
   before(() => {
     BatchTransaction =
         proxyquire('../src/batch-transaction.js', {
+          '@google-cloud/precise-date': {PreciseDate: FakeTimestamp},
           '@google-cloud/promisify': fakePfy,
-          './codec.js': {codec: fakeCodec, Timestamp: FakeTimestamp},
+          './codec.js': {codec: fakeCodec},
           './transaction.js': {Snapshot: FakeTransaction},
         }).BatchTransaction;
   });

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -51,6 +51,17 @@ describe('codec', () => {
         assert.strictEqual(json, '1986-03-22');
       });
 
+      it('should default to the current local date', () => {
+        const date = new codec.SpannerDate();
+        const today = new Date();
+        const year = today.getFullYear();
+        const month = today.getMonth();
+        const day = today.getDate();
+        const expected = new codec.SpannerDate(year, month, day);
+
+        assert.deepStrictEqual(date, expected);
+      });
+
       it('should interpret ISO date strings as local time', () => {
         const date = new codec.SpannerDate('1986-03-22');
         const json = date.toJSON();

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -353,16 +353,6 @@ describe('codec', () => {
         timestamp = codec.Timestamp.fromProto(proto);
         assert.strictEqual(timestamp.getTime(), expectedTime);
       });
-
-      it('should left pad the nanoseconds if need be', () => {
-        const proto = {seconds: SECONDS, nanos: 4123};
-        const expectedMicros = 4;
-        const expectedNanos = 123;
-
-        timestamp = codec.Timestamp.fromProto(proto);
-        assert.strictEqual(timestamp.getMicroseconds(), expectedMicros);
-        assert.strictEqual(timestamp.getNanoseconds(), expectedNanos);
-      });
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -66,6 +66,7 @@ const fakePfy = extend({}, pfy, {
       'instance',
       'int',
       'operation',
+      'timestamp',
     ]);
   },
 });
@@ -261,6 +262,23 @@ describe('Spanner', () => {
       };
 
       const date = Spanner.date(value);
+      assert.strictEqual(date, customValue);
+    });
+  });
+
+  describe('timestamp', () => {
+    it('should create a Timestamp instance', () => {
+      const value = {};
+      const customValue = {};
+
+      fakeCodec.Timestamp = class {
+        constructor(value_) {
+          assert.strictEqual(value_, value);
+          return customValue;
+        }
+      };
+
+      const date = Spanner.timestamp(value);
       assert.strictEqual(date, customValue);
     });
   });

--- a/test/index.ts
+++ b/test/index.ts
@@ -22,6 +22,7 @@ import * as path from 'path';
 import * as proxyquire from 'proxyquire';
 import * as through from 'through2';
 import {util} from '@google-cloud/common-grpc';
+import {PreciseDate} from '@google-cloud/precise-date';
 import {replaceProjectIdToken} from '@google-cloud/projectify';
 import * as pfy from '@google-cloud/promisify';
 import * as sinon from 'sinon';
@@ -267,19 +268,9 @@ describe('Spanner', () => {
   });
 
   describe('timestamp', () => {
-    it('should create a Timestamp instance', () => {
-      const value = {};
-      const customValue = {};
-
-      fakeCodec.Timestamp = class {
-        constructor(value_) {
-          assert.strictEqual(value_, value);
-          return customValue;
-        }
-      };
-
-      const date = Spanner.timestamp(value);
-      assert.strictEqual(date, customValue);
+    it('should create a PreciseDate instance', () => {
+      const date = Spanner.timestamp();
+      assert(date instanceof PreciseDate);
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -252,7 +252,7 @@ describe('Spanner', () => {
 
   describe('date', () => {
     it('should create a SpannerDate instance', () => {
-      const value = {};
+      const value = '1999-1-1';
       const customValue = {};
 
       fakeCodec.SpannerDate = class {

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -169,12 +169,12 @@ describe('Transaction', () => {
       });
 
       it('should localize `readTimestamp` if present', done => {
-        const convertedTimestamp = new Date();
+        const convertedTimestamp = new codec.Timestamp();
         const readTimestamp = {};
         const response = Object.assign({readTimestamp}, BEGIN_RESPONSE);
 
         REQUEST.callsFake((_, callback) => callback(null, response));
-        sandbox.stub(codec, 'convertProtoTimestampToDate')
+        sandbox.stub(codec.Timestamp, 'fromProto')
             .withArgs(readTimestamp)
             .returns(convertedTimestamp);
 
@@ -697,31 +697,25 @@ describe('Transaction', () => {
       });
 
       it('should convert `minReadTimestamp` Date to proto', () => {
-        const fakeTimestamp = Date.now();
-        const fakeDate = new Date();
+        const fakeTimestamp = new codec.Timestamp();
 
-        sandbox.stub(fakeDate, 'getTime').returns(fakeTimestamp);
-        sandbox.stub(codec, 'convertMsToProtoTimestamp')
-            .withArgs(fakeTimestamp)
-            .returns(PROTO_TIMESTAMP);
+        sandbox.stub(fakeTimestamp, 'toProto').returns(PROTO_TIMESTAMP);
 
-        const options =
-            Snapshot.encodeTimestampBounds({minReadTimestamp: fakeDate});
+        const options = Snapshot.encodeTimestampBounds({
+          minReadTimestamp: fakeTimestamp,
+        });
 
         assert.strictEqual(options.minReadTimestamp, PROTO_TIMESTAMP);
       });
 
       it('should convert `readTimestamp` Date to proto', () => {
-        const fakeTimestamp = Date.now();
-        const fakeDate = new Date();
+        const fakeTimestamp = new codec.Timestamp();
 
-        sandbox.stub(fakeDate, 'getTime').returns(fakeTimestamp);
-        sandbox.stub(codec, 'convertMsToProtoTimestamp')
-            .withArgs(fakeTimestamp)
-            .returns(PROTO_TIMESTAMP);
+        sandbox.stub(fakeTimestamp, 'toProto').returns(PROTO_TIMESTAMP);
 
-        const options =
-            Snapshot.encodeTimestampBounds({readTimestamp: fakeDate});
+        const options = Snapshot.encodeTimestampBounds({
+          readTimestamp: fakeTimestamp,
+        });
 
         assert.strictEqual(options.readTimestamp, PROTO_TIMESTAMP);
       });
@@ -1014,9 +1008,9 @@ describe('Transaction', () => {
         const requestStub = sandbox.stub(transaction, 'request');
 
         const fakeTimestamp = {};
-        const formattedTimestamp = new Date();
+        const formattedTimestamp = new codec.Timestamp();
 
-        sandbox.stub(codec, 'convertProtoTimestampToDate')
+        sandbox.stub(codec.Timestamp, 'fromProto')
             .withArgs(fakeTimestamp)
             .returns(formattedTimestamp);
 

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -169,18 +169,15 @@ describe('Transaction', () => {
       });
 
       it('should localize `readTimestamp` if present', done => {
-        const convertedTimestamp = new codec.Timestamp();
-        const readTimestamp = {};
+        const expectedTimestamp = new codec.Timestamp(0);
+        const readTimestamp = {seconds: 0, nanos: 0};
         const response = Object.assign({readTimestamp}, BEGIN_RESPONSE);
 
         REQUEST.callsFake((_, callback) => callback(null, response));
-        sandbox.stub(codec.Timestamp, 'fromProto')
-            .withArgs(readTimestamp)
-            .returns(convertedTimestamp);
 
         snapshot.begin(err => {
           assert.ifError(err);
-          assert.strictEqual(snapshot.readTimestamp, convertedTimestamp);
+          assert.deepStrictEqual(snapshot.readTimestamp, expectedTimestamp);
           assert.strictEqual(snapshot.readTimestampProto, readTimestamp);
           done();
         });
@@ -1007,19 +1004,15 @@ describe('Transaction', () => {
       it('should set the `commitTimestamp` if in response', () => {
         const requestStub = sandbox.stub(transaction, 'request');
 
-        const fakeTimestamp = {};
-        const formattedTimestamp = new codec.Timestamp();
-
-        sandbox.stub(codec.Timestamp, 'fromProto')
-            .withArgs(fakeTimestamp)
-            .returns(formattedTimestamp);
+        const expectedTimestamp = new codec.Timestamp(0);
+        const fakeTimestamp = {seconds: 0, nanos: 0};
 
         transaction.commit(() => {});
 
         const requestCallback = requestStub.lastCall.args[1];
         requestCallback(null, {commitTimestamp: fakeTimestamp});
 
-        assert.strictEqual(transaction.commitTimestamp, formattedTimestamp);
+        assert.deepStrictEqual(transaction.commitTimestamp, expectedTimestamp);
         assert.strictEqual(transaction.commitTimestampProto, fakeTimestamp);
       });
 

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {PreciseDate} from '@google-cloud/precise-date';
 import * as assert from 'assert';
 import {EventEmitter} from 'events';
 import {common as p} from 'protobufjs';
@@ -169,7 +170,7 @@ describe('Transaction', () => {
       });
 
       it('should localize `readTimestamp` if present', done => {
-        const expectedTimestamp = new codec.Timestamp(0);
+        const expectedTimestamp = new PreciseDate(0);
         const readTimestamp = {seconds: 0, nanos: 0};
         const response = Object.assign({readTimestamp}, BEGIN_RESPONSE);
 
@@ -694,9 +695,9 @@ describe('Transaction', () => {
       });
 
       it('should convert `minReadTimestamp` Date to proto', () => {
-        const fakeTimestamp = new codec.Timestamp();
+        const fakeTimestamp = new PreciseDate();
 
-        sandbox.stub(fakeTimestamp, 'toProto').returns(PROTO_TIMESTAMP);
+        sandbox.stub(fakeTimestamp, 'toStruct').returns(PROTO_TIMESTAMP);
 
         const options = Snapshot.encodeTimestampBounds({
           minReadTimestamp: fakeTimestamp,
@@ -706,9 +707,9 @@ describe('Transaction', () => {
       });
 
       it('should convert `readTimestamp` Date to proto', () => {
-        const fakeTimestamp = new codec.Timestamp();
+        const fakeTimestamp = new PreciseDate();
 
-        sandbox.stub(fakeTimestamp, 'toProto').returns(PROTO_TIMESTAMP);
+        sandbox.stub(fakeTimestamp, 'toStruct').returns(PROTO_TIMESTAMP);
 
         const options = Snapshot.encodeTimestampBounds({
           readTimestamp: fakeTimestamp,
@@ -1004,7 +1005,7 @@ describe('Transaction', () => {
       it('should set the `commitTimestamp` if in response', () => {
         const requestStub = sandbox.stub(transaction, 'request');
 
-        const expectedTimestamp = new codec.Timestamp(0);
+        const expectedTimestamp = new PreciseDate(0);
         const fakeTimestamp = {seconds: 0, nanos: 0};
 
         transaction.commit(() => {});


### PR DESCRIPTION
Fixes #494
Fixes #526 
Closes #529

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

---

### Timestamps

This PR brings a new class for dealing with Cloud Spanner Timestamps. Previously we would return Date objects, but these were only good for millisecond precision. Since timestamps can come from the API in the form of either an ISO string or a protobuf timestamp, the class can handle either allowing users to easily use commit and read timestamps in queries, as well as result timestamps in snapshot bounds.

With ISO string.

```js
const timestamp = Spanner.timestamp('2019-02-08T10:34:29.481145231Z');
```

With protobuf timestamp.

```js
const [seconds, nanos] = process.hrtime();
const timestamp = Spanner.timestamp({seconds, nanos});
```

The Timestamp class extends the native Date class, so users can perform basic operations to the Timestamp if they choose.

```js
timestamp.setNanoseconds(10);

console.log(timestamp.toISOString());
// => "2019-02-08T10:34:29.481145010Z"
```

It will also accept any single value that the Date object would accept in scenarios where micro-precision isn't important.

```js
const timestamp = Spanner.timestamp(Date.now());

console.log(timestamp.toISOString());
// => "1985-06-03T22:37:14.312Z"
```

### SpannerDate

To keep dealing with date times consistent, I've also refactored the SpannerDate class to extend the native Date class. It accepts any single value that the Date class would also accept.

```js
const date = Spanner.date('6-3-1985');

console.log(date.toISOString());
// => "1985-06-03T00:00:00.000Z"

console.log(date.toJSON());
// => "1985-06-03"
```