### PR TITLE
chore(test): unflake transaction system tests

### DIFF
--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -4213,7 +4213,10 @@ describe('Spanner', () => {
                   const lastRow = rows!.pop()!.toJSON();
 
                   assert.deepStrictEqual(lastRow, expectedRow);
-                  assert.strictEqual(attempts, 2);
+                  // The transaction should have been tried at least twice, but
+                  // there could be more attempts, as the backend could abort
+                  // any subsequent retry attempts as well.
+                  assert.ok(attempts >= 2);
 
                   done();
                 });
@@ -4282,7 +4285,10 @@ describe('Spanner', () => {
               const lastRow = rows!.pop()!.toJSON();
 
               assert.deepStrictEqual(lastRow, expectedRow);
-              assert.strictEqual(attempts, 2);
+              // The transaction should have been tried at least twice, but
+              // there could be more attempts, as the backend could abort any
+              // subsequent retry attempts as well.
+              assert.ok(attempts >= 2);
 
               done();
             });


### PR DESCRIPTION
Cloud Spanner could abort any read/write transaction, meaning that the number of attempts can always be higher than the minimum number of attempts expected.

Fixes #785 
