### PR TITLE
fix: restore SessionLeakError name after super call

### DIFF
--- a/samples/struct.js
+++ b/samples/struct.js
@@ -193,7 +193,8 @@ async function queryWithArrayofStruct(instanceId, databaseId, projectId) {
     sql:
       'SELECT SingerId FROM Singers ' +
       'WHERE STRUCT<FirstName STRING, LastName STRING>(FirstName, LastName) ' +
-      'IN UNNEST(@names)',
+      'IN UNNEST(@names) ' +
+      'ORDER BY SingerId',
     params: {
       names: bandMembers,
     },

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -416,7 +416,7 @@ describe('Spanner', () => {
     const output = execSync(
       `${structCmd} queryWithArrayOfStruct ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
-    assert.match(output, /SingerId: 8\nSingerId: 7\nSingerId: 6/);
+    assert.match(output, /SingerId: 6\nSingerId: 7\nSingerId: 8/);
   });
 
   // query_with_struct_field_param

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -178,7 +178,7 @@ export class SessionLeakError extends Error {
   messages: string[];
   constructor(leaks: string[]) {
     super(`${leaks.length} session leak(s) detected.`);
-    // Restore error name that was overwritten by the super(..) call.
+    // Restore error name that was overwritten by the super constructor call.
     this.name = SessionLeakError.name;
     this.messages = leaks;
   }

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -178,6 +178,8 @@ export class SessionLeakError extends Error {
   messages: string[];
   constructor(leaks: string[]) {
     super(`${leaks.length} session leak(s) detected.`);
+    // Restore error name that was overwritten by the super(..) call.
+    this.name = SessionLeakError.name;
     this.messages = leaks;
   }
 }

--- a/test/session-pool.ts
+++ b/test/session-pool.ts
@@ -385,6 +385,7 @@ describe('SessionPool', () => {
       sandbox.stub(sessionPool, '_getLeaks').returns(fakeLeaks);
 
       sessionPool.close((err?: sp.SessionLeakError) => {
+        assert.strictEqual(err!.name, 'SessionLeakError');
         assert.strictEqual(
           err!.message,
           `${fakeLeaks.length} session leak(s) detected.`


### PR DESCRIPTION
The name of a `SessionLeakError` is set to `Error` by its super constructor. This makes checking specifically for a `SessionLeakError` more difficult.

Fixes #744 