### PR TITLE
fix: return different databases for different pool options

### DIFF
--- a/src/instance.ts
+++ b/src/instance.ts
@@ -354,7 +354,7 @@ class Instance extends common.GrpcServiceObject {
     // Only add an additional key for SessionPoolOptions if an options object with at least one value was passed in.
     const optionsKey =
       poolOptions && Object.keys(poolOptions).length > 0
-        ? '/' + JSON.stringify(poolOptions)
+        ? '/' + JSON.stringify(Object.entries(poolOptions).sort())
         : '';
     const key = name.split('/').pop() + optionsKey;
     if (!this.databases_.has(key!)) {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -351,7 +351,12 @@ class Instance extends common.GrpcServiceObject {
     if (!name) {
       throw new Error('A name is required to access a Database object.');
     }
-    const key = name.split('/').pop();
+    // Only add an additional key for SessionPoolOptions if an options object with at least one value was passed in.
+    const optionsKey =
+      poolOptions && Object.keys(poolOptions).length > 0
+        ? '/' + JSON.stringify(poolOptions)
+        : '';
+    const key = name.split('/').pop() + optionsKey;
     if (!this.databases_.has(key!)) {
       this.databases_.set(key!, new Database(this, name, poolOptions));
     }

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -24,6 +24,7 @@ import * as sinon from 'sinon';
 
 import * as inst from '../src/instance';
 import {Spanner, Database} from '../src';
+import {SessionPoolOptions} from '../src/session-pool';
 
 const fakePaginator = {
   paginator: {
@@ -369,6 +370,40 @@ describe('Instance', () => {
       const database = instance.database(NAME);
 
       assert.strictEqual(database, fakeDatabase);
+    });
+
+    it('should create and cache different objects when called with different session pool options', () => {
+      const cache = instance.databases_;
+      const fakeDatabase = {} as Database;
+      const fakeDatabaseWithSessionPoolOptions = {} as Database;
+      const emptySessionPoolOptions = {} as SessionPoolOptions;
+      const fakeSessionPoolOptions = {
+        min: 1000,
+        max: 1000,
+      } as SessionPoolOptions;
+
+      cache.set(NAME, fakeDatabase);
+      cache.set(
+        NAME + '/' + JSON.stringify(fakeSessionPoolOptions),
+        fakeDatabaseWithSessionPoolOptions
+      );
+
+      const database = instance.database(NAME);
+      const databaseWithEmptyOptions = instance.database(
+        NAME,
+        emptySessionPoolOptions
+      );
+      const databaseWithOptions = instance.database(
+        NAME,
+        fakeSessionPoolOptions
+      );
+
+      assert.strictEqual(database, fakeDatabase);
+      assert.strictEqual(databaseWithEmptyOptions, fakeDatabase);
+      assert.strictEqual(
+        databaseWithOptions,
+        fakeDatabaseWithSessionPoolOptions
+      );
     });
   });
 

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -381,10 +381,16 @@ describe('Instance', () => {
         min: 1000,
         max: 1000,
       } as SessionPoolOptions;
+      const fakeSessionPoolOptionsInOtherOrder = {
+        max: 1000,
+        min: 1000,
+      } as SessionPoolOptions;
 
       cache.set(NAME, fakeDatabase);
       cache.set(
-        NAME + '/' + JSON.stringify(fakeSessionPoolOptions),
+        NAME +
+          '/' +
+          JSON.stringify(Object.entries(fakeSessionPoolOptions).sort()),
         fakeDatabaseWithSessionPoolOptions
       );
 
@@ -397,11 +403,19 @@ describe('Instance', () => {
         NAME,
         fakeSessionPoolOptions
       );
+      const databaseWithOptionsInOtherOrder = instance.database(
+        NAME,
+        fakeSessionPoolOptionsInOtherOrder
+      );
 
       assert.strictEqual(database, fakeDatabase);
       assert.strictEqual(databaseWithEmptyOptions, fakeDatabase);
       assert.strictEqual(
         databaseWithOptions,
+        fakeDatabaseWithSessionPoolOptions
+      );
+      assert.strictEqual(
+        databaseWithOptionsInOtherOrder,
         fakeDatabaseWithSessionPoolOptions
       );
     });


### PR DESCRIPTION
`Instance.database(name, poolOptions)` should return different databases when called multiple times with the same name but with different pool options. Otherwise, the `SessionPoolOptions` supplied in the second and subsequent calls are not respected, and instead the options of the first call are used.

Fixes #753 
