### PR TITLE
fix: fixed part of backoff should be between 1 and 32 seconds + max 1 second randomized jitter

### DIFF
--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -152,7 +152,11 @@ export abstract class Runner<T> {
       return secondsInMs + nanosInMs;
     }
 
-    return Math.pow(2, this.attempts) * 1000 + Math.floor(Math.random() * 1000);
+    // Max backoff should be 32 seconds.
+    return (
+      Math.pow(2, Math.min(this.attempts, 5)) * 1000 +
+      Math.floor(Math.random() * 1000)
+    );
   }
   /**
    * Retrieves a transaction to run against.

--- a/test/transaction-runner.ts
+++ b/test/transaction-runner.ts
@@ -163,7 +163,22 @@ describe('TransactionRunner', () => {
       it('should create a backoff when `retryInfo` is absent', () => {
         const random = Math.random();
 
-        runner.attempts = 5;
+        runner.attempts = 3;
+        sandbox.stub(global.Math, 'random').returns(random);
+
+        const badError = new Error('err') as ServiceError;
+        badError.metadata = new Metadata();
+
+        const expectedDelay = Math.pow(2, 3) * 1000 + Math.floor(random * 1000);
+        const delay = runner.getNextDelay(badError);
+
+        assert.strictEqual(delay, expectedDelay);
+      });
+
+      it('should use a backoff of max 32 seconds when `retryInfo` is absent', () => {
+        const random = Math.random();
+
+        runner.attempts = 10;
         sandbox.stub(global.Math, 'random').returns(random);
 
         const badError = new Error('err') as ServiceError;


### PR DESCRIPTION
The Node client did implement a client side backoff if no backoff information was provided by the server, but it did not maximize the fixed part of the backoff at 32 seconds. In addition, each backoff is added a randomized max 1 second jitter.

Fixes #653 
