### PR TITLE
fix: year zero was not accepted for SpannerDate

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -58,8 +58,8 @@ type DateFields = [number, number, number];
  * @extends Date
  *
  * @param {string|number} [date] String representing the date or number
- *     representing the year. If year is a number between 0 and 99 is used, then
- *     year is assumed to be 1900 + year.
+ *     representing the year. If year is a number between 0 and 99, then year is
+ *     is assumed to be 1900 + year.
  * @param {number} [month] Number representing the month (0 = January).
  * @param {number} [date] Number representing the date.
  *

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -59,7 +59,7 @@ type DateFields = [number, number, number];
  *
  * @param {string|number} [date] String representing the date or number
  *     representing the year. If year is a number between 0 and 99, then year is
- *     is assumed to be 1900 + year.
+ *     assumed to be 1900 + year.
  * @param {number} [month] Number representing the month (0 = January).
  * @param {number} [date] Number representing the date.
  *

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -58,8 +58,9 @@ type DateFields = [number, number, number];
  * @extends Date
  *
  * @param {string|number} [date] String representing the date or number
- *     representing the year.
- * @param {number} [month] Number representing the month.
+ *     representing the year. If year is a number between 0 and 99 is used, then
+ *     year is assumed to be 1900 + year.
+ * @param {number} [month] Number representing the month (0 = January).
  * @param {number} [date] Number representing the date.
  *
  * @example
@@ -71,7 +72,8 @@ export class SpannerDate extends Date {
   constructor(...dateFields: Array<string | number | undefined>) {
     const yearOrDateString = dateFields[0];
 
-    if (!yearOrDateString) {
+    // yearOrDateString could be 0 (number).
+    if (yearOrDateString == null) {
       dateFields[0] = new Date().toDateString();
     }
 

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -80,6 +80,7 @@ describe('codec', () => {
         const date = new codec.SpannerDate(0, 2, 22);
         const json = date.toJSON();
 
+        assert.ok(d);
         assert.strictEqual(json, '1900-03-22');
       });
 

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -75,6 +75,14 @@ describe('codec', () => {
         assert.strictEqual(json, '1986-03-22');
       });
 
+      it('should accept year zero in y/m/d number values', () => {
+        const d = new codec.SpannerDate(null!);
+        const date = new codec.SpannerDate(0, 2, 22);
+        const json = date.toJSON();
+
+        assert.strictEqual(json, '1900-03-22');
+      });
+
       it('should truncate additional date fields', () => {
         const truncated = new codec.SpannerDate(1986, 2, 22, 4, 8, 10);
         const expected = new codec.SpannerDate(1986, 2, 22);


### PR DESCRIPTION
Creating a SpannerDate with year/month/date values with year=0 would return an invalid date.

Fixes #782 
