### PR TITLE
fix: update DELETE samples to match docs

### DIFF
--- a/samples/crud.js
+++ b/samples/crud.js
@@ -156,7 +156,7 @@ async function deleteData(instanceId, databaseId, projectId) {
     }
     try {
       const [rowCount] = await transaction.runUpdate({
-        sql: 'DELETE FROM Singers WHERE SingerId >= 3',
+        sql: 'DELETE FROM Singers WHERE SingerId >= 3 AND SingerId < 5',
       });
       console.log(`${rowCount} records deleted from Singers.`);
       await transaction.commit();

--- a/samples/crud.js
+++ b/samples/crud.js
@@ -138,7 +138,10 @@ async function deleteData(instanceId, databaseId, projectId) {
 
   // Deletes individual rows from the Albums table.
   try {
-    const keys = [[2, 1], [2, 3]];
+    const keys = [
+      [2, 1],
+      [2, 3],
+    ];
     await albumsTable.deleteRows(keys);
     console.log('Deleted individual rows in Albums.');
   } catch (err) {
@@ -153,7 +156,7 @@ async function deleteData(instanceId, databaseId, projectId) {
     }
     try {
       const [rowCount] = await transaction.runUpdate({
-        sql: `DELETE FROM Singers WHERE SingerId >= 3`
+        sql: 'DELETE FROM Singers WHERE SingerId >= 3',
       });
       console.log(`${rowCount} records deleted from Singers.`);
       await transaction.commit();
@@ -171,7 +174,7 @@ async function deleteData(instanceId, databaseId, projectId) {
     }
     try {
       const [rowCount] = await transaction.runUpdate({
-        sql: `DELETE FROM Singers WHERE true`
+        sql: 'DELETE FROM Singers WHERE true',
       });
       console.log(`${rowCount} records deleted from Singers.`);
       await transaction.commit();

--- a/samples/crud.js
+++ b/samples/crud.js
@@ -173,6 +173,9 @@ async function deleteData(instanceId, databaseId, projectId) {
       return;
     }
     try {
+      // The WHERE clause is required for DELETE statements to prevent
+      // accidentally deleting all rows in a table.
+      // https://cloud.google.com/spanner/docs/dml-syntax#where_clause
       const [rowCount] = await transaction.runUpdate({
         sql: 'DELETE FROM Singers WHERE true',
       });

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -167,8 +167,8 @@ describe('Spanner', () => {
       `${crudCmd} delete ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
     assert.include(output, 'Deleted individual rows in Albums.');
-    assert.include(output, '3 records deleted from Singers.');
     assert.include(output, '2 records deleted from Singers.');
+    assert.include(output, '3 records deleted from Singers.');
     output = execSync(
       `${crudCmd} insert ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -166,7 +166,9 @@ describe('Spanner', () => {
     let output = execSync(
       `${crudCmd} delete ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
-    assert.match(output, /Deleted data\./);
+    assert.include(output, 'Deleted individual rows in Albums.');
+    assert.include(output, '3 records deleted from Singers.');
+    assert.include(output, '2 records deleted from Singers.');
     output = execSync(
       `${crudCmd} insert ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );


### PR DESCRIPTION
[Docs](https://cloud.google.com/spanner/docs/modify-mutation-api#deleting_rows_in_a_table) list a set of dot points on the multiple ways to perform deletes. The updated samples now contain these examples.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1071 🦕
