### PR TITLE
feat: add support for QueryOptions

### DIFF
--- a/proto/spanner.d.ts
+++ b/proto/spanner.d.ts
@@ -1146,16 +1146,19 @@ export namespace google {
                 paramTypes?: ({ [k: string]: google.spanner.v1.IType }|null);
 
                 /** ExecuteSqlRequest resumeToken */
-                resumeToken?: (Uint8Array|null);
+                resumeToken?: (Uint8Array|string|null);
 
                 /** ExecuteSqlRequest queryMode */
-                queryMode?: (google.spanner.v1.ExecuteSqlRequest.QueryMode|null);
+                queryMode?: (google.spanner.v1.ExecuteSqlRequest.QueryMode|keyof typeof google.spanner.v1.ExecuteSqlRequest.QueryMode|null);
 
                 /** ExecuteSqlRequest partitionToken */
-                partitionToken?: (Uint8Array|null);
+                partitionToken?: (Uint8Array|string|null);
 
                 /** ExecuteSqlRequest seqno */
-                seqno?: (number|Long|null);
+                seqno?: (number|Long|string|null);
+
+                /** ExecuteSqlRequest queryOptions */
+                queryOptions?: (google.spanner.v1.ExecuteSqlRequest.IQueryOptions|null);
             }
 
             /** Represents an ExecuteSqlRequest. */
@@ -1183,16 +1186,19 @@ export namespace google {
                 public paramTypes: { [k: string]: google.spanner.v1.IType };
 
                 /** ExecuteSqlRequest resumeToken. */
-                public resumeToken: Uint8Array;
+                public resumeToken: (Uint8Array|string);
 
                 /** ExecuteSqlRequest queryMode. */
-                public queryMode: google.spanner.v1.ExecuteSqlRequest.QueryMode;
+                public queryMode: (google.spanner.v1.ExecuteSqlRequest.QueryMode|keyof typeof google.spanner.v1.ExecuteSqlRequest.QueryMode);
 
                 /** ExecuteSqlRequest partitionToken. */
-                public partitionToken: Uint8Array;
+                public partitionToken: (Uint8Array|string);
 
                 /** ExecuteSqlRequest seqno. */
-                public seqno: (number|Long);
+                public seqno: (number|Long|string);
+
+                /** ExecuteSqlRequest queryOptions. */
+                public queryOptions?: (google.spanner.v1.ExecuteSqlRequest.IQueryOptions|null);
 
                 /**
                  * Creates a new ExecuteSqlRequest instance using the specified properties.
@@ -1267,6 +1273,96 @@ export namespace google {
 
             namespace ExecuteSqlRequest {
 
+                /** Properties of a QueryOptions. */
+                interface IQueryOptions {
+
+                    /** QueryOptions optimizerVersion */
+                    optimizerVersion?: (string|null);
+                }
+
+                /** Represents a QueryOptions. */
+                class QueryOptions implements IQueryOptions {
+
+                    /**
+                     * Constructs a new QueryOptions.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.spanner.v1.ExecuteSqlRequest.IQueryOptions);
+
+                    /** QueryOptions optimizerVersion. */
+                    public optimizerVersion: string;
+
+                    /**
+                     * Creates a new QueryOptions instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns QueryOptions instance
+                     */
+                    public static create(properties?: google.spanner.v1.ExecuteSqlRequest.IQueryOptions): google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+
+                    /**
+                     * Encodes the specified QueryOptions message. Does not implicitly {@link google.spanner.v1.ExecuteSqlRequest.QueryOptions.verify|verify} messages.
+                     * @param message QueryOptions message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.spanner.v1.ExecuteSqlRequest.IQueryOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified QueryOptions message, length delimited. Does not implicitly {@link google.spanner.v1.ExecuteSqlRequest.QueryOptions.verify|verify} messages.
+                     * @param message QueryOptions message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.spanner.v1.ExecuteSqlRequest.IQueryOptions, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a QueryOptions message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns QueryOptions
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+
+                    /**
+                     * Decodes a QueryOptions message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns QueryOptions
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+
+                    /**
+                     * Verifies a QueryOptions message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a QueryOptions message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns QueryOptions
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+
+                    /**
+                     * Creates a plain object from a QueryOptions message. Also converts values to other types if specified.
+                     * @param message QueryOptions
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.spanner.v1.ExecuteSqlRequest.QueryOptions, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this QueryOptions to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
                 /** QueryMode enum. */
                 enum QueryMode {
                     NORMAL = 0,
@@ -1288,7 +1384,7 @@ export namespace google {
                 statements?: (google.spanner.v1.ExecuteBatchDmlRequest.IStatement[]|null);
 
                 /** ExecuteBatchDmlRequest seqno */
-                seqno?: (number|Long|null);
+                seqno?: (number|Long|string|null);
             }
 
             /** Represents an ExecuteBatchDmlRequest. */
@@ -1310,7 +1406,7 @@ export namespace google {
                 public statements: google.spanner.v1.ExecuteBatchDmlRequest.IStatement[];
 
                 /** ExecuteBatchDmlRequest seqno. */
-                public seqno: (number|Long);
+                public seqno: (number|Long|string);
 
                 /**
                  * Creates a new ExecuteBatchDmlRequest instance using the specified properties.
@@ -1588,10 +1684,10 @@ export namespace google {
             interface IPartitionOptions {
 
                 /** PartitionOptions partitionSizeBytes */
-                partitionSizeBytes?: (number|Long|null);
+                partitionSizeBytes?: (number|Long|string|null);
 
                 /** PartitionOptions maxPartitions */
-                maxPartitions?: (number|Long|null);
+                maxPartitions?: (number|Long|string|null);
             }
 
             /** Represents a PartitionOptions. */
@@ -1604,10 +1700,10 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IPartitionOptions);
 
                 /** PartitionOptions partitionSizeBytes. */
-                public partitionSizeBytes: (number|Long);
+                public partitionSizeBytes: (number|Long|string);
 
                 /** PartitionOptions maxPartitions. */
-                public maxPartitions: (number|Long);
+                public maxPartitions: (number|Long|string);
 
                 /**
                  * Creates a new PartitionOptions instance using the specified properties.
@@ -1930,7 +2026,7 @@ export namespace google {
             interface IPartition {
 
                 /** Partition partitionToken */
-                partitionToken?: (Uint8Array|null);
+                partitionToken?: (Uint8Array|string|null);
             }
 
             /** Represents a Partition. */
@@ -1943,7 +2039,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IPartition);
 
                 /** Partition partitionToken. */
-                public partitionToken: Uint8Array;
+                public partitionToken: (Uint8Array|string);
 
                 /**
                  * Creates a new Partition instance using the specified properties.
@@ -2134,13 +2230,13 @@ export namespace google {
                 keySet?: (google.spanner.v1.IKeySet|null);
 
                 /** ReadRequest limit */
-                limit?: (number|Long|null);
+                limit?: (number|Long|string|null);
 
                 /** ReadRequest resumeToken */
-                resumeToken?: (Uint8Array|null);
+                resumeToken?: (Uint8Array|string|null);
 
                 /** ReadRequest partitionToken */
-                partitionToken?: (Uint8Array|null);
+                partitionToken?: (Uint8Array|string|null);
             }
 
             /** Represents a ReadRequest. */
