### PR TITLE
fix(types): import request types from teeny-request

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -27,7 +27,7 @@ import {promisify, promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import * as extend from 'extend';
 import * as is from 'is';
-import * as r from 'request';
+import * as r from 'teeny-request';
 import * as streamEvents from 'stream-events';
 import * as through from 'through2';
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -24,7 +24,7 @@ import {ServiceObject} from '@google-cloud/common-grpc';
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as is from 'is';
-import * as r from 'request';
+import * as r from 'teeny-request';
 import {
   Snapshot,
   Transaction,


### PR DESCRIPTION
Looks like the compile script is borked from a type change.
