### PR TITLE
fix: end read-write transaction in sample

### DIFF
--- a/samples/transaction.js
+++ b/samples/transaction.js
@@ -188,6 +188,7 @@ function readWriteTransaction(instanceId, databaseId, projectId) {
         console.error('ERROR:', err);
       })
       .then(() => {
+        transaction.end();
         // Closes the database when finished
         return database.close();
       });


### PR DESCRIPTION
In the readWriteTransaction sample, if an error was thrown,
transaction.end() is now called so that the session is returned back to
the pool.
