### PR TITLE
deps: remove @types/extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.1",
     "@types/concat-stream": "^1.6.0",
+    "@types/extend": "^3.0.0",
     "@types/is": "0.0.21",
     "@types/lodash.snakecase": "^4.1.4",
     "@types/merge-stream": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.1",
     "@types/concat-stream": "^1.6.0",
-    "@types/extend": "^3.0.0",
     "@types/is": "0.0.21",
     "@types/lodash.snakecase": "^4.1.4",
     "@types/merge-stream": "^1.1.2",

--- a/test/database.ts
+++ b/test/database.ts
@@ -1592,7 +1592,7 @@ describe('Database', () => {
     it('should send labels correctly', done => {
       const labels = {a: 'b'};
       const options = {a: 'b', labels};
-      const originalOptions = extend({}, options, labels);
+      const originalOptions = extend(true, {}, options);
 
       database.request = config => {
         assert.deepStrictEqual(config.reqOpts.session, {labels});
@@ -1878,7 +1878,7 @@ describe('Database', () => {
       const gaxOpts = {};
       const options = {a: 'a', gaxOptions: gaxOpts};
 
-      const expectedReqOpts = Object.assign({}, options, {
+      const expectedReqOpts = extend({}, options, {
         database: database.formattedName_,
       });
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -28,7 +28,6 @@ import {Instance} from '../src';
 import {TimestampBounds} from '../src/transaction';
 import {ServiceError, status} from 'grpc';
 import {MockError} from './mockserver/mockspanner';
-import extend = require('extend');
 
 let promisified = false;
 const fakePfy = Object.assign({}, pfy, {

--- a/test/database.ts
+++ b/test/database.ts
@@ -17,7 +17,6 @@
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {EventEmitter} from 'events';
-import * as extend from 'extend';
 import {ApiError, util} from '@google-cloud/common';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
@@ -29,9 +28,10 @@ import {Instance} from '../src';
 import {TimestampBounds} from '../src/transaction';
 import {ServiceError, status} from 'grpc';
 import {MockError} from './mockserver/mockspanner';
+import extend = require('extend');
 
 let promisified = false;
-const fakePfy = extend({}, pfy, {
+const fakePfy = Object.assign({}, pfy, {
   promisifyAll(klass, options) {
     if (klass.name !== 'Database') {
       return;
@@ -210,12 +210,12 @@ describe('Database', () => {
         AsyncTransactionRunner: FakeAsyncTransactionRunner,
       },
     }).Database;
-    DatabaseCached = extend({}, Database);
+    DatabaseCached = Object.assign({}, Database);
   });
 
   beforeEach(() => {
     fakeCodec.encode = util.noop;
-    extend(Database, DatabaseCached);
+    Object.assign(Database, DatabaseCached);
     database = new Database(INSTANCE, NAME, POOL_OPTIONS);
     database.parent = INSTANCE;
   });
@@ -294,7 +294,7 @@ describe('Database', () => {
     it('should inherit from ServiceObject', done => {
       const options = {};
 
-      const instanceInstance = extend({}, INSTANCE, {
+      const instanceInstance = Object.assign({}, INSTANCE, {
         createDatabase(name, options_, callback) {
           assert.strictEqual(name, database.formattedName_);
           assert.strictEqual(options_, options);
@@ -1034,7 +1034,7 @@ describe('Database', () => {
       database.request = config => {
         assert.deepStrictEqual(
           config.reqOpts,
-          extend({}, CONFIG.reqOpts, {
+          Object.assign({}, CONFIG.reqOpts, {
             session: SESSION.formattedName_,
           })
         );
@@ -1541,7 +1541,7 @@ describe('Database', () => {
         otherConfiguration: {},
       };
 
-      const expectedReqOpts = extend({}, config, {
+      const expectedReqOpts = Object.assign({}, config, {
         database: database.formattedName_,
       });
 
@@ -1590,7 +1590,7 @@ describe('Database', () => {
     it('should send labels correctly', done => {
       const labels = {a: 'b'};
       const options = {a: 'b', labels};
-      const originalOptions = extend(true, {}, options);
+      const originalOptions = Object.assign({}, options, labels);
 
       database.request = config => {
         assert.deepStrictEqual(config.reqOpts.session, {labels});
@@ -1876,7 +1876,7 @@ describe('Database', () => {
       const gaxOpts = {};
       const options = {a: 'a', gaxOptions: gaxOpts};
 
-      const expectedReqOpts = extend({}, options, {
+      const expectedReqOpts = Object.assign({}, options, {
         database: database.formattedName_,
       });
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -17,6 +17,7 @@
 import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import {EventEmitter} from 'events';
+import * as extend from 'extend';
 import {ApiError, util} from '@google-cloud/common';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
@@ -30,7 +31,7 @@ import {ServiceError, status} from 'grpc';
 import {MockError} from './mockserver/mockspanner';
 
 let promisified = false;
-const fakePfy = Object.assign({}, pfy, {
+const fakePfy = extend({}, pfy, {
   promisifyAll(klass, options) {
     if (klass.name !== 'Database') {
       return;
@@ -209,12 +210,14 @@ describe('Database', () => {
         AsyncTransactionRunner: FakeAsyncTransactionRunner,
       },
     }).Database;
+    // The following commented out line is the one that will trigger the error.
+    // DatabaseCached = extend({}, Database);
     DatabaseCached = Object.assign({}, Database);
   });
 
   beforeEach(() => {
     fakeCodec.encode = util.noop;
-    Object.assign(Database, DatabaseCached);
+    extend(Database, DatabaseCached);
     database = new Database(INSTANCE, NAME, POOL_OPTIONS);
     database.parent = INSTANCE;
   });
@@ -293,7 +296,7 @@ describe('Database', () => {
     it('should inherit from ServiceObject', done => {
       const options = {};
 
-      const instanceInstance = Object.assign({}, INSTANCE, {
+      const instanceInstance = extend({}, INSTANCE, {
         createDatabase(name, options_, callback) {
           assert.strictEqual(name, database.formattedName_);
           assert.strictEqual(options_, options);
@@ -1033,7 +1036,7 @@ describe('Database', () => {
       database.request = config => {
         assert.deepStrictEqual(
           config.reqOpts,
-          Object.assign({}, CONFIG.reqOpts, {
+          extend({}, CONFIG.reqOpts, {
             session: SESSION.formattedName_,
           })
         );
@@ -1540,7 +1543,7 @@ describe('Database', () => {
         otherConfiguration: {},
       };
 
-      const expectedReqOpts = Object.assign({}, config, {
+      const expectedReqOpts = extend({}, config, {
         database: database.formattedName_,
       });
 
@@ -1589,7 +1592,7 @@ describe('Database', () => {
     it('should send labels correctly', done => {
       const labels = {a: 'b'};
       const options = {a: 'b', labels};
-      const originalOptions = Object.assign({}, options, labels);
+      const originalOptions = extend({}, options, labels);
 
       database.request = config => {
         assert.deepStrictEqual(config.reqOpts.session, {labels});


### PR DESCRIPTION
Remove @types/extend as it seems to be broken in combination with Node 12.16.0. `Object.assign(...)` can be used instead of extend. Only the deep copy option of extend is not natively supported by `Object.assign`.

Fixes #829
