### PR TITLE
fix: do not use empty string as emulator host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ class Spanner extends GrpcService {
     | {endpoint: string; port?: number}
     | undefined {
     const endpointWithPort = process.env.SPANNER_EMULATOR_HOST;
-    if (endpointWithPort) {
+    if (endpointWithPort && endpointWithPort.length > 0) {
       if (
         endpointWithPort.startsWith('http:') ||
         endpointWithPort.startsWith('https:')


### PR DESCRIPTION
Check whether the `SPANNER_EMULATOR_HOST` environment variable contains an empty string, and if it does, do not use it.