### PR TITLE
feat: support environment variable SPANNER_EMULATOR_HOST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 .vscode
 yarn.lock
 __pycache__
+.idea

--- a/test/index.ts
+++ b/test/index.ts
@@ -269,6 +269,87 @@ describe('Spanner', () => {
 
       assert.strictEqual(config.baseUrl, SERVICE_PATH);
     });
+
+    it('should parse emulator host without port correctly', () => {
+      const currentEmulator = process.env.SPANNER_EMULATOR_HOST;
+      try {
+        const EMULATOR_HOST = 'somehost.local';
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}`;
+
+        const emulator = Spanner.getSpannerEmulatorHost();
+
+        assert.deepStrictEqual(emulator, {endpoint: EMULATOR_HOST});
+      } finally {
+        process.env.SPANNER_EMULATOR_HOST = currentEmulator;
+      }
+    });
+
+    it('should parse emulator host with port correctly', () => {
+      const currentEmulator = process.env.SPANNER_EMULATOR_HOST;
+      try {
+        const EMULATOR_HOST = 'somehost.local';
+        const EMULATOR_PORT = 1610;
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}:${EMULATOR_PORT}`;
+
+        const emulator = Spanner.getSpannerEmulatorHost();
+
+        assert.deepStrictEqual(emulator, {
+          endpoint: EMULATOR_HOST,
+          port: EMULATOR_PORT,
+        });
+      } finally {
+        process.env.SPANNER_EMULATOR_HOST = currentEmulator;
+      }
+    });
+
+    it('should reject emulator host with protocol', () => {
+      const currentEmulator = process.env.SPANNER_EMULATOR_HOST;
+      try {
+        const EMULATOR_HOST = 'https://somehost.local:1234';
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}`;
+        Spanner.getSpannerEmulatorHost();
+        assert.fail('Missing expected error');
+      } catch (e) {
+        assert.strictEqual(
+          e.message,
+          'SPANNER_EMULATOR_HOST must not start with a protocol specification (http/https)'
+        );
+      } finally {
+        process.env.SPANNER_EMULATOR_HOST = currentEmulator;
+      }
+    });
+
+    it('should reject emulator host with invalid port number', () => {
+      const currentEmulator = process.env.SPANNER_EMULATOR_HOST;
+      try {
+        const EMULATOR_HOST = 'somehost.local:not_a_port';
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}`;
+        Spanner.getSpannerEmulatorHost();
+        assert.fail('Missing expected error');
+      } catch (e) {
+        assert.strictEqual(e.message, 'Invalid port number: not_a_port');
+      } finally {
+        process.env.SPANNER_EMULATOR_HOST = currentEmulator;
+      }
+    });
+
+    it('should use SPANNER_EMULATOR_HOST', () => {
+      const currentEmulator = process.env.SPANNER_EMULATOR_HOST;
+      try {
+        const EMULATOR_HOST = 'somehost.local';
+        const EMULATOR_PORT = 1610;
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}:${EMULATOR_PORT}`;
+        const spanner = new Spanner();
+
+        const config = getFake(spanner).calledWith_[0];
+        const options = getFake(spanner).calledWith_[1];
+
+        assert.strictEqual(config.baseUrl, EMULATOR_HOST);
+        assert.strictEqual(options.port, EMULATOR_PORT);
+      } finally {
+        process.env.SPANNER_EMULATOR_HOST = currentEmulator;
+      }
+    });
   });
 
   describe('date', () => {


### PR DESCRIPTION
The Spanner client will now connect to a custom host if the environment variable SPANNER_EMULATOR_HOST has been set to a valid `host:port` combination.