### PR TITLE
fix: chained promises to guarantee deletion order

### DIFF
--- a/samples/crud.js
+++ b/samples/crud.js
@@ -149,30 +149,17 @@ async function deleteData(instanceId, databaseId, projectId) {
   }
 
   // Delete a range of rows where the column key is >=3 and <5
-  database.runTransaction(async (err, transaction) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-    try {
-      const [rowCount] = await transaction.runUpdate({
-        sql: 'DELETE FROM Singers WHERE SingerId >= 3 AND SingerId < 5',
-      });
-      console.log(`${rowCount} records deleted from Singers.`);
-      await transaction.commit();
-    } catch (err) {
-      console.error('ERROR:', err);
-    }
-  });
-
-  // Deletes remaining rows from the Singers table and the Albums table,
-  // because Albums table is defined with ON DELETE CASCADE.
-  database.runTransaction(async (err, transaction) => {
-    if (err) {
-      console.error(err);
-      return;
-    }
-    try {
+  database.runTransactionAsync(async transaction => {
+    const [rowCount] = await transaction.runUpdate({
+      sql: 'DELETE FROM Singers WHERE SingerId >= 3 AND SingerId < 5',
+    });
+    console.log(`${rowCount} records deleted from Singers.`);
+    await transaction.commit();
+  })
+  .then(() => {
+    // Deletes remaining rows from the Singers table and the Albums table,
+    // because Albums table is defined with ON DELETE CASCADE.
+    return database.runTransactionAsync(async transaction => {
       // The WHERE clause is required for DELETE statements to prevent
       // accidentally deleting all rows in a table.
       // https://cloud.google.com/spanner/docs/dml-syntax#where_clause
@@ -181,12 +168,12 @@ async function deleteData(instanceId, databaseId, projectId) {
       });
       console.log(`${rowCount} records deleted from Singers.`);
       await transaction.commit();
-    } catch (err) {
-      console.error('ERROR:', err);
-    } finally {
-      // Close the database when finished.
-      await database.close();
-    }
+    })
+  })
+  .catch(err => { console.error('ERROR:', err); })
+  .then(async () => {
+    // Close the database when finished.
+    await database.close();
   });
   // [END spanner_delete_data]
 }

--- a/samples/crud.js
+++ b/samples/crud.js
@@ -149,32 +149,35 @@ async function deleteData(instanceId, databaseId, projectId) {
   }
 
   // Delete a range of rows where the column key is >=3 and <5
-  database.runTransactionAsync(async transaction => {
-    const [rowCount] = await transaction.runUpdate({
-      sql: 'DELETE FROM Singers WHERE SingerId >= 3 AND SingerId < 5',
-    });
-    console.log(`${rowCount} records deleted from Singers.`);
-    await transaction.commit();
-  })
-  .then(() => {
-    // Deletes remaining rows from the Singers table and the Albums table,
-    // because Albums table is defined with ON DELETE CASCADE.
-    return database.runTransactionAsync(async transaction => {
-      // The WHERE clause is required for DELETE statements to prevent
-      // accidentally deleting all rows in a table.
-      // https://cloud.google.com/spanner/docs/dml-syntax#where_clause
+  database
+    .runTransactionAsync(async transaction => {
       const [rowCount] = await transaction.runUpdate({
-        sql: 'DELETE FROM Singers WHERE true',
+        sql: 'DELETE FROM Singers WHERE SingerId >= 3 AND SingerId < 5',
       });
       console.log(`${rowCount} records deleted from Singers.`);
       await transaction.commit();
     })
-  })
-  .catch(err => { console.error('ERROR:', err); })
-  .then(async () => {
-    // Close the database when finished.
-    await database.close();
-  });
+    .then(() => {
+      // Deletes remaining rows from the Singers table and the Albums table,
+      // because Albums table is defined with ON DELETE CASCADE.
+      return database.runTransactionAsync(async transaction => {
+        // The WHERE clause is required for DELETE statements to prevent
+        // accidentally deleting all rows in a table.
+        // https://cloud.google.com/spanner/docs/dml-syntax#where_clause
+        const [rowCount] = await transaction.runUpdate({
+          sql: 'DELETE FROM Singers WHERE true',
+        });
+        console.log(`${rowCount} records deleted from Singers.`);
+        await transaction.commit();
+      });
+    })
+    .catch(err => {
+      console.error('ERROR:', err);
+    })
+    .then(async () => {
+      // Close the database when finished.
+      await database.close();
+    });
   // [END spanner_delete_data]
 }
 


### PR DESCRIPTION
Previously, in the delete code sample, due to the async callbacks given
to `runTransaction`, it was possible for the last delete query to be
executed before the second last delete query. The deletion order is
important so now using `runTransactionAsync` with the promises chained
to guarantee the deletion order.

Fixes #1147, #1095
