### PR TITLE
fix: set instanceId to the given id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,7 @@ class Spanner extends GrpcService {
     const displayName = config.displayName || formattedName.split('/').pop();
     const reqOpts = {
       parent: 'projects/' + this.projectId,
-      instanceId: displayName,
+      instanceId: formattedName.split('/').pop(),
       instance: extend(
         {
           name: formattedName,

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -2283,6 +2283,30 @@ describe('Spanner with mock server', () => {
       assert.strictEqual(createdInstance.nodeCount, 10);
     });
 
+    it('should create an instance with a display name', async () => {
+      const [createdInstance] = await spanner
+        .createInstance('new-instance', {
+          config: 'test-instance-config',
+          nodes: 10,
+          displayName: 'some new instance',
+        })
+        .then(data => {
+          const operation = data[1];
+          return operation.promise() as Promise<
+            [Instance, CreateInstanceMetadata, object]
+          >;
+        })
+        .then(response => {
+          return response;
+        });
+      assert.strictEqual(
+        createdInstance.name,
+        `projects/${spanner.projectId}/instances/new-instance`
+      );
+      assert.strictEqual(createdInstance.nodeCount, 10);
+      assert.strictEqual(createdInstance.displayName, 'some new instance');
+    });
+
     it('should create an instance using a callback', done => {
       spanner.createInstance(
         'new-instance',


### PR DESCRIPTION
Previously if a display name was given, we were setting the instanceId to the display name. This is a bug.

Fixes #1093