### PR TITLE
fix: only fail if session pool is full

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -723,7 +723,7 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       return this._borrowNextAvailableSession(type);
     }
 
-    if (this.options.fail!) {
+    if (this.isFull && this.options.fail!) {
       throw new Error('No resources available.');
     }
 


### PR DESCRIPTION
Only fail session creation if the pool is already full.

Fixes #751 

See also:
https://github.com/googleapis/nodejs-spanner/blob/e7edcb744ef5b3ea48d510aa3db514889d275bf7/test/spanner.ts#L192 and https://github.com/googleapis/nodejs-spanner/blob/e7edcb744ef5b3ea48d510aa3db514889d275bf7/src/session-pool.ts#L724 in PR #743 

