### PR TITLE
fix: don't wrap SpannerDate so timezone does not affect results

### DIFF
--- a/samples/datatypes.js
+++ b/samples/datatypes.js
@@ -190,7 +190,7 @@ async function queryWithArray(instanceId, databaseId, projectId) {
   try {
     const [rows] = await database.run(query);
     rows.forEach(row => {
-      const availableDate = new Date(row[2]['value']);
+      const availableDate = row[2]['value'];
       const json = row.toJSON();
       console.log(
         `VenueId: ${json.VenueId}, VenueName: ${


### PR DESCRIPTION
This change allows the `should use an ARRAY query parameter to query record from the Venues example table` test to pass when run on machines with time zones with positive offsets.

Fixes #710 