### PR TITLE
fix: get stacktrace before any async method call

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -459,6 +459,8 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       throw new Error(errors.Closed);
     }
 
+    // Get the stacktrace of the caller before we call any async methods, as calling an async method will break the stacktrace.
+    const frames = trace.get();
     const startTime = Date.now();
     const timeout = this.options.acquireTimeout;
 
@@ -492,7 +494,7 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       }
     }
 
-    this._traces.set(session.id, trace.get());
+    this._traces.set(session.id, frames);
     return session;
   }
 


### PR DESCRIPTION
The current stacktrace that is included in a `SessionLeakError` only contains the `_acquire` method itself, as the `_acquire` method calls an async method before getting the stacktrace. This change moves the call to get the caller stacktrace to the beginning of the method, which ensures that the stacktrace does contain the information that is needed.

This will also give us additional information that would be valuable to debug #716 

Fixes #755 
