### PR TITLE
fix: retry 'Session not found' errors on getSnapshot

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -1223,8 +1223,14 @@ class Database extends GrpcServiceObject {
 
       snapshot.begin(err => {
         if (err) {
-          this.pool_.release(session!);
-          callback!(err);
+          if (isSessionNotFoundError(err)) {
+            session!.lastError = err;
+            this.pool_.release(session!);
+            this.getSnapshot(options, callback!);
+          } else {
+            this.pool_.release(session!);
+            callback!(err);
+          }
           return;
         }
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -18,18 +18,17 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {EventEmitter} from 'events';
 import * as extend from 'extend';
-import {ApiError} from '@google-cloud/common';
+import {ApiError, util} from '@google-cloud/common';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import {Transform} from 'stream';
 import * as through from 'through2';
-import {util} from '@google-cloud/common';
 import * as pfy from '@google-cloud/promisify';
 import * as db from '../src/database';
 import {Instance} from '../src';
 import {TimestampBounds} from '../src/transaction';
 import {ServiceError, status} from 'grpc';
-import {isSessionNotFoundError} from '../src/session-pool';
+import {MockError} from './mockserver/mockspanner';
 
 let promisified = false;
 const fakePfy = extend({}, pfy, {
@@ -1730,6 +1729,44 @@ describe('Database', () => {
       database.getSnapshot(err => {
         assert.strictEqual(err, fakeError);
         assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
+    });
+
+    it('should retry if `begin` errors with `Session not found`', done => {
+      const fakeError = {
+        code: status.NOT_FOUND,
+        message: 'Session not found',
+      } as MockError;
+
+      const fakeSession2 = new FakeSession();
+      const fakeSnapshot2 = new FakeTransaction();
+      sandbox
+        .stub(fakeSnapshot2, 'begin')
+        .callsFake(callback => callback(null));
+      sandbox.stub(fakeSession2, 'snapshot').returns(fakeSnapshot2);
+
+      getReadSessionStub
+        .onFirstCall()
+        .callsFake(callback => callback(null, fakeSession))
+        .onSecondCall()
+        .callsFake(callback => callback(null, fakeSession2));
+      beginSnapshotStub.callsFake(callback => callback(fakeError));
+
+      // The first session that was not found should be released back into the
+      // pool, so that the pool can remove it from its inventory.
+      const releaseStub = sandbox.stub(fakePool, 'release');
+
+      database.getSnapshot((err, snapshot) => {
+        assert.ifError(err);
+        assert.strictEqual(snapshot, fakeSnapshot2);
+        // The first session that error should already have been released back
+        // to the pool.
+        assert.strictEqual(releaseStub.callCount, 1);
+        // Ending the valid snapshot will release its session back into the
+        // pool.
+        snapshot.emit('end');
+        assert.strictEqual(releaseStub.callCount, 2);
         done();
       });
     });

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -615,6 +615,60 @@ describe('Spanner with mock server', () => {
         done();
       });
     });
+
+    it('should retry "Session not found" errors for Database.getSnapshot() with callbacks', done => {
+      const db = newTestDatabase();
+      const sessionNotFound = {
+        code: status.NOT_FOUND,
+        message: 'Session not found',
+      } as MockError;
+      // The beginTransaction call will fail 3 times with 'Session not found'
+      // before succeeding.
+      spannerMock.setExecutionTime(
+        spannerMock.beginTransaction,
+        SimulatedExecutionTime.ofErrors([
+          sessionNotFound,
+          sessionNotFound,
+          sessionNotFound,
+        ])
+      );
+      db.getSnapshot((err, snapshot) => {
+        assert.ifError(err);
+        snapshot!.run(selectSql, (err, rows) => {
+          assert.ifError(err);
+          assert.strictEqual(rows.length, 3);
+          snapshot!.end();
+          db.close(done);
+        });
+      });
+    });
+
+    it('should retry "Session not found" errors for Database.getSnapshot()', done => {
+      const db = newTestDatabase();
+      spannerMock.setExecutionTime(
+        spannerMock.beginTransaction,
+        SimulatedExecutionTime.ofError({
+          code: status.NOT_FOUND,
+          message: 'Session not found',
+        } as MockError)
+      );
+      db.getSnapshot()
+        .then(response => {
+          const [snapshot] = response;
+          snapshot
+            .run(selectSql)
+            .then(response => {
+              const [rows] = response;
+              assert.strictEqual(rows.length, 3);
+              snapshot.end();
+              db.close()
+                .then(() => done())
+                .catch(done);
+            })
+            .catch(done);
+        })
+        .catch(done);
+    });
   });
 
   describe('session-pool', () => {

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -661,9 +661,7 @@ describe('Spanner with mock server', () => {
               const [rows] = response;
               assert.strictEqual(rows.length, 3);
               snapshot.end();
-              db.close()
-                .then(() => done())
-                .catch(done);
+              db.close(done);
             })
             .catch(done);
         })


### PR DESCRIPTION
If the `BeginTransaction` RPC of a read-only transaction fails with a 'Session not found' error, we can safely discard the invalid session, get a new session from the pool and retry the BeginTransaction call on the new session.

### Background
The session pool should normally keep all sessions alive by pinging them regularly with a simple SELECT 1, but it is known from other clients (Java, Go) that users can sporadically experience Session not found errors as sessions can be dropped by the backend. These clients have therefore added retry functionality for these errors.