### PR TITLE
fix(docs): add google.type namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,9 @@ export interface SpannerOptions extends GrpcClientOptions {
  * @namespace google.iam.v1
  */
 /**
+ * @namespace google.type
+ */
+/**
  * @namespace google.protobuf
  */
 /**


### PR DESCRIPTION
Fixes #604.

nodejs-spanner is not compiling for me, @JustinBeckwith is this being
looked at?