### PR TITLE
fix: handle errors thrown by success callback in getReadSession/getWriteSession

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -425,10 +425,9 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
    * @param {GetReadSessionCallback} callback The callback function.
    */
   getReadSession(callback: GetReadSessionCallback): void {
-    this._acquire(types.ReadOnly).then(
-      session => callback(null, session),
-      callback
-    );
+    this._acquire(types.ReadOnly)
+      .then(session => callback(null, session))
+      .catch(callback);
   }
 
   /**
@@ -437,10 +436,9 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
    * @param {GetWriteSessionCallback} callback The callback function.
    */
   getWriteSession(callback: GetWriteSessionCallback): void {
-    this._acquire(types.ReadWrite).then(
-      session => callback(null, session, session.txn!),
-      callback
-    );
+    this._acquire(types.ReadWrite)
+      .then(session => callback(null, session, session.txn!))
+      .catch(callback);
   }
 
   /**


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes https://github.com/googleapis/nodejs-spanner/issues/1078 🦕


**Description**
Errors thrown by the `callback` executed in the "success" branch of the `then()` method are never caught by its second parameter; and since there are no outside `catch` block; it results in Unhandled Promise rejections.

I don't know if the correct fix is to move the second parameter provided to `then()` to a different `catch` block, or if it should be left as is while providing a different error callback to a different `catch` block (it depends on whether you want errors from both ` this._acquire` and its success callback to be handled by the same handler or not)
