### PR TITLE
fix: transaction runner should not timeout before first attempt

### DIFF
--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -186,7 +186,7 @@ export abstract class Runner<T> {
 
     let lastError: ServiceError;
 
-    // The transaction runner should always executed at least one attempt before
+    // The transaction runner should always execute at least one attempt before
     // timing out.
     while (this.attempts === 0 || Date.now() - start < timeout) {
       const transaction = await this.getTransaction();

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -186,7 +186,9 @@ export abstract class Runner<T> {
 
     let lastError: ServiceError;
 
-    while (Date.now() - start < timeout) {
+    // The transaction runner should always executed at least one attempt before
+    // timing out.
+    while (this.attempts === 0 || Date.now() - start < timeout) {
       const transaction = await this.getTransaction();
 
       try {

--- a/test/transaction-runner.ts
+++ b/test/transaction-runner.ts
@@ -287,11 +287,16 @@ describe('TransactionRunner', () => {
         sandbox.stub(runner, 'getNextDelay').returns(2);
         runner.options.timeout = 1;
 
-        runner.run().catch(err => {
-          assert.strictEqual(err.code, status.DEADLINE_EXCEEDED);
-          assert.deepStrictEqual(err.errors, [fakeError]);
-          done();
-        });
+        runner
+          .run()
+          .then(() => {
+            done(new Error('missing expected DEADLINE_EXCEEDED error'));
+          })
+          .catch(err => {
+            assert.strictEqual(err.code, status.DEADLINE_EXCEEDED);
+            assert.deepStrictEqual(err.errors, [fakeError]);
+            done();
+          });
       });
     });
   });


### PR DESCRIPTION
The transaction runner could timeout before the first transaction attempt had been executed, if a very short timeout value had been set. The transaction runner should always execute at least one transaction attempt before throwing a `DeadlineError`.

Fixes #786.