### PR TITLE
fix: createInstance should return a value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -372,7 +372,8 @@ class Spanner extends GrpcService {
    *     // Instance created successfully.
    *   });
    */
-  createInstance(name: string, config?, callback?) {
+  // tslint:disable-next-line no-any
+  createInstance(name: string, config?, callback?): any {
     if (!name) {
       throw new Error('A name is required to create an instance.');
     }


### PR DESCRIPTION
The createInstance() method should return a value to allow promise chaining.

Fixes #746.