### PR TITLE
fix!: params issue in executeSql

### DIFF
--- a/src/v1/spanner_client.js
+++ b/src/v1/spanner_client.js
@@ -17,6 +17,7 @@
 const gapicConfig = require('./spanner_client_config.json');
 const gax = require('google-gax');
 const path = require('path');
+const snapshot = require('../transaction').Snapshot;
 
 const VERSION = require('../../../package.json').version;
 
@@ -832,6 +833,9 @@ class SpannerClient {
       session: request.session,
     });
 
+    const {params, paramTypes} = snapshot.encodeParams(request);
+    request.params = params;
+    request.paramTypes = paramTypes;
     return this._innerApiCalls.executeSql(request, options, callback);
   }
 

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -761,6 +761,42 @@ describe('InstanceAdminClient', () => {
       });
     });
   });
+
+  describe('executeSql', () => {
+    it('shloud filter data using params', done => {
+      const client = new spannerModule.v1.SpannerClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
+
+      // Mock request
+      const sql = 'SELECT * FROM User Where Name =@name';
+      const request = {
+        sql: sql,
+        params: {
+          name: 'Grace',
+        },
+      };
+
+      // Mock response
+      const expectedResponse = {
+        id: '1',
+        name: 'Grace',
+      };
+
+      // Mock Grpc layer
+      client._innerApiCalls.executeSql = mockSimpleGrpcMethod(
+        request,
+        expectedResponse
+      );
+
+      client.executeSql(request, (err, response) => {
+        assert.ifError(err);
+        assert.deepStrictEqual(response, expectedResponse);
+        done();
+      });
+    });
+  });
 });
 
 function mockSimpleGrpcMethod(expectedRequest, response, error) {


### PR DESCRIPTION
This is PR is Address to encode the params as it does in `database.run` using [encodeParams](https://github.com/googleapis/nodejs-spanner/blob/master/src/transaction.ts#L992) function, but it breaks the existing code.
Fixes #845 
