### PR TITLE
feat: use JSON proto for transaction-runner

### DIFF
--- a/protos/protos.json
+++ b/protos/protos.json
@@ -2,6 +2,1172 @@
   "nested": {
     "google": {
       "nested": {
+        "protobuf": {
+          "options": {
+            "go_package": "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor",
+            "java_package": "com.google.protobuf",
+            "java_outer_classname": "DescriptorProtos",
+            "csharp_namespace": "Google.Protobuf.Reflection",
+            "objc_class_prefix": "GPB",
+            "cc_enable_arenas": true,
+            "optimize_for": "SPEED"
+          },
+          "nested": {
+            "Duration": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "FileDescriptorSet": {
+              "fields": {
+                "file": {
+                  "rule": "repeated",
+                  "type": "FileDescriptorProto",
+                  "id": 1
+                }
+              }
+            },
+            "FileDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "package": {
+                  "type": "string",
+                  "id": 2
+                },
+                "dependency": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 3
+                },
+                "publicDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 10,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "weakDependency": {
+                  "rule": "repeated",
+                  "type": "int32",
+                  "id": 11,
+                  "options": {
+                    "packed": false
+                  }
+                },
+                "messageType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 4
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 5
+                },
+                "service": {
+                  "rule": "repeated",
+                  "type": "ServiceDescriptorProto",
+                  "id": 6
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 7
+                },
+                "options": {
+                  "type": "FileOptions",
+                  "id": 8
+                },
+                "sourceCodeInfo": {
+                  "type": "SourceCodeInfo",
+                  "id": 9
+                },
+                "syntax": {
+                  "type": "string",
+                  "id": 12
+                }
+              }
+            },
+            "DescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "field": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 2
+                },
+                "extension": {
+                  "rule": "repeated",
+                  "type": "FieldDescriptorProto",
+                  "id": 6
+                },
+                "nestedType": {
+                  "rule": "repeated",
+                  "type": "DescriptorProto",
+                  "id": 3
+                },
+                "enumType": {
+                  "rule": "repeated",
+                  "type": "EnumDescriptorProto",
+                  "id": 4
+                },
+                "extensionRange": {
+                  "rule": "repeated",
+                  "type": "ExtensionRange",
+                  "id": 5
+                },
+                "oneofDecl": {
+                  "rule": "repeated",
+                  "type": "OneofDescriptorProto",
+                  "id": 8
+                },
+                "options": {
+                  "type": "MessageOptions",
+                  "id": 7
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "ReservedRange",
+                  "id": 9
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 10
+                }
+              },
+              "nested": {
+                "ExtensionRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "options": {
+                      "type": "ExtensionRangeOptions",
+                      "id": 3
+                    }
+                  }
+                },
+                "ReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "ExtensionRangeOptions": {
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "FieldDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 3
+                },
+                "label": {
+                  "type": "Label",
+                  "id": 4
+                },
+                "type": {
+                  "type": "Type",
+                  "id": 5
+                },
+                "typeName": {
+                  "type": "string",
+                  "id": 6
+                },
+                "extendee": {
+                  "type": "string",
+                  "id": 2
+                },
+                "defaultValue": {
+                  "type": "string",
+                  "id": 7
+                },
+                "oneofIndex": {
+                  "type": "int32",
+                  "id": 9
+                },
+                "jsonName": {
+                  "type": "string",
+                  "id": 10
+                },
+                "options": {
+                  "type": "FieldOptions",
+                  "id": 8
+                }
+              },
+              "nested": {
+                "Type": {
+                  "values": {
+                    "TYPE_DOUBLE": 1,
+                    "TYPE_FLOAT": 2,
+                    "TYPE_INT64": 3,
+                    "TYPE_UINT64": 4,
+                    "TYPE_INT32": 5,
+                    "TYPE_FIXED64": 6,
+                    "TYPE_FIXED32": 7,
+                    "TYPE_BOOL": 8,
+                    "TYPE_STRING": 9,
+                    "TYPE_GROUP": 10,
+                    "TYPE_MESSAGE": 11,
+                    "TYPE_BYTES": 12,
+                    "TYPE_UINT32": 13,
+                    "TYPE_ENUM": 14,
+                    "TYPE_SFIXED32": 15,
+                    "TYPE_SFIXED64": 16,
+                    "TYPE_SINT32": 17,
+                    "TYPE_SINT64": 18
+                  }
+                },
+                "Label": {
+                  "values": {
+                    "LABEL_OPTIONAL": 1,
+                    "LABEL_REQUIRED": 2,
+                    "LABEL_REPEATED": 3
+                  }
+                }
+              }
+            },
+            "OneofDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "options": {
+                  "type": "OneofOptions",
+                  "id": 2
+                }
+              }
+            },
+            "EnumDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "rule": "repeated",
+                  "type": "EnumValueDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumOptions",
+                  "id": 3
+                },
+                "reservedRange": {
+                  "rule": "repeated",
+                  "type": "EnumReservedRange",
+                  "id": 4
+                },
+                "reservedName": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 5
+                }
+              },
+              "nested": {
+                "EnumReservedRange": {
+                  "fields": {
+                    "start": {
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "EnumValueDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "number": {
+                  "type": "int32",
+                  "id": 2
+                },
+                "options": {
+                  "type": "EnumValueOptions",
+                  "id": 3
+                }
+              }
+            },
+            "ServiceDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "method": {
+                  "rule": "repeated",
+                  "type": "MethodDescriptorProto",
+                  "id": 2
+                },
+                "options": {
+                  "type": "ServiceOptions",
+                  "id": 3
+                }
+              }
+            },
+            "MethodDescriptorProto": {
+              "fields": {
+                "name": {
+                  "type": "string",
+                  "id": 1
+                },
+                "inputType": {
+                  "type": "string",
+                  "id": 2
+                },
+                "outputType": {
+                  "type": "string",
+                  "id": 3
+                },
+                "options": {
+                  "type": "MethodOptions",
+                  "id": 4
+                },
+                "clientStreaming": {
+                  "type": "bool",
+                  "id": 5,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "serverStreaming": {
+                  "type": "bool",
+                  "id": 6,
+                  "options": {
+                    "default": false
+                  }
+                }
+              }
+            },
+            "FileOptions": {
+              "fields": {
+                "javaPackage": {
+                  "type": "string",
+                  "id": 1
+                },
+                "javaOuterClassname": {
+                  "type": "string",
+                  "id": 8
+                },
+                "javaMultipleFiles": {
+                  "type": "bool",
+                  "id": 10,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "javaGenerateEqualsAndHash": {
+                  "type": "bool",
+                  "id": 20,
+                  "options": {
+                    "deprecated": true
+                  }
+                },
+                "javaStringCheckUtf8": {
+                  "type": "bool",
+                  "id": 27,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "optimizeFor": {
+                  "type": "OptimizeMode",
+                  "id": 9,
+                  "options": {
+                    "default": "SPEED"
+                  }
+                },
+                "goPackage": {
+                  "type": "string",
+                  "id": 11
+                },
+                "ccGenericServices": {
+                  "type": "bool",
+                  "id": 16,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "javaGenericServices": {
+                  "type": "bool",
+                  "id": 17,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "pyGenericServices": {
+                  "type": "bool",
+                  "id": 18,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "phpGenericServices": {
+                  "type": "bool",
+                  "id": 42,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 23,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "ccEnableArenas": {
+                  "type": "bool",
+                  "id": 31,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "objcClassPrefix": {
+                  "type": "string",
+                  "id": 36
+                },
+                "csharpNamespace": {
+                  "type": "string",
+                  "id": 37
+                },
+                "swiftPrefix": {
+                  "type": "string",
+                  "id": 39
+                },
+                "phpClassPrefix": {
+                  "type": "string",
+                  "id": 40
+                },
+                "phpNamespace": {
+                  "type": "string",
+                  "id": 41
+                },
+                "phpMetadataNamespace": {
+                  "type": "string",
+                  "id": 44
+                },
+                "rubyPackage": {
+                  "type": "string",
+                  "id": 45
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  38,
+                  38
+                ]
+              ],
+              "nested": {
+                "OptimizeMode": {
+                  "values": {
+                    "SPEED": 1,
+                    "CODE_SIZE": 2,
+                    "LITE_RUNTIME": 3
+                  }
+                }
+              }
+            },
+            "MessageOptions": {
+              "fields": {
+                "messageSetWireFormat": {
+                  "type": "bool",
+                  "id": 1,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "noStandardDescriptorAccessor": {
+                  "type": "bool",
+                  "id": 2,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "mapEntry": {
+                  "type": "bool",
+                  "id": 7
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  8,
+                  8
+                ],
+                [
+                  9,
+                  9
+                ]
+              ]
+            },
+            "FieldOptions": {
+              "fields": {
+                "ctype": {
+                  "type": "CType",
+                  "id": 1,
+                  "options": {
+                    "default": "STRING"
+                  }
+                },
+                "packed": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "jstype": {
+                  "type": "JSType",
+                  "id": 6,
+                  "options": {
+                    "default": "JS_NORMAL"
+                  }
+                },
+                "lazy": {
+                  "type": "bool",
+                  "id": 5,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "weak": {
+                  "type": "bool",
+                  "id": 10,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  4,
+                  4
+                ]
+              ],
+              "nested": {
+                "CType": {
+                  "values": {
+                    "STRING": 0,
+                    "CORD": 1,
+                    "STRING_PIECE": 2
+                  }
+                },
+                "JSType": {
+                  "values": {
+                    "JS_NORMAL": 0,
+                    "JS_STRING": 1,
+                    "JS_NUMBER": 2
+                  }
+                }
+              }
+            },
+            "OneofOptions": {
+              "fields": {
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "EnumOptions": {
+              "fields": {
+                "allowAlias": {
+                  "type": "bool",
+                  "id": 2
+                },
+                "deprecated": {
+                  "type": "bool",
+                  "id": 3,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "reserved": [
+                [
+                  5,
+                  5
+                ]
+              ]
+            },
+            "EnumValueOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 1,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "ServiceOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ]
+            },
+            "MethodOptions": {
+              "fields": {
+                "deprecated": {
+                  "type": "bool",
+                  "id": 33,
+                  "options": {
+                    "default": false
+                  }
+                },
+                "idempotencyLevel": {
+                  "type": "IdempotencyLevel",
+                  "id": 34,
+                  "options": {
+                    "default": "IDEMPOTENCY_UNKNOWN"
+                  }
+                },
+                "uninterpretedOption": {
+                  "rule": "repeated",
+                  "type": "UninterpretedOption",
+                  "id": 999
+                }
+              },
+              "extensions": [
+                [
+                  1000,
+                  536870911
+                ]
+              ],
+              "nested": {
+                "IdempotencyLevel": {
+                  "values": {
+                    "IDEMPOTENCY_UNKNOWN": 0,
+                    "NO_SIDE_EFFECTS": 1,
+                    "IDEMPOTENT": 2
+                  }
+                }
+              }
+            },
+            "UninterpretedOption": {
+              "fields": {
+                "name": {
+                  "rule": "repeated",
+                  "type": "NamePart",
+                  "id": 2
+                },
+                "identifierValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "positiveIntValue": {
+                  "type": "uint64",
+                  "id": 4
+                },
+                "negativeIntValue": {
+                  "type": "int64",
+                  "id": 5
+                },
+                "doubleValue": {
+                  "type": "double",
+                  "id": 6
+                },
+                "stringValue": {
+                  "type": "bytes",
+                  "id": 7
+                },
+                "aggregateValue": {
+                  "type": "string",
+                  "id": 8
+                }
+              },
+              "nested": {
+                "NamePart": {
+                  "fields": {
+                    "namePart": {
+                      "rule": "required",
+                      "type": "string",
+                      "id": 1
+                    },
+                    "isExtension": {
+                      "rule": "required",
+                      "type": "bool",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "SourceCodeInfo": {
+              "fields": {
+                "location": {
+                  "rule": "repeated",
+                  "type": "Location",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Location": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "span": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 2
+                    },
+                    "leadingComments": {
+                      "type": "string",
+                      "id": 3
+                    },
+                    "trailingComments": {
+                      "type": "string",
+                      "id": 4
+                    },
+                    "leadingDetachedComments": {
+                      "rule": "repeated",
+                      "type": "string",
+                      "id": 6
+                    }
+                  }
+                }
+              }
+            },
+            "GeneratedCodeInfo": {
+              "fields": {
+                "annotation": {
+                  "rule": "repeated",
+                  "type": "Annotation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Annotation": {
+                  "fields": {
+                    "path": {
+                      "rule": "repeated",
+                      "type": "int32",
+                      "id": 1
+                    },
+                    "sourceFile": {
+                      "type": "string",
+                      "id": 2
+                    },
+                    "begin": {
+                      "type": "int32",
+                      "id": 3
+                    },
+                    "end": {
+                      "type": "int32",
+                      "id": 4
+                    }
+                  }
+                }
+              }
+            },
+            "Any": {
+              "fields": {
+                "type_url": {
+                  "type": "string",
+                  "id": 1
+                },
+                "value": {
+                  "type": "bytes",
+                  "id": 2
+                }
+              }
+            },
+            "Empty": {
+              "fields": {}
+            },
+            "Timestamp": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
+            "FieldMask": {
+              "fields": {
+                "paths": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 1
+                }
+              }
+            },
+            "Struct": {
+              "fields": {
+                "fields": {
+                  "keyType": "string",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            },
+            "Value": {
+              "oneofs": {
+                "kind": {
+                  "oneof": [
+                    "nullValue",
+                    "numberValue",
+                    "stringValue",
+                    "boolValue",
+                    "structValue",
+                    "listValue"
+                  ]
+                }
+              },
+              "fields": {
+                "nullValue": {
+                  "type": "NullValue",
+                  "id": 1
+                },
+                "numberValue": {
+                  "type": "double",
+                  "id": 2
+                },
+                "stringValue": {
+                  "type": "string",
+                  "id": 3
+                },
+                "boolValue": {
+                  "type": "bool",
+                  "id": 4
+                },
+                "structValue": {
+                  "type": "Struct",
+                  "id": 5
+                },
+                "listValue": {
+                  "type": "ListValue",
+                  "id": 6
+                }
+              }
+            },
+            "NullValue": {
+              "values": {
+                "NULL_VALUE": 0
+              }
+            },
+            "ListValue": {
+              "fields": {
+                "values": {
+                  "rule": "repeated",
+                  "type": "Value",
+                  "id": 1
+                }
+              }
+            }
+          }
+        },
+        "rpc": {
+          "options": {
+            "go_package": "google.golang.org/genproto/googleapis/rpc/status;status",
+            "java_multiple_files": true,
+            "java_outer_classname": "StatusProto",
+            "java_package": "com.google.rpc",
+            "objc_class_prefix": "RPC"
+          },
+          "nested": {
+            "RetryInfo": {
+              "fields": {
+                "retryDelay": {
+                  "type": "google.protobuf.Duration",
+                  "id": 1
+                }
+              }
+            },
+            "DebugInfo": {
+              "fields": {
+                "stackEntries": {
+                  "rule": "repeated",
+                  "type": "string",
+                  "id": 1
+                },
+                "detail": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "QuotaFailure": {
+              "fields": {
+                "violations": {
+                  "rule": "repeated",
+                  "type": "Violation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Violation": {
+                  "fields": {
+                    "subject": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "BadRequest": {
+              "fields": {
+                "fieldViolations": {
+                  "rule": "repeated",
+                  "type": "FieldViolation",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "FieldViolation": {
+                  "fields": {
+                    "field": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "description": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "RequestInfo": {
+              "fields": {
+                "requestId": {
+                  "type": "string",
+                  "id": 1
+                },
+                "servingData": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "ResourceInfo": {
+              "fields": {
+                "resourceType": {
+                  "type": "string",
+                  "id": 1
+                },
+                "resourceName": {
+                  "type": "string",
+                  "id": 2
+                },
+                "owner": {
+                  "type": "string",
+                  "id": 3
+                },
+                "description": {
+                  "type": "string",
+                  "id": 4
+                }
+              }
+            },
+            "Help": {
+              "fields": {
+                "links": {
+                  "rule": "repeated",
+                  "type": "Link",
+                  "id": 1
+                }
+              },
+              "nested": {
+                "Link": {
+                  "fields": {
+                    "description": {
+                      "type": "string",
+                      "id": 1
+                    },
+                    "url": {
+                      "type": "string",
+                      "id": 2
+                    }
+                  }
+                }
+              }
+            },
+            "LocalizedMessage": {
+              "fields": {
+                "locale": {
+                  "type": "string",
+                  "id": 1
+                },
+                "message": {
+                  "type": "string",
+                  "id": 2
+                }
+              }
+            },
+            "Status": {
+              "fields": {
+                "code": {
+                  "type": "int32",
+                  "id": 1
+                },
+                "message": {
+                  "type": "string",
+                  "id": 2
+                },
+                "details": {
+                  "rule": "repeated",
+                  "type": "google.protobuf.Any",
+                  "id": 3
+                }
+              }
+            }
+          }
+        },
         "spanner": {
           "nested": {
             "admin": {
@@ -1641,1010 +2807,6 @@
             }
           }
         },
-        "protobuf": {
-          "options": {
-            "go_package": "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor",
-            "java_package": "com.google.protobuf",
-            "java_outer_classname": "DescriptorProtos",
-            "csharp_namespace": "Google.Protobuf.Reflection",
-            "objc_class_prefix": "GPB",
-            "cc_enable_arenas": true,
-            "optimize_for": "SPEED"
-          },
-          "nested": {
-            "FileDescriptorSet": {
-              "fields": {
-                "file": {
-                  "rule": "repeated",
-                  "type": "FileDescriptorProto",
-                  "id": 1
-                }
-              }
-            },
-            "FileDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "package": {
-                  "type": "string",
-                  "id": 2
-                },
-                "dependency": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 3
-                },
-                "publicDependency": {
-                  "rule": "repeated",
-                  "type": "int32",
-                  "id": 10,
-                  "options": {
-                    "packed": false
-                  }
-                },
-                "weakDependency": {
-                  "rule": "repeated",
-                  "type": "int32",
-                  "id": 11,
-                  "options": {
-                    "packed": false
-                  }
-                },
-                "messageType": {
-                  "rule": "repeated",
-                  "type": "DescriptorProto",
-                  "id": 4
-                },
-                "enumType": {
-                  "rule": "repeated",
-                  "type": "EnumDescriptorProto",
-                  "id": 5
-                },
-                "service": {
-                  "rule": "repeated",
-                  "type": "ServiceDescriptorProto",
-                  "id": 6
-                },
-                "extension": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 7
-                },
-                "options": {
-                  "type": "FileOptions",
-                  "id": 8
-                },
-                "sourceCodeInfo": {
-                  "type": "SourceCodeInfo",
-                  "id": 9
-                },
-                "syntax": {
-                  "type": "string",
-                  "id": 12
-                }
-              }
-            },
-            "DescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "field": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 2
-                },
-                "extension": {
-                  "rule": "repeated",
-                  "type": "FieldDescriptorProto",
-                  "id": 6
-                },
-                "nestedType": {
-                  "rule": "repeated",
-                  "type": "DescriptorProto",
-                  "id": 3
-                },
-                "enumType": {
-                  "rule": "repeated",
-                  "type": "EnumDescriptorProto",
-                  "id": 4
-                },
-                "extensionRange": {
-                  "rule": "repeated",
-                  "type": "ExtensionRange",
-                  "id": 5
-                },
-                "oneofDecl": {
-                  "rule": "repeated",
-                  "type": "OneofDescriptorProto",
-                  "id": 8
-                },
-                "options": {
-                  "type": "MessageOptions",
-                  "id": 7
-                },
-                "reservedRange": {
-                  "rule": "repeated",
-                  "type": "ReservedRange",
-                  "id": 9
-                },
-                "reservedName": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 10
-                }
-              },
-              "nested": {
-                "ExtensionRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    },
-                    "options": {
-                      "type": "ExtensionRangeOptions",
-                      "id": 3
-                    }
-                  }
-                },
-                "ReservedRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "ExtensionRangeOptions": {
-              "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "FieldDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "number": {
-                  "type": "int32",
-                  "id": 3
-                },
-                "label": {
-                  "type": "Label",
-                  "id": 4
-                },
-                "type": {
-                  "type": "Type",
-                  "id": 5
-                },
-                "typeName": {
-                  "type": "string",
-                  "id": 6
-                },
-                "extendee": {
-                  "type": "string",
-                  "id": 2
-                },
-                "defaultValue": {
-                  "type": "string",
-                  "id": 7
-                },
-                "oneofIndex": {
-                  "type": "int32",
-                  "id": 9
-                },
-                "jsonName": {
-                  "type": "string",
-                  "id": 10
-                },
-                "options": {
-                  "type": "FieldOptions",
-                  "id": 8
-                }
-              },
-              "nested": {
-                "Type": {
-                  "values": {
-                    "TYPE_DOUBLE": 1,
-                    "TYPE_FLOAT": 2,
-                    "TYPE_INT64": 3,
-                    "TYPE_UINT64": 4,
-                    "TYPE_INT32": 5,
-                    "TYPE_FIXED64": 6,
-                    "TYPE_FIXED32": 7,
-                    "TYPE_BOOL": 8,
-                    "TYPE_STRING": 9,
-                    "TYPE_GROUP": 10,
-                    "TYPE_MESSAGE": 11,
-                    "TYPE_BYTES": 12,
-                    "TYPE_UINT32": 13,
-                    "TYPE_ENUM": 14,
-                    "TYPE_SFIXED32": 15,
-                    "TYPE_SFIXED64": 16,
-                    "TYPE_SINT32": 17,
-                    "TYPE_SINT64": 18
-                  }
-                },
-                "Label": {
-                  "values": {
-                    "LABEL_OPTIONAL": 1,
-                    "LABEL_REQUIRED": 2,
-                    "LABEL_REPEATED": 3
-                  }
-                }
-              }
-            },
-            "OneofDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "options": {
-                  "type": "OneofOptions",
-                  "id": 2
-                }
-              }
-            },
-            "EnumDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "value": {
-                  "rule": "repeated",
-                  "type": "EnumValueDescriptorProto",
-                  "id": 2
-                },
-                "options": {
-                  "type": "EnumOptions",
-                  "id": 3
-                },
-                "reservedRange": {
-                  "rule": "repeated",
-                  "type": "EnumReservedRange",
-                  "id": 4
-                },
-                "reservedName": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 5
-                }
-              },
-              "nested": {
-                "EnumReservedRange": {
-                  "fields": {
-                    "start": {
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "EnumValueDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "number": {
-                  "type": "int32",
-                  "id": 2
-                },
-                "options": {
-                  "type": "EnumValueOptions",
-                  "id": 3
-                }
-              }
-            },
-            "ServiceDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "method": {
-                  "rule": "repeated",
-                  "type": "MethodDescriptorProto",
-                  "id": 2
-                },
-                "options": {
-                  "type": "ServiceOptions",
-                  "id": 3
-                }
-              }
-            },
-            "MethodDescriptorProto": {
-              "fields": {
-                "name": {
-                  "type": "string",
-                  "id": 1
-                },
-                "inputType": {
-                  "type": "string",
-                  "id": 2
-                },
-                "outputType": {
-                  "type": "string",
-                  "id": 3
-                },
-                "options": {
-                  "type": "MethodOptions",
-                  "id": 4
-                },
-                "clientStreaming": {
-                  "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "serverStreaming": {
-                  "type": "bool",
-                  "id": 6,
-                  "options": {
-                    "default": false
-                  }
-                }
-              }
-            },
-            "FileOptions": {
-              "fields": {
-                "javaPackage": {
-                  "type": "string",
-                  "id": 1
-                },
-                "javaOuterClassname": {
-                  "type": "string",
-                  "id": 8
-                },
-                "javaMultipleFiles": {
-                  "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "javaGenerateEqualsAndHash": {
-                  "type": "bool",
-                  "id": 20,
-                  "options": {
-                    "deprecated": true
-                  }
-                },
-                "javaStringCheckUtf8": {
-                  "type": "bool",
-                  "id": 27,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "optimizeFor": {
-                  "type": "OptimizeMode",
-                  "id": 9,
-                  "options": {
-                    "default": "SPEED"
-                  }
-                },
-                "goPackage": {
-                  "type": "string",
-                  "id": 11
-                },
-                "ccGenericServices": {
-                  "type": "bool",
-                  "id": 16,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "javaGenericServices": {
-                  "type": "bool",
-                  "id": 17,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "pyGenericServices": {
-                  "type": "bool",
-                  "id": 18,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "phpGenericServices": {
-                  "type": "bool",
-                  "id": 42,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 23,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "ccEnableArenas": {
-                  "type": "bool",
-                  "id": 31,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "objcClassPrefix": {
-                  "type": "string",
-                  "id": 36
-                },
-                "csharpNamespace": {
-                  "type": "string",
-                  "id": 37
-                },
-                "swiftPrefix": {
-                  "type": "string",
-                  "id": 39
-                },
-                "phpClassPrefix": {
-                  "type": "string",
-                  "id": 40
-                },
-                "phpNamespace": {
-                  "type": "string",
-                  "id": 41
-                },
-                "phpMetadataNamespace": {
-                  "type": "string",
-                  "id": 44
-                },
-                "rubyPackage": {
-                  "type": "string",
-                  "id": 45
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  38,
-                  38
-                ]
-              ],
-              "nested": {
-                "OptimizeMode": {
-                  "values": {
-                    "SPEED": 1,
-                    "CODE_SIZE": 2,
-                    "LITE_RUNTIME": 3
-                  }
-                }
-              }
-            },
-            "MessageOptions": {
-              "fields": {
-                "messageSetWireFormat": {
-                  "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "noStandardDescriptorAccessor": {
-                  "type": "bool",
-                  "id": 2,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "mapEntry": {
-                  "type": "bool",
-                  "id": 7
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  8,
-                  8
-                ],
-                [
-                  9,
-                  9
-                ]
-              ]
-            },
-            "FieldOptions": {
-              "fields": {
-                "ctype": {
-                  "type": "CType",
-                  "id": 1,
-                  "options": {
-                    "default": "STRING"
-                  }
-                },
-                "packed": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "jstype": {
-                  "type": "JSType",
-                  "id": 6,
-                  "options": {
-                    "default": "JS_NORMAL"
-                  }
-                },
-                "lazy": {
-                  "type": "bool",
-                  "id": 5,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "weak": {
-                  "type": "bool",
-                  "id": 10,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  4,
-                  4
-                ]
-              ],
-              "nested": {
-                "CType": {
-                  "values": {
-                    "STRING": 0,
-                    "CORD": 1,
-                    "STRING_PIECE": 2
-                  }
-                },
-                "JSType": {
-                  "values": {
-                    "JS_NORMAL": 0,
-                    "JS_STRING": 1,
-                    "JS_NUMBER": 2
-                  }
-                }
-              }
-            },
-            "OneofOptions": {
-              "fields": {
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "EnumOptions": {
-              "fields": {
-                "allowAlias": {
-                  "type": "bool",
-                  "id": 2
-                },
-                "deprecated": {
-                  "type": "bool",
-                  "id": 3,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "reserved": [
-                [
-                  5,
-                  5
-                ]
-              ]
-            },
-            "EnumValueOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 1,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "ServiceOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ]
-            },
-            "MethodOptions": {
-              "fields": {
-                "deprecated": {
-                  "type": "bool",
-                  "id": 33,
-                  "options": {
-                    "default": false
-                  }
-                },
-                "idempotencyLevel": {
-                  "type": "IdempotencyLevel",
-                  "id": 34,
-                  "options": {
-                    "default": "IDEMPOTENCY_UNKNOWN"
-                  }
-                },
-                "uninterpretedOption": {
-                  "rule": "repeated",
-                  "type": "UninterpretedOption",
-                  "id": 999
-                }
-              },
-              "extensions": [
-                [
-                  1000,
-                  536870911
-                ]
-              ],
-              "nested": {
-                "IdempotencyLevel": {
-                  "values": {
-                    "IDEMPOTENCY_UNKNOWN": 0,
-                    "NO_SIDE_EFFECTS": 1,
-                    "IDEMPOTENT": 2
-                  }
-                }
-              }
-            },
-            "UninterpretedOption": {
-              "fields": {
-                "name": {
-                  "rule": "repeated",
-                  "type": "NamePart",
-                  "id": 2
-                },
-                "identifierValue": {
-                  "type": "string",
-                  "id": 3
-                },
-                "positiveIntValue": {
-                  "type": "uint64",
-                  "id": 4
-                },
-                "negativeIntValue": {
-                  "type": "int64",
-                  "id": 5
-                },
-                "doubleValue": {
-                  "type": "double",
-                  "id": 6
-                },
-                "stringValue": {
-                  "type": "bytes",
-                  "id": 7
-                },
-                "aggregateValue": {
-                  "type": "string",
-                  "id": 8
-                }
-              },
-              "nested": {
-                "NamePart": {
-                  "fields": {
-                    "namePart": {
-                      "rule": "required",
-                      "type": "string",
-                      "id": 1
-                    },
-                    "isExtension": {
-                      "rule": "required",
-                      "type": "bool",
-                      "id": 2
-                    }
-                  }
-                }
-              }
-            },
-            "SourceCodeInfo": {
-              "fields": {
-                "location": {
-                  "rule": "repeated",
-                  "type": "Location",
-                  "id": 1
-                }
-              },
-              "nested": {
-                "Location": {
-                  "fields": {
-                    "path": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "span": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 2
-                    },
-                    "leadingComments": {
-                      "type": "string",
-                      "id": 3
-                    },
-                    "trailingComments": {
-                      "type": "string",
-                      "id": 4
-                    },
-                    "leadingDetachedComments": {
-                      "rule": "repeated",
-                      "type": "string",
-                      "id": 6
-                    }
-                  }
-                }
-              }
-            },
-            "GeneratedCodeInfo": {
-              "fields": {
-                "annotation": {
-                  "rule": "repeated",
-                  "type": "Annotation",
-                  "id": 1
-                }
-              },
-              "nested": {
-                "Annotation": {
-                  "fields": {
-                    "path": {
-                      "rule": "repeated",
-                      "type": "int32",
-                      "id": 1
-                    },
-                    "sourceFile": {
-                      "type": "string",
-                      "id": 2
-                    },
-                    "begin": {
-                      "type": "int32",
-                      "id": 3
-                    },
-                    "end": {
-                      "type": "int32",
-                      "id": 4
-                    }
-                  }
-                }
-              }
-            },
-            "Any": {
-              "fields": {
-                "type_url": {
-                  "type": "string",
-                  "id": 1
-                },
-                "value": {
-                  "type": "bytes",
-                  "id": 2
-                }
-              }
-            },
-            "Duration": {
-              "fields": {
-                "seconds": {
-                  "type": "int64",
-                  "id": 1
-                },
-                "nanos": {
-                  "type": "int32",
-                  "id": 2
-                }
-              }
-            },
-            "Empty": {
-              "fields": {}
-            },
-            "Timestamp": {
-              "fields": {
-                "seconds": {
-                  "type": "int64",
-                  "id": 1
-                },
-                "nanos": {
-                  "type": "int32",
-                  "id": 2
-                }
-              }
-            },
-            "FieldMask": {
-              "fields": {
-                "paths": {
-                  "rule": "repeated",
-                  "type": "string",
-                  "id": 1
-                }
-              }
-            },
-            "Struct": {
-              "fields": {
-                "fields": {
-                  "keyType": "string",
-                  "type": "Value",
-                  "id": 1
-                }
-              }
-            },
-            "Value": {
-              "oneofs": {
-                "kind": {
-                  "oneof": [
-                    "nullValue",
-                    "numberValue",
-                    "stringValue",
-                    "boolValue",
-                    "structValue",
-                    "listValue"
-                  ]
-                }
-              },
-              "fields": {
-                "nullValue": {
-                  "type": "NullValue",
-                  "id": 1
-                },
-                "numberValue": {
-                  "type": "double",
-                  "id": 2
-                },
-                "stringValue": {
-                  "type": "string",
-                  "id": 3
-                },
-                "boolValue": {
-                  "type": "bool",
-                  "id": 4
-                },
-                "structValue": {
-                  "type": "Struct",
-                  "id": 5
-                },
-                "listValue": {
-                  "type": "ListValue",
-                  "id": 6
-                }
-              }
-            },
-            "NullValue": {
-              "values": {
-                "NULL_VALUE": 0
-              }
-            },
-            "ListValue": {
-              "fields": {
-                "values": {
-                  "rule": "repeated",
-                  "type": "Value",
-                  "id": 1
-                }
-              }
-            }
-          }
-        },
         "iam": {
           "nested": {
             "v1": {
@@ -3047,34 +3209,6 @@
                 "metadataType": {
                   "type": "string",
                   "id": 2
-                }
-              }
-            }
-          }
-        },
-        "rpc": {
-          "options": {
-            "go_package": "google.golang.org/genproto/googleapis/rpc/status;status",
-            "java_multiple_files": true,
-            "java_outer_classname": "StatusProto",
-            "java_package": "com.google.rpc",
-            "objc_class_prefix": "RPC"
-          },
-          "nested": {
-            "Status": {
-              "fields": {
-                "code": {
-                  "type": "int32",
-                  "id": 1
-                },
-                "message": {
-                  "type": "string",
-                  "id": 2
-                },
-                "details": {
-                  "rule": "repeated",
-                  "type": "google.protobuf.Any",
-                  "id": 3
                 }
               }
             }

--- a/src/extra_proto_list.json
+++ b/src/extra_proto_list.json
@@ -1,0 +1,1 @@
+["../protos/google/rpc/error_details.proto"]

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -23,7 +23,7 @@ import * as through from 'through2';
 import {Session} from './session';
 import {Transaction} from './transaction';
 
-const jsonProtos = require('../../protos/protos.json');
+const jsonProtos = require('../protos/protos.json');
 const RETRY_INFO = 'google.rpc.retryinfo-bin';
 
 const RETRYABLE: status[] = [status.ABORTED, status.UNKNOWN];

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -15,24 +15,21 @@
  */
 
 import {promisify} from '@google-cloud/promisify';
-import {GoogleProtoFilesRoot} from 'google-gax';
 import {Metadata, ServiceError, status} from 'grpc';
 import {join} from 'path';
-import {common as p, loadSync} from 'protobufjs';
+import {Root} from 'protobufjs';
 import * as through from 'through2';
 
 import {Session} from './session';
 import {Transaction} from './transaction';
 
+const jsonProtos = require('../../protos/protos.json');
 const RETRY_INFO = 'google.rpc.retryinfo-bin';
 
 const RETRYABLE: status[] = [status.ABORTED, status.UNKNOWN];
 
 // tslint:disable-next-line variable-name
-const RetryInfo = loadSync(
-  join(__dirname, '..', 'protos', 'google/rpc/error_details.proto'),
-  new GoogleProtoFilesRoot()
-).lookup('google.rpc.RetryInfo');
+const RetryInfo = Root.fromJSON(jsonProtos).lookup('google.rpc.RetryInfo');
 
 /**
  * @typedef {object} RunTransactionOptions

--- a/test/transaction-runner.ts
+++ b/test/transaction-runner.ts
@@ -43,7 +43,7 @@ describe('TransactionRunner', () => {
     .stub()
     .withArgs(RETRY_KEY)
     .returns(RETRY_INFO);
-  const LOAD_SYNC = sandbox.stub().returns({lookup: LOOKUP});
+  const FROM_JSON = sandbox.stub().returns({lookup: LOOKUP});
 
   const SESSION = {
     transaction: () => fakeTransaction,
@@ -60,7 +60,7 @@ describe('TransactionRunner', () => {
 
   before(() => {
     const runners = proxyquire('../src/transaction-runner', {
-      protobufjs: {loadSync: LOAD_SYNC},
+      protobufjs: {Root: {fromJSON: FROM_JSON}},
     });
 
     Runner = runners.Runner;


### PR DESCRIPTION
Uses JSON proto load instead of `GoogleProtoFilesRoot` to load a proto for `RetryInfo`. Also, updates the JSON proto to include `google/rpc/error_details.proto`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
