### PR TITLE
fix: clear stack of session while preparing new r/w tx

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -455,6 +455,10 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       return;
     }
 
+    // Delete the trace associated with this session to mark the session as checked
+    // back into the pool. This will prevent the session to be marked as leaked if
+    // the pool is closed while the session is being prepared.
+    this._traces.delete(session.id);
     this._prepareTransaction(session)
       .catch(() => (session.type = types.ReadOnly))
       .then(() => this._release(session));


### PR DESCRIPTION
When a write-prepared session is returned to the session pool, a new read/write transaction will automatically be prepared for the session. The session stays in the `borrowed` set of the session pool inventory while the session is being prepared. The `_traces` entry for the session was however also kept while the session was being prepared. This would mark the session as leaked if the pool was closed before the `BeginTransaction` RPC had finished its execution. This is incorrect, as the session has been checked back into the pool by the application. Clearing the `_traces` entry for the session before starting the `BeginTransaction` RPC solves this.

[This test case](https://github.com/googleapis/nodejs-spanner/blob/840d9723cdd8cf71f9de083b426d83a0b44cd07a/test/spanner.ts#L144) would fail without this fix, as the session pool would be closed while the session that was used for the mutation was still being prepared by the pool.

Fixes #765 