@@ -2171,13 +2267,13 @@ export namespace google {
                 public keySet?: (google.spanner.v1.IKeySet|null);
 
                 /** ReadRequest limit. */
-                public limit: (number|Long);
+                public limit: (number|Long|string);
 
                 /** ReadRequest resumeToken. */
-                public resumeToken: Uint8Array;
+                public resumeToken: (Uint8Array|string);
 
                 /** ReadRequest partitionToken. */
-                public partitionToken: Uint8Array;
+                public partitionToken: (Uint8Array|string);
 
                 /**
                  * Creates a new ReadRequest instance using the specified properties.
@@ -2353,7 +2449,7 @@ export namespace google {
                 session?: (string|null);
 
                 /** CommitRequest transactionId */
-                transactionId?: (Uint8Array|null);
+                transactionId?: (Uint8Array|string|null);
 
                 /** CommitRequest singleUseTransaction */
                 singleUseTransaction?: (google.spanner.v1.ITransactionOptions|null);
@@ -2375,7 +2471,7 @@ export namespace google {
                 public session: string;
 
                 /** CommitRequest transactionId. */
-                public transactionId: Uint8Array;
+                public transactionId: (Uint8Array|string);
 
                 /** CommitRequest singleUseTransaction. */
                 public singleUseTransaction?: (google.spanner.v1.ITransactionOptions|null);
@@ -2554,7 +2650,7 @@ export namespace google {
                 session?: (string|null);
 
                 /** RollbackRequest transactionId */
-                transactionId?: (Uint8Array|null);
+                transactionId?: (Uint8Array|string|null);
             }
 
             /** Represents a RollbackRequest. */
@@ -2570,7 +2666,7 @@ export namespace google {
                 public session: string;
 
                 /** RollbackRequest transactionId. */
-                public transactionId: Uint8Array;
+                public transactionId: (Uint8Array|string);
 
                 /**
                  * Creates a new RollbackRequest instance using the specified properties.
@@ -3292,7 +3388,7 @@ export namespace google {
                 chunkedValue?: (boolean|null);
 
                 /** PartialResultSet resumeToken */
-                resumeToken?: (Uint8Array|null);
+                resumeToken?: (Uint8Array|string|null);
 
                 /** PartialResultSet stats */
                 stats?: (google.spanner.v1.IResultSetStats|null);
@@ -3317,7 +3413,7 @@ export namespace google {
                 public chunkedValue: boolean;
 
                 /** PartialResultSet resumeToken. */
-                public resumeToken: Uint8Array;
+                public resumeToken: (Uint8Array|string);
 
                 /** PartialResultSet stats. */
                 public stats?: (google.spanner.v1.IResultSetStats|null);
@@ -3499,10 +3595,10 @@ export namespace google {
                 queryStats?: (google.protobuf.IStruct|null);
 
                 /** ResultSetStats rowCountExact */
-                rowCountExact?: (number|Long|null);
+                rowCountExact?: (number|Long|string|null);
 
                 /** ResultSetStats rowCountLowerBound */
-                rowCountLowerBound?: (number|Long|null);
+                rowCountLowerBound?: (number|Long|string|null);
             }
 
             /** Represents a ResultSetStats. */
@@ -3521,10 +3617,10 @@ export namespace google {
                 public queryStats?: (google.protobuf.IStruct|null);
 
                 /** ResultSetStats rowCountExact. */
-                public rowCountExact: (number|Long);
+                public rowCountExact: (number|Long|string);
 
                 /** ResultSetStats rowCountLowerBound. */
-                public rowCountLowerBound: (number|Long);
+                public rowCountLowerBound: (number|Long|string);
 
                 /** ResultSetStats rowCount. */
                 public rowCount?: ("rowCountExact"|"rowCountLowerBound");
@@ -3607,7 +3703,7 @@ export namespace google {
                 index?: (number|null);
 
                 /** PlanNode kind */
-                kind?: (google.spanner.v1.PlanNode.Kind|null);
+                kind?: (google.spanner.v1.PlanNode.Kind|keyof typeof google.spanner.v1.PlanNode.Kind|null);
 
                 /** PlanNode displayName */
                 displayName?: (string|null);
@@ -3638,7 +3734,7 @@ export namespace google {
                 public index: number;
 
                 /** PlanNode kind. */
-                public kind: google.spanner.v1.PlanNode.Kind;
+                public kind: (google.spanner.v1.PlanNode.Kind|keyof typeof google.spanner.v1.PlanNode.Kind);
 
                 /** PlanNode displayName. */
                 public displayName: string;
@@ -4427,7 +4523,7 @@ export namespace google {
             interface ITransaction {
 
                 /** Transaction id */
-                id?: (Uint8Array|null);
+                id?: (Uint8Array|string|null);
 
                 /** Transaction readTimestamp */
                 readTimestamp?: (google.protobuf.ITimestamp|null);
@@ -4443,7 +4539,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.ITransaction);
 
                 /** Transaction id. */
-                public id: Uint8Array;
+                public id: (Uint8Array|string);
 
                 /** Transaction readTimestamp. */
                 public readTimestamp?: (google.protobuf.ITimestamp|null);
@@ -4526,7 +4622,7 @@ export namespace google {
                 singleUse?: (google.spanner.v1.ITransactionOptions|null);
 
                 /** TransactionSelector id */
-                id?: (Uint8Array|null);
+                id?: (Uint8Array|string|null);
 
                 /** TransactionSelector begin */
                 begin?: (google.spanner.v1.ITransactionOptions|null);
@@ -4545,7 +4641,7 @@ export namespace google {
                 public singleUse?: (google.spanner.v1.ITransactionOptions|null);
 
                 /** TransactionSelector id. */
-                public id: Uint8Array;
+                public id: (Uint8Array|string);
 
                 /** TransactionSelector begin. */
                 public begin?: (google.spanner.v1.ITransactionOptions|null);
@@ -4624,11 +4720,25 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
+            /** TypeCode enum. */
+            enum TypeCode {
+                TYPE_CODE_UNSPECIFIED = 0,
+                BOOL = 1,
+                INT64 = 2,
+                FLOAT64 = 3,
+                TIMESTAMP = 4,
+                DATE = 5,
+                STRING = 6,
+                BYTES = 7,
+                ARRAY = 8,
+                STRUCT = 9
+            }
+
             /** Properties of a Type. */
             interface IType {
 
                 /** Type code */
-                code?: (google.spanner.v1.TypeCode|null);
+                code?: (google.spanner.v1.TypeCode|keyof typeof google.spanner.v1.TypeCode|null);
 
                 /** Type arrayElementType */
                 arrayElementType?: (google.spanner.v1.IType|null);
@@ -4647,7 +4757,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IType);
 
                 /** Type code. */
-                public code: google.spanner.v1.TypeCode;
+                public code: (google.spanner.v1.TypeCode|keyof typeof google.spanner.v1.TypeCode);
 
                 /** Type arrayElementType. */
                 public arrayElementType?: (google.spanner.v1.IType|null);
@@ -4913,20 +5023,6 @@ export namespace google {
                      */
                     public toJSON(): { [k: string]: any };
                 }
-            }
-
-            /** TypeCode enum. */
-            enum TypeCode {
-                TYPE_CODE_UNSPECIFIED = 0,
-                BOOL = 1,
-                INT64 = 2,
-                FLOAT64 = 3,
-                TIMESTAMP = 4,
-                DATE = 5,
-                STRING = 6,
-                BYTES = 7,
-                ARRAY = 8,
-                STRUCT = 9
             }
         }
     }

--- a/proto/spanner.d.ts
+++ b/proto/spanner.d.ts
@@ -1146,16 +1146,16 @@ export namespace google {
                 paramTypes?: ({ [k: string]: google.spanner.v1.IType }|null);
 
                 /** ExecuteSqlRequest resumeToken */
-                resumeToken?: (Uint8Array|string|null);
+                resumeToken?: (Uint8Array|null);
 
                 /** ExecuteSqlRequest queryMode */
-                queryMode?: (google.spanner.v1.ExecuteSqlRequest.QueryMode|keyof typeof google.spanner.v1.ExecuteSqlRequest.QueryMode|null);
+                queryMode?: (google.spanner.v1.ExecuteSqlRequest.QueryMode|null);
 
                 /** ExecuteSqlRequest partitionToken */
-                partitionToken?: (Uint8Array|string|null);
+                partitionToken?: (Uint8Array|null);
 
                 /** ExecuteSqlRequest seqno */
-                seqno?: (number|Long|string|null);
+                seqno?: (number|Long|null);
 
                 /** ExecuteSqlRequest queryOptions */
                 queryOptions?: (google.spanner.v1.ExecuteSqlRequest.IQueryOptions|null);
@@ -1186,16 +1186,16 @@ export namespace google {
                 public paramTypes: { [k: string]: google.spanner.v1.IType };
 
                 /** ExecuteSqlRequest resumeToken. */
-                public resumeToken: (Uint8Array|string);
+                public resumeToken: Uint8Array;
 
                 /** ExecuteSqlRequest queryMode. */
-                public queryMode: (google.spanner.v1.ExecuteSqlRequest.QueryMode|keyof typeof google.spanner.v1.ExecuteSqlRequest.QueryMode);
+                public queryMode: google.spanner.v1.ExecuteSqlRequest.QueryMode;
 
                 /** ExecuteSqlRequest partitionToken. */
-                public partitionToken: (Uint8Array|string);
+                public partitionToken: Uint8Array;
 
                 /** ExecuteSqlRequest seqno. */
-                public seqno: (number|Long|string);
+                public seqno: (number|Long);
 
                 /** ExecuteSqlRequest queryOptions. */
                 public queryOptions?: (google.spanner.v1.ExecuteSqlRequest.IQueryOptions|null);
@@ -1384,7 +1384,7 @@ export namespace google {
                 statements?: (google.spanner.v1.ExecuteBatchDmlRequest.IStatement[]|null);
 
                 /** ExecuteBatchDmlRequest seqno */
-                seqno?: (number|Long|string|null);
+                seqno?: (number|Long|null);
             }
 
             /** Represents an ExecuteBatchDmlRequest. */
@@ -1406,7 +1406,7 @@ export namespace google {
                 public statements: google.spanner.v1.ExecuteBatchDmlRequest.IStatement[];
 
                 /** ExecuteBatchDmlRequest seqno. */
-                public seqno: (number|Long|string);
+                public seqno: (number|Long);
 
                 /**
                  * Creates a new ExecuteBatchDmlRequest instance using the specified properties.
@@ -1684,10 +1684,10 @@ export namespace google {
             interface IPartitionOptions {
 
                 /** PartitionOptions partitionSizeBytes */
-                partitionSizeBytes?: (number|Long|string|null);
+                partitionSizeBytes?: (number|Long|null);
 
                 /** PartitionOptions maxPartitions */
-                maxPartitions?: (number|Long|string|null);
+                maxPartitions?: (number|Long|null);
             }
 
             /** Represents a PartitionOptions. */
@@ -1700,10 +1700,10 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IPartitionOptions);
 
                 /** PartitionOptions partitionSizeBytes. */
-                public partitionSizeBytes: (number|Long|string);
+                public partitionSizeBytes: (number|Long);
 
                 /** PartitionOptions maxPartitions. */
-                public maxPartitions: (number|Long|string);
+                public maxPartitions: (number|Long);
 
                 /**
                  * Creates a new PartitionOptions instance using the specified properties.
@@ -2026,7 +2026,7 @@ export namespace google {
             interface IPartition {
 
                 /** Partition partitionToken */
-                partitionToken?: (Uint8Array|string|null);
+                partitionToken?: (Uint8Array|null);
             }
 
             /** Represents a Partition. */
@@ -2039,7 +2039,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IPartition);
 
                 /** Partition partitionToken. */
-                public partitionToken: (Uint8Array|string);
+                public partitionToken: Uint8Array;
 
                 /**
                  * Creates a new Partition instance using the specified properties.
@@ -2230,13 +2230,13 @@ export namespace google {
                 keySet?: (google.spanner.v1.IKeySet|null);
 
                 /** ReadRequest limit */
-                limit?: (number|Long|string|null);
+                limit?: (number|Long|null);
 
                 /** ReadRequest resumeToken */
-                resumeToken?: (Uint8Array|string|null);
+                resumeToken?: (Uint8Array|null);
 
                 /** ReadRequest partitionToken */
-                partitionToken?: (Uint8Array|string|null);
+                partitionToken?: (Uint8Array|null);
             }
 
             /** Represents a ReadRequest. */
@@ -2267,13 +2267,13 @@ export namespace google {
                 public keySet?: (google.spanner.v1.IKeySet|null);
 
                 /** ReadRequest limit. */
-                public limit: (number|Long|string);
+                public limit: (number|Long);
 
                 /** ReadRequest resumeToken. */
-                public resumeToken: (Uint8Array|string);
+                public resumeToken: Uint8Array;
 
                 /** ReadRequest partitionToken. */
-                public partitionToken: (Uint8Array|string);
+                public partitionToken: Uint8Array;
 
                 /**
                  * Creates a new ReadRequest instance using the specified properties.
@@ -2449,7 +2449,7 @@ export namespace google {
                 session?: (string|null);
 
                 /** CommitRequest transactionId */
-                transactionId?: (Uint8Array|string|null);
+                transactionId?: (Uint8Array|null);
 
                 /** CommitRequest singleUseTransaction */
                 singleUseTransaction?: (google.spanner.v1.ITransactionOptions|null);
@@ -2471,7 +2471,7 @@ export namespace google {
                 public session: string;
 
                 /** CommitRequest transactionId. */
-                public transactionId: (Uint8Array|string);
+                public transactionId: Uint8Array;
 
                 /** CommitRequest singleUseTransaction. */
                 public singleUseTransaction?: (google.spanner.v1.ITransactionOptions|null);
@@ -2650,7 +2650,7 @@ export namespace google {
                 session?: (string|null);
 
                 /** RollbackRequest transactionId */
-                transactionId?: (Uint8Array|string|null);
+                transactionId?: (Uint8Array|null);
             }
 
             /** Represents a RollbackRequest. */
@@ -2666,7 +2666,7 @@ export namespace google {
                 public session: string;
 
                 /** RollbackRequest transactionId. */
-                public transactionId: (Uint8Array|string);
+                public transactionId: Uint8Array;
 
                 /**
                  * Creates a new RollbackRequest instance using the specified properties.
@@ -3388,7 +3388,7 @@ export namespace google {
                 chunkedValue?: (boolean|null);
 
                 /** PartialResultSet resumeToken */
-                resumeToken?: (Uint8Array|string|null);
+                resumeToken?: (Uint8Array|null);
 
                 /** PartialResultSet stats */
                 stats?: (google.spanner.v1.IResultSetStats|null);
@@ -3413,7 +3413,7 @@ export namespace google {
                 public chunkedValue: boolean;
 
                 /** PartialResultSet resumeToken. */
-                public resumeToken: (Uint8Array|string);
+                public resumeToken: Uint8Array;
 
                 /** PartialResultSet stats. */
                 public stats?: (google.spanner.v1.IResultSetStats|null);
@@ -3595,10 +3595,10 @@ export namespace google {
                 queryStats?: (google.protobuf.IStruct|null);
 
                 /** ResultSetStats rowCountExact */
-                rowCountExact?: (number|Long|string|null);
+                rowCountExact?: (number|Long|null);
 
                 /** ResultSetStats rowCountLowerBound */
-                rowCountLowerBound?: (number|Long|string|null);
+                rowCountLowerBound?: (number|Long|null);
             }
 
             /** Represents a ResultSetStats. */
@@ -3617,10 +3617,10 @@ export namespace google {
                 public queryStats?: (google.protobuf.IStruct|null);
 
                 /** ResultSetStats rowCountExact. */
-                public rowCountExact: (number|Long|string);
+                public rowCountExact: (number|Long);
 
                 /** ResultSetStats rowCountLowerBound. */
-                public rowCountLowerBound: (number|Long|string);
+                public rowCountLowerBound: (number|Long);
 
                 /** ResultSetStats rowCount. */
                 public rowCount?: ("rowCountExact"|"rowCountLowerBound");
@@ -3703,7 +3703,7 @@ export namespace google {
                 index?: (number|null);
 
                 /** PlanNode kind */
-                kind?: (google.spanner.v1.PlanNode.Kind|keyof typeof google.spanner.v1.PlanNode.Kind|null);
+                kind?: (google.spanner.v1.PlanNode.Kind|null);
 
                 /** PlanNode displayName */
                 displayName?: (string|null);
@@ -3734,7 +3734,7 @@ export namespace google {
                 public index: number;
 
                 /** PlanNode kind. */
-                public kind: (google.spanner.v1.PlanNode.Kind|keyof typeof google.spanner.v1.PlanNode.Kind);
+                public kind: google.spanner.v1.PlanNode.Kind;
 
                 /** PlanNode displayName. */
                 public displayName: string;
@@ -4523,7 +4523,7 @@ export namespace google {
             interface ITransaction {
 
                 /** Transaction id */
-                id?: (Uint8Array|string|null);
+                id?: (Uint8Array|null);
 
                 /** Transaction readTimestamp */
                 readTimestamp?: (google.protobuf.ITimestamp|null);
@@ -4539,7 +4539,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.ITransaction);
 
                 /** Transaction id. */
-                public id: (Uint8Array|string);
+                public id: Uint8Array;
 
                 /** Transaction readTimestamp. */
                 public readTimestamp?: (google.protobuf.ITimestamp|null);
@@ -4622,7 +4622,7 @@ export namespace google {
                 singleUse?: (google.spanner.v1.ITransactionOptions|null);
 
                 /** TransactionSelector id */
-                id?: (Uint8Array|string|null);
+                id?: (Uint8Array|null);
 
                 /** TransactionSelector begin */
                 begin?: (google.spanner.v1.ITransactionOptions|null);
@@ -4641,7 +4641,7 @@ export namespace google {
                 public singleUse?: (google.spanner.v1.ITransactionOptions|null);
 
                 /** TransactionSelector id. */
-                public id: (Uint8Array|string);
+                public id: Uint8Array;
 
                 /** TransactionSelector begin. */
                 public begin?: (google.spanner.v1.ITransactionOptions|null);
@@ -4720,25 +4720,11 @@ export namespace google {
                 public toJSON(): { [k: string]: any };
             }
 
-            /** TypeCode enum. */
-            enum TypeCode {
-                TYPE_CODE_UNSPECIFIED = 0,
-                BOOL = 1,
-                INT64 = 2,
-                FLOAT64 = 3,
-                TIMESTAMP = 4,
-                DATE = 5,
-                STRING = 6,
-                BYTES = 7,
-                ARRAY = 8,
-                STRUCT = 9
-            }
-
             /** Properties of a Type. */
             interface IType {
 
                 /** Type code */
-                code?: (google.spanner.v1.TypeCode|keyof typeof google.spanner.v1.TypeCode|null);
+                code?: (google.spanner.v1.TypeCode|null);
 
                 /** Type arrayElementType */
                 arrayElementType?: (google.spanner.v1.IType|null);
@@ -4757,7 +4743,7 @@ export namespace google {
                 constructor(properties?: google.spanner.v1.IType);
 
                 /** Type code. */
-                public code: (google.spanner.v1.TypeCode|keyof typeof google.spanner.v1.TypeCode);
+                public code: google.spanner.v1.TypeCode;
 
                 /** Type arrayElementType. */
                 public arrayElementType?: (google.spanner.v1.IType|null);
@@ -5023,6 +5009,20 @@ export namespace google {
                      */
                     public toJSON(): { [k: string]: any };
                 }
+            }
+
+            /** TypeCode enum. */
+            enum TypeCode {
+                TYPE_CODE_UNSPECIFIED = 0,
+                BOOL = 1,
+                INT64 = 2,
+                FLOAT64 = 3,
+                TIMESTAMP = 4,
+                DATE = 5,
+                STRING = 6,
+                BYTES = 7,
+                ARRAY = 8,
+                STRUCT = 9
             }
         }
     }

--- a/samples/queryoptions.js
+++ b/samples/queryoptions.js
@@ -1,0 +1,152 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+async function databaseWithQueryOptions(instanceId, databaseId, projectId) {
+  // [START spanner_create_client_with_query_options]
+  // Imports the Google Cloud client library
+  const {Spanner} = require('@google-cloud/spanner');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = 'my-project-id';
+  // const instanceId = 'my-instance';
+  // const databaseId = 'my-database';
+
+  // Creates a client
+  const spanner = new Spanner({
+    projectId: projectId,
+  });
+
+  // Gets a reference to a Cloud Spanner instance and database
+  const instance = spanner.instance(instanceId);
+  const database = instance.database(databaseId, {}, {optimizerVersion: '1'});
+
+  const query = {
+    sql: `SELECT AlbumId, AlbumTitle, MarketingBudget
+          FROM Albums
+          ORDER BY AlbumTitle`,
+  };
+
+  // Queries rows from the Albums table
+  try {
+    const [rows] = await database.run(query);
+
+    rows.forEach(row => {
+      const json = row.toJSON();
+      const marketingBudget = json.MarketingBudget
+        ? json.MarketingBudget
+        : null; // This value is nullable
+      console.log(
+        `AlbumId: ${json.AlbumId}, AlbumTitle: ${json.AlbumTitle}, MarketingBudget: ${marketingBudget}`
+      );
+    });
+  } catch (err) {
+    console.error('ERROR:', err);
+  } finally {
+    // Close the database when finished.
+    database.close();
+  }
+  // [END spanner_create_client_with_query_options]
+}
+
+async function queryWithQueryOptions(instanceId, databaseId, projectId) {
+  // [START spanner_query_with_query_options]
+  // Imports the Google Cloud client library
+  const {Spanner} = require('@google-cloud/spanner');
+
+  /**
+   * TODO(developer): Uncomment the following lines before running the sample.
+   */
+  // const projectId = 'my-project-id';
+  // const instanceId = 'my-instance';
+  // const databaseId = 'my-database';
+
+  // Creates a client
+  const spanner = new Spanner({
+    projectId: projectId,
+  });
+
+  // Gets a reference to a Cloud Spanner instance and database
+  const instance = spanner.instance(instanceId);
+  const database = instance.database(databaseId);
+
+  const query = {
+    sql: `SELECT AlbumId, AlbumTitle, MarketingBudget
+          FROM Albums
+          ORDER BY AlbumTitle`,
+    queryOptions: {
+      optimizerVersion: 'latest',
+    },
+  };
+
+  // Queries rows from the Albums table
+  try {
+    const [rows] = await database.run(query);
+
+    rows.forEach(row => {
+      const json = row.toJSON();
+      const marketingBudget = json.MarketingBudget
+        ? json.MarketingBudget
+        : null; // This value is nullable
+      console.log(
+        `AlbumId: ${json.AlbumId}, AlbumTitle: ${json.AlbumTitle}, MarketingBudget: ${marketingBudget}`
+      );
+    });
+  } catch (err) {
+    console.error('ERROR:', err);
+  } finally {
+    // Close the database when finished.
+    database.close();
+  }
+  // [END spanner_query_with_query_options]
+}
+
+require(`yargs`)
+  .demand(1)
+  .command(
+    `databaseWithQueryOptions <instanceName> <databaseName> <projectId>`,
+    `Gets a database reference with default query options and executes a query`,
+    {},
+    opts =>
+      databaseWithQueryOptions(
+        opts.instanceName,
+        opts.databaseName,
+        opts.projectId
+      )
+  )
+  .command(
+    `queryWithQueryOptions <instanceName> <databaseName> <projectId>`,
+    `Executes a query using specific query options`,
+    {},
+    opts =>
+      queryWithQueryOptions(
+        opts.instanceName,
+        opts.databaseName,
+        opts.projectId
+      )
+  )
+  .example(
+    `node $0 databaseWithQueryOptions "my-instance" "my-database" "my-project-id"`
+  )
+  .example(
+    `node $0 queryWithQueryOptions "my-instance" "my-database" "my-project-id"`
+  )
+  .wrap(120)
+  .recommendCommands()
+  .epilogue(`For more information, see https://cloud.google.com/spanner/docs`)
+  .strict()
+  .help().argv;

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -25,6 +25,7 @@ const batchCmd = `node batch.js`;
 const crudCmd = `node crud.js`;
 const schemaCmd = `node schema.js`;
 const indexingCmd = `node indexing.js`;
+const queryOptionsCmd = `node queryoptions.js`;
 const transactionCmd = `node transaction.js`;
 const timestampCmd = `node timestamp.js`;
 const structCmd = `node struct.js`;
@@ -267,6 +268,36 @@ describe('Spanner', () => {
       `${indexingCmd} readStoringIndex ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
     assert.match(output, /AlbumId: 1, AlbumTitle: Total Junk/);
+  });
+
+  // spanner_create_client_with_query_options
+  it(`should use query options from a database reference`, async () => {
+    const output = execSync(
+      `${queryOptionsCmd} databaseWithQueryOptions ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
+    );
+    assert.match(
+      output,
+      /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
+    );
+    assert.notMatch(
+      output,
+      /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+    );
+  });
+
+  // spanner_query_with_query_options
+  it(`should use query options on request`, async () => {
+    const output = execSync(
+      `${queryOptionsCmd} queryWithQueryOptions ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
+    );
+    assert.match(
+      output,
+      /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
+    );
+    assert.notMatch(
+      output,
+      /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+    );
   });
 
   // read_only_transaction

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -277,11 +277,7 @@ describe('Spanner', () => {
     );
     assert.match(
       output,
-      /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
-    );
-    assert.notMatch(
-      output,
-      /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+      /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
     );
   });
 
@@ -292,11 +288,7 @@ describe('Spanner', () => {
     );
     assert.match(
       output,
-      /AlbumId: 2, AlbumTitle: Go, Go, Go, MarketingBudget:/
-    );
-    assert.notMatch(
-      output,
-      /AlbumId: 1, AlbumTitle: Total Junk, MarketingBudget:/
+      /AlbumId: 2, AlbumTitle: Forever Hold your Peace, MarketingBudget:/
     );
   });
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -290,10 +290,6 @@ class Database extends GrpcServiceObject {
     if (process.env.SPANNER_OPTIMIZER_VERSION) {
       options.optimizerVersion = process.env.SPANNER_OPTIMIZER_VERSION;
     }
-    if (process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE) {
-      options.optimizerStatisticsPackage =
-        process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE;
-    }
     return options;
   }
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -187,6 +187,8 @@ export interface CancelableDuplex extends Duplex {
  * @param {string} name Name of the database.
  * @param {SessionPoolOptions|SessionPoolInterface} options Session pool
  *     configuration options or custom pool interface.
+ * @param {spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions} queryOptions
+ *     The default query options to use for queries on the database.
  *
  * @example
  * const {Spanner} = require('@google-cloud/spanner');
@@ -197,6 +199,7 @@ export interface CancelableDuplex extends Duplex {
 class Database extends GrpcServiceObject {
   formattedName_: string;
   pool_: SessionPoolInterface;
+  queryOptions_?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions;
   request: <T, R = void>(
     config: RequestConfig,
     callback: RequestCallback<T, R>
@@ -204,7 +207,8 @@ class Database extends GrpcServiceObject {
   constructor(
     instance: Instance,
     name: string,
-    poolOptions?: SessionPoolConstructor | SessionPoolOptions
+    poolOptions?: SessionPoolConstructor | SessionPoolOptions,
+    queryOptions?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions
   ) {
     const methods = {
       /**
@@ -275,6 +279,22 @@ class Database extends GrpcServiceObject {
     this.requestStream = instance.requestStream as any;
     this.pool_.on('error', this.emit.bind(this, 'error'));
     this.pool_.open();
+    this.queryOptions_ = Object.assign(
+      Object.assign({}, queryOptions),
+      Database.getEnvironmentQueryOptions()
+    );
+  }
+
+  static getEnvironmentQueryOptions() {
+    const options = {} as spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions;
+    if (process.env.SPANNER_OPTIMIZER_VERSION) {
+      options.optimizerVersion = process.env.SPANNER_OPTIMIZER_VERSION;
+    }
+    if (process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE) {
+      options.optimizerStatisticsPackage =
+        process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE;
+    }
+    return options;
   }
 
   batchCreateSessions(
@@ -1219,7 +1239,7 @@ class Database extends GrpcServiceObject {
         return;
       }
 
-      const snapshot = session!.snapshot(options);
+      const snapshot = session!.snapshot(options, this.queryOptions_);
 
       snapshot.begin(err => {
         if (err) {
@@ -1737,7 +1757,7 @@ class Database extends GrpcServiceObject {
         return;
       }
 
-      const snapshot = session!.snapshot(options);
+      const snapshot = session!.snapshot(options, this.queryOptions_);
 
       this._releaseOnEnd(session!, snapshot);
 
@@ -1878,6 +1898,7 @@ class Database extends GrpcServiceObject {
         return;
       }
 
+      transaction!.queryOptions = this.queryOptions_;
       const release = this.pool_.release.bind(this.pool_, session!);
       const runner = new TransactionRunner(
         session!,

--- a/src/database.ts
+++ b/src/database.ts
@@ -1894,7 +1894,6 @@ class Database extends GrpcServiceObject {
         return;
       }
 
-      transaction!.queryOptions = this.queryOptions_;
       const release = this.pool_.release.bind(this.pool_, session!);
       const runner = new TransactionRunner(
         session!,

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -896,7 +896,9 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
    * @returns {Promise}
    */
   async _prepareTransaction(session: Session): Promise<void> {
-    const transaction = session.transaction();
+    const transaction = session.transaction(
+      (session.parent as Database).queryOptions_
+    );
     await transaction.begin();
     session.txn = transaction;
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -389,13 +389,16 @@ export class Session extends GrpcServiceObject {
   /**
    * Create a read write Transaction.
    *
+   * @param {google.spanner.v1.ExecuteSqlRequest.IQueryOptions} [queryOptions] The default query options to use.
    * @return {Transaction}
    *
    * @example
    * const transaction = session.transaction();
    */
-  transaction() {
-    return new Transaction(this);
+  transaction(
+    queryOptions?: google.spanner.v1.ExecuteSqlRequest.IQueryOptions
+  ) {
+    return new Transaction(this, undefined, queryOptions);
   }
   /**
    * Format the session name to include the parent database's name.

--- a/src/session.ts
+++ b/src/session.ts
@@ -374,13 +374,17 @@ export class Session extends GrpcServiceObject {
    * Create a Snapshot transaction.
    *
    * @param {TimestampBounds} [options] The timestamp bounds.
+   * @param {google.spanner.v1.ExecuteSqlRequest.IQueryOptions} [queryOptions] The default query options to use.
    * @returns {Snapshot}
    *
    * @example
    * const snapshot = session.snapshot({strong: false});
    */
-  snapshot(options?: TimestampBounds) {
-    return new Snapshot(this, options);
+  snapshot(
+    options?: TimestampBounds,
+    queryOptions?: google.spanner.v1.ExecuteSqlRequest.IQueryOptions
+  ) {
+    return new Snapshot(this, options, queryOptions);
   }
   /**
    * Create a read write Transaction.

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -23,6 +23,7 @@ import {Session} from './session';
 import {Transaction} from './transaction';
 import {NormalCallback} from './common';
 import {isSessionNotFoundError} from './session-pool';
+import {Database} from './database';
 
 const jsonProtos = require('../protos/protos.json');
 const RETRY_INFO = 'google.rpc.retryinfo-bin';
@@ -182,7 +183,9 @@ export abstract class Runner<T> {
       return transaction;
     }
 
-    const transaction = this.session.transaction();
+    const transaction = this.session.transaction(
+      (this.session.parent as Database).queryOptions_
+    );
     await transaction.begin();
     return transaction;
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -39,6 +39,7 @@ import {NormalCallback} from './common';
 import {google} from '../protos/protos';
 import IAny = google.protobuf.IAny;
 import * as grpc from 'grpc';
+import {Database} from './database';
 
 export type Rows = Array<Row | Json>;
 const RETRY_INFO_TYPE = 'type.googleapis.com/google.rpc.retryinfo';
@@ -253,7 +254,8 @@ export class Snapshot extends EventEmitter {
 
     this.ended = false;
     this.session = session;
-    this.queryOptions = Object.assign({}, queryOptions);
+    const parentQueryOptions = Object.assign({}, (this.session.parent as Database).queryOptions_);
+    this.queryOptions = Object.assign({}, Object.assign(parentQueryOptions, queryOptions));
     this.request = session.request.bind(session);
     this.requestStream = session.requestStream.bind(session);
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -72,7 +72,7 @@ export interface ExecuteSqlRequest extends Statement, RequestOptions {
   queryMode?: s.QueryMode;
   partitionToken?: Uint8Array | string;
   seqno?: number;
-  queryOptions?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions;
+  queryOptions?: IQueryOptions;
 }
 
 export interface KeyRange {
@@ -201,7 +201,7 @@ export class Snapshot extends EventEmitter {
   request: (config: {}, callback: Function) => void;
   requestStream: (config: {}) => Readable;
   session: Session;
-  queryOptions?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions;
+  queryOptions?: IQueryOptions;
 
   /**
    * The transaction ID.
@@ -249,7 +249,7 @@ export class Snapshot extends EventEmitter {
   constructor(
     session: Session,
     options?: TimestampBounds,
-    queryOptions?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions
+    queryOptions?: IQueryOptions
   ) {
     super();
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -40,6 +40,7 @@ import {google} from '../protos/protos';
 import IAny = google.protobuf.IAny;
 import * as grpc from 'grpc';
 import {Database} from './database';
+import IQueryOptions = google.spanner.v1.ExecuteSqlRequest.IQueryOptions;
 
 export type Rows = Array<Row | Json>;
 const RETRY_INFO_TYPE = 'type.googleapis.com/google.rpc.retryinfo';
@@ -254,8 +255,7 @@ export class Snapshot extends EventEmitter {
 
     this.ended = false;
     this.session = session;
-    const parentQueryOptions = Object.assign({}, (this.session.parent as Database).queryOptions_);
-    this.queryOptions = Object.assign({}, Object.assign(parentQueryOptions, queryOptions));
+    this.queryOptions = Object.assign({}, queryOptions);
     this.request = session.request.bind(session);
     this.requestStream = session.requestStream.bind(session);
 
@@ -1200,8 +1200,12 @@ export class Transaction extends Dml {
    *   }
    * });
    */
-  constructor(session: Session, options = {} as s.ReadWrite) {
-    super(session);
+  constructor(
+    session: Session,
+    options = {} as s.ReadWrite,
+    queryOptions?: IQueryOptions
+  ) {
+    super(session, undefined, queryOptions);
 
     this._queuedMutations = [];
     this._options = {readWrite: options};

--- a/src/v1/spanner_client.d.ts
+++ b/src/v1/spanner_client.d.ts
@@ -201,6 +201,7 @@ declare namespace SpannerClient {
     queryMode?: QueryMode;
     partitionToken?: Uint8Array | string;
     seqno?: number;
+    queryOptions?: google.spanner.v1.ExecuteSqlRequest.IQueryOptions;
   }
 
   interface ExecuteSqlCallback {

--- a/test/mockserver/mockspanner.ts
+++ b/test/mockserver/mockspanner.ts
@@ -26,7 +26,6 @@ import ExecuteBatchDmlResponse = google.spanner.v1.ExecuteBatchDmlResponse;
 import ResultSet = google.spanner.v1.ResultSet;
 import Status = google.rpc.Status;
 import Any = google.protobuf.Any;
-import {RequestType} from 'google-gax/build/src/apitypes';
 
 const PROTO_PATH = 'spanner.proto';
 const IMPORT_PATH = __dirname + '/../../../protos';

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -629,7 +629,7 @@ describe('Spanner with mock server', () => {
         options?: SessionPoolOptions,
         queryOptions?: IQueryOptions
       ): Database {
-        return instanceWithEnvVar.database(`database-${dbCounter++}`, options);
+        return instanceWithEnvVar.database(`database-${dbCounter++}`, options, queryOptions);
       }
 
       before(() => {
@@ -658,7 +658,7 @@ describe('Spanner with mock server', () => {
         }
       });
 
-      it('database-with-query-options database.run', async () => {
+      it('database.run with database-with-query-options', async () => {
         // The options that are given in the database options will not be used
         // as they are overridden by the environment variable.
         const database = newTestDatabase(undefined, {
@@ -716,7 +716,7 @@ describe('Spanner with mock server', () => {
         }
       });
 
-      it('database-with-query-options snapshot.run', async () => {
+      it('snapshot.run with database-with-query-options', async () => {
         const database = newTestDatabase(undefined, {
           optimizerVersion: 'version-in-db-opts',
         });
@@ -759,7 +759,7 @@ describe('Spanner with mock server', () => {
         });
       });
 
-      it('database-with-query-options transaction.run', done => {
+      it('transaction.run with database-with-query-options', done => {
         const database = newTestDatabase(undefined, {
           optimizerVersion: 'version-in-db-opts',
         });
@@ -804,7 +804,7 @@ describe('Spanner with mock server', () => {
         }
       });
 
-      it('database-with-query-options async transaction.run', async () => {
+      it('async transaction.run with database-with-query-options', async () => {
         const database = newTestDatabase(undefined, {
           optimizerVersion: 'version-in-db-opts',
         });

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -41,6 +41,9 @@ import {
 import CreateInstanceMetadata = google.spanner.admin.instance.v1.CreateInstanceMetadata;
 import {Json} from '../src/codec';
 import Done = Mocha.Done;
+import QueryOptions = google.spanner.v1.ExecuteSqlRequest.QueryOptions;
+import v1 = google.spanner.v1;
+import IQueryOptions = google.spanner.v1.ExecuteSqlRequest.IQueryOptions;
 
 function numberToEnglishWord(num: number): string {
   switch (num) {
@@ -68,6 +71,7 @@ describe('Spanner with mock server', () => {
   const spannerMock = mock.createMockSpanner(server);
   mockInstanceAdmin.createMockInstanceAdmin(server);
   mockDatabaseAdmin.createMockDatabaseAdmin(server);
+  let port: number;
   let spanner: Spanner;
   let instance: Instance;
   let dbCounter = 1;
@@ -78,10 +82,7 @@ describe('Spanner with mock server', () => {
 
   before(() => {
     sandbox = sinon.createSandbox();
-    const port = server.bind(
-      '0.0.0.0:0',
-      grpc.ServerCredentials.createInsecure()
-    );
+    port = server.bind('0.0.0.0:0', grpc.ServerCredentials.createInsecure());
     server.start();
     spannerMock.putStatementResult(
       selectSql,
@@ -117,6 +118,10 @@ describe('Spanner with mock server', () => {
     server.tryShutdown(() => {});
     delete process.env.SPANNER_EMULATOR_HOST;
     sandbox.restore();
+  });
+
+  beforeEach(() => {
+    spannerMock.resetRequests();
   });
 
   describe('basics', () => {
@@ -519,6 +524,357 @@ describe('Spanner with mock server', () => {
             })
             .catch(done);
         });
+      });
+    });
+  });
+
+  describe('queryOptions', () => {
+    /** Common verify method for QueryOptions tests. */
+    function verifyQueryOptions(
+      optimizerVersion: string,
+    ) {
+      const request = spannerMock.getRequests().find(val => {
+        return (val as v1.ExecuteSqlRequest).sql;
+      }) as v1.ExecuteSqlRequest;
+      assert.ok(request, 'no ExecuteSqlRequest found');
+      assert.ok(
+        request.queryOptions,
+        'no queryOptions found on ExecuteSqlRequest'
+      );
+      assert.strictEqual(
+        request.queryOptions!.optimizerVersion,
+        optimizerVersion
+      );
+    }
+
+    describe('on request', () => {
+      it('database.run', async () => {
+        const query = {
+          sql: selectSql,
+          queryOptions: QueryOptions.create({
+            optimizerVersion: '100',
+          }),
+        } as ExecuteSqlRequest;
+        const database = newTestDatabase();
+        try {
+          await database.run(query);
+          verifyQueryOptions('100');
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('snapshot.run', async () => {
+        const query = {
+          sql: selectSql,
+          queryOptions: QueryOptions.create({
+            optimizerVersion: '100',
+          }),
+        } as ExecuteSqlRequest;
+        const database = newTestDatabase();
+        try {
+          const [snapshot] = await database.getSnapshot();
+          await snapshot.run(query);
+          verifyQueryOptions('100');
+          await snapshot.end();
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('transaction.run', done => {
+        const query = {
+          sql: selectSql,
+          queryOptions: QueryOptions.create({
+            optimizerVersion: '100',
+          }),
+        } as ExecuteSqlRequest;
+        const database = newTestDatabase();
+        database.runTransaction(async (err, transaction) => {
+          assert.ifError(err);
+          await transaction!.run(query);
+          verifyQueryOptions('100');
+          await transaction!.commit();
+          await database.close();
+          done();
+        });
+      });
+
+      it('async transaction.run', async () => {
+        const query = {
+          sql: selectSql,
+          queryOptions: QueryOptions.create({
+            optimizerVersion: '100',
+          }),
+        } as ExecuteSqlRequest;
+        const database = newTestDatabase();
+        try {
+          await database.runTransactionAsync(async transaction => {
+            await transaction.run(query);
+            verifyQueryOptions('100');
+            await transaction.commit();
+          });
+        } finally {
+          await database.close();
+        }
+      });
+    });
+
+    describe('with environment variable', () => {
+      const OPTIMIZER_VERSION = '20';
+      let spannerWithEnvVar: Spanner;
+      let instanceWithEnvVar: Instance;
+
+      function newTestDatabase(
+        options?: SessionPoolOptions,
+        queryOptions?: IQueryOptions
+      ): Database {
+        return instanceWithEnvVar.database(`database-${dbCounter++}`, options);
+      }
+
+      before(() => {
+        process.env.SPANNER_OPTIMIZER_VERSION = OPTIMIZER_VERSION;
+        spannerWithEnvVar = new Spanner({
+          projectId: 'fake-project-id',
+          servicePath: 'localhost',
+          port,
+          sslCreds: grpc.credentials.createInsecure(),
+        });
+        // Gets a reference to a Cloud Spanner instance and database
+        instanceWithEnvVar = spannerWithEnvVar.instance('instance');
+      });
+
+      after(() => {
+        delete process.env.SPANNER_OPTIMIZER_VERSION;
+      });
+
+      it('database.run', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('database-with-query-options database.run', async () => {
+        // The options that are given in the database options will not be used
+        // as they are overridden by the environment variable.
+        const database = newTestDatabase(undefined, {
+          optimizerVersion: 'version-in-db-opts',
+        });
+        try {
+          await database.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('database.run with query-options', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.run({
+            sql: selectSql,
+            queryOptions: {
+              optimizerVersion: 'version-on-query',
+            },
+          });
+          verifyQueryOptions('version-on-query');
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('snapshot.run', async () => {
+        const database = newTestDatabase();
+        try {
+          const [snapshot] = await database.getSnapshot();
+          await snapshot.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await snapshot.end();
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('snapshot.run with query-options', async () => {
+        const database = newTestDatabase();
+        try {
+          const [snapshot] = await database.getSnapshot();
+          await snapshot.run({
+            sql: selectSql,
+            queryOptions: {
+              optimizerVersion: 'version-on-query',
+            },
+          });
+          verifyQueryOptions('version-on-query');
+          await snapshot.end();
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('database-with-query-options snapshot.run', async () => {
+        const database = newTestDatabase(undefined, {
+          optimizerVersion: 'version-in-db-opts',
+        });
+        try {
+          const [snapshot] = await database.getSnapshot();
+          await snapshot.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await snapshot.end();
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('transaction.run', done => {
+        const database = newTestDatabase();
+        database.runTransaction(async (err, transaction) => {
+          assert.ifError(err);
+          await transaction!.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await transaction!.commit();
+          await database.close();
+          done();
+        });
+      });
+
+      it('transaction.run with query-options', done => {
+        const database = newTestDatabase();
+        database.runTransaction(async (err, transaction) => {
+          assert.ifError(err);
+          await transaction!.run({
+            sql: selectSql,
+            queryOptions: {
+              optimizerVersion: 'version-on-query',
+            },
+          });
+          verifyQueryOptions('version-on-query');
+          await transaction!.commit();
+          await database.close();
+          done();
+        });
+      });
+
+      it('database-with-query-options transaction.run', done => {
+        const database = newTestDatabase(undefined, {
+          optimizerVersion: 'version-in-db-opts',
+        });
+        database.runTransaction(async (err, transaction) => {
+          assert.ifError(err);
+          await transaction!.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await transaction!.commit();
+          await database.close();
+          done();
+        });
+      });
+
+      it('async transaction.run', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.runTransactionAsync(async transaction => {
+            await transaction.run(selectSql);
+            verifyQueryOptions(OPTIMIZER_VERSION);
+            await transaction.commit();
+          });
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('async transaction.run with query-options', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.runTransactionAsync(async transaction => {
+            await transaction.run({
+              sql: selectSql,
+              queryOptions: {
+                optimizerVersion: 'version-on-query',
+              },
+            });
+            verifyQueryOptions('version-on-query');
+            await transaction.commit();
+          });
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('database-with-query-options async transaction.run', async () => {
+        const database = newTestDatabase(undefined, {
+          optimizerVersion: 'version-in-db-opts',
+        });
+        try {
+          await database.runTransactionAsync(async transaction => {
+            await transaction.run(selectSql);
+            verifyQueryOptions(OPTIMIZER_VERSION);
+            await transaction.commit();
+          });
+        } finally {
+          await database.close();
+        }
+      });
+    });
+
+    describe('on database options', () => {
+      const OPTIMIZER_VERSION = '40';
+
+      // Request a database with default query options.
+      function newTestDatabase(options?: SessionPoolOptions): Database {
+        return instance.database(`database-${dbCounter++}`, options, {
+          optimizerVersion: OPTIMIZER_VERSION,
+        } as IQueryOptions);
+      }
+
+      it('database.run', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('snapshot.run', async () => {
+        const database = newTestDatabase();
+        try {
+          const [snapshot] = await database.getSnapshot();
+          await snapshot.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await snapshot.end();
+        } finally {
+          await database.close();
+        }
+      });
+
+      it('transaction.run', done => {
+        const database = newTestDatabase();
+        database.runTransaction(async (err, transaction) => {
+          assert.ifError(err);
+          await transaction!.run(selectSql);
+          verifyQueryOptions(OPTIMIZER_VERSION);
+          await transaction!.commit();
+          await database.close();
+          done();
+        });
+      });
+
+      it('async transaction.run', async () => {
+        const database = newTestDatabase();
+        try {
+          await database.runTransactionAsync(async transaction => {
+            await transaction.run(selectSql);
+            verifyQueryOptions(OPTIMIZER_VERSION);
+            await transaction.commit();
+          });
+        } finally {
+          await database.close();
+        }
       });
     });
   });

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -530,9 +530,7 @@ describe('Spanner with mock server', () => {
 
   describe('queryOptions', () => {
     /** Common verify method for QueryOptions tests. */
-    function verifyQueryOptions(
-      optimizerVersion: string,
-    ) {
+    function verifyQueryOptions(optimizerVersion: string) {
       const request = spannerMock.getRequests().find(val => {
         return (val as v1.ExecuteSqlRequest).sql;
       }) as v1.ExecuteSqlRequest;
@@ -629,7 +627,11 @@ describe('Spanner with mock server', () => {
         options?: SessionPoolOptions,
         queryOptions?: IQueryOptions
       ): Database {
-        return instanceWithEnvVar.database(`database-${dbCounter++}`, options, queryOptions);
+        return instanceWithEnvVar.database(
+          `database-${dbCounter++}`,
+          options,
+          queryOptions
+        );
       }
 
       before(() => {

--- a/test/transaction-runner.ts
+++ b/test/transaction-runner.ts
@@ -47,6 +47,7 @@ describe('TransactionRunner', () => {
   const FROM_JSON = sandbox.stub().returns({lookup: LOOKUP});
 
   const SESSION = {
+    parent: {},
     transaction: () => fakeTransaction,
   };
 

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -28,11 +28,13 @@ import {SpannerClient as s} from '../src/v1';
 describe('Transaction', () => {
   const sandbox = sinon.createSandbox();
 
+  const PARENT = {};
   const REQUEST = sandbox.stub();
   const REQUEST_STREAM = sandbox.stub();
   const SESSION_NAME = 'session-123';
 
   const SESSION = {
+    parent: PARENT,
     formattedName_: SESSION_NAME,
     request: REQUEST,
     requestStream: REQUEST_STREAM,

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -511,6 +511,7 @@ describe('Transaction', () => {
           params: {a: 'b'},
           types: {a: 'string'},
           seqno: 1,
+          queryOptions: {},
         });
 
         const expectedRequest = {
@@ -520,6 +521,7 @@ describe('Transaction', () => {
           params: fakeParams,
           paramTypes: fakeParamTypes,
           seqno: 1,
+          queryOptions: {},
           resumeToken: undefined,
         };
 


### PR DESCRIPTION
Adds the ability to set `QueryOptions` when running Cloud Spanner queries. For now, only setting the `query_optimizer_version` is added.

QueryOptions can be configured through the following mechanisms:

1. Through the `SPANNER_OPTIMIZER_VERSION` environment variable.
1. At `Database` level using `spanner.instance('instance-name').database('database-name', sessionPoolOptions, queryOptions)`.
1. At query level using `ExecuteSqlRequest.queryOptions`.

If the options are configured through multiple mechanisms then:

1. Options set at an environment variable level will override options configured at the `Database` level.
1. Options set at a query-level will override options set at either the `Database` or environment variable level.

If no options are set, the optimizer version will default to:

1. The optimizer version the database is pinned to in the backend.
1. If the database is not pinned to a specific version, then the Cloud Spanner backend will use the "latest" version.