### PR TITLE
feat: return full nextQuery object in paginated calls

### DIFF
--- a/samples/backups-get.js
+++ b/samples/backups-get.js
@@ -94,19 +94,18 @@ async function getBackups(instanceId, databaseId, backupId, projectId) {
     });
 
     // List backups using pagination
-    let pageToken = undefined;
+    let getBackupsOptions = {
+      pageSize: 3,
+      gaxOptions: {autoPaginate: false},
+    };
     console.log('Get backups paginated:');
     do {
-      const [backups, , response] = await instance.getBackups({
-        pageSize: 3,
-        pageToken,
-        gaxOptions: {autoPaginate: false},
-      });
+      const [backups, nextQuery] = await instance.getBackups(getBackupsOptions);
       backups.forEach(backup => {
         console.log(backup.id);
       });
-      pageToken = response.nextPageToken;
-    } while (pageToken);
+      getBackupsOptions = nextQuery;
+    } while (getBackupsOptions);
   } catch (err) {
     console.error('ERROR:', err);
   }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1336,7 +1336,7 @@ class Database extends GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, sessions, nexPageRequest, ...args) => {
+      (err, sessions, nextPageRequest, ...args) => {
         let sessionInstances: Session[] | null = null;
         if (sessions) {
           sessionInstances = sessions.map(metadata => {
@@ -1345,8 +1345,8 @@ class Database extends GrpcServiceObject {
             return session;
           });
         }
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
         callback!(err, sessionInstances!, nextQuery, ...args);
       }

--- a/src/database.ts
+++ b/src/database.ts
@@ -1336,7 +1336,7 @@ class Database extends GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, sessions, ...args) => {
+      (err, sessions, nexPageRequest, ...args) => {
         let sessionInstances: Session[] | null = null;
         if (sessions) {
           sessionInstances = sessions.map(metadata => {
@@ -1345,7 +1345,10 @@ class Database extends GrpcServiceObject {
             return session;
           });
         }
-        callback!(err, sessionInstances!, ...args);
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+        callback!(err, sessionInstances!, nextQuery, ...args);
       }
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,7 +534,7 @@ class Spanner extends GrpcService {
         reqOpts,
         gaxOpts,
       },
-      (err, instances, nexPageRequest, ...args) => {
+      (err, instances, nextPageRequest, ...args) => {
         let instanceInstances: Instance[] | null = null;
         if (instances) {
           instanceInstances = instances.map(instance => {
@@ -543,8 +543,8 @@ class Spanner extends GrpcService {
             return instanceInstance;
           });
         }
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
         callback!(err, instanceInstances, nextQuery, ...args);
       }
@@ -740,9 +740,9 @@ class Spanner extends GrpcService {
         reqOpts,
         gaxOpts,
       },
-      (err, instanceConfigs, nexPageRequest, ...args) => {
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+      (err, instanceConfigs, nextPageRequest, ...args) => {
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
         callback!(err, instanceConfigs, nextQuery, ...args);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,11 +66,11 @@ export type GetInstancesCallback = PagedCallback<
 
 export type GetInstanceConfigsOptions = PagedOptions;
 export type GetInstanceConfigsResponse = PagedResponse<
-  instanceAdmin.spanner.admin.instance.v1.InstanceConfig,
+  instanceAdmin.spanner.admin.instance.v1.IInstanceConfig,
   instanceAdmin.spanner.admin.instance.v1.IListInstanceConfigsResponse
 >;
 export type GetInstanceConfigsCallback = PagedCallback<
-  instanceAdmin.spanner.admin.instance.v1.InstanceConfig,
+  instanceAdmin.spanner.admin.instance.v1.IInstanceConfig,
   instanceAdmin.spanner.admin.instance.v1.IListInstanceConfigsResponse
 >;
 
@@ -534,7 +534,7 @@ class Spanner extends GrpcService {
         reqOpts,
         gaxOpts,
       },
-      (err, instances, ...args) => {
+      (err, instances, nexPageRequest, ...args) => {
         let instanceInstances: Instance[] | null = null;
         if (instances) {
           instanceInstances = instances.map(instance => {
@@ -543,7 +543,10 @@ class Spanner extends GrpcService {
             return instanceInstance;
           });
         }
-        callback!(err, instanceInstances, ...args);
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+        callback!(err, instanceInstances, nextQuery, ...args);
       }
     );
   }
@@ -737,7 +740,12 @@ class Spanner extends GrpcService {
         reqOpts,
         gaxOpts,
       },
-      callback
+      (err, instanceConfigs, nexPageRequest, ...args) => {
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+        callback!(err, instanceConfigs, nextQuery, ...args);
+      }
     );
   }
 
@@ -1058,15 +1066,7 @@ class Spanner extends GrpcService {
  * that a callback is omitted.
  */
 promisifyAll(Spanner, {
-  exclude: [
-    'date',
-    'float',
-    'getInstanceConfigs',
-    'instance',
-    'int',
-    'operation',
-    'timestamp',
-  ],
+  exclude: ['date', 'float', 'instance', 'int', 'operation', 'timestamp'],
 });
 
 /**

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -351,15 +351,15 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, backups, nexPageRequest, ...args) => {
+      (err, backups, nextPageRequest, ...args) => {
         let backupInstances: Backup[] | null = null;
         if (backups) {
           backupInstances = backups.map(backup => {
             return this.backup(backup.name!);
           });
         }
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
 
         callback(err, backupInstances, nextQuery, ...args);
@@ -548,9 +548,9 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, operations, nexPageRequest, ...args) => {
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+      (err, operations, nextPageRequest, ...args) => {
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
 
         callback!(err, operations, nextQuery, ...args);
@@ -672,9 +672,9 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, operations, nexPageRequest, ...args) => {
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+      (err, operations, nextPageRequest, ...args) => {
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
 
         callback!(err, operations, nextQuery, ...args);
@@ -1236,7 +1236,7 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, rowDatabases, nexPageRequest, ...args) => {
+      (err, rowDatabases, nextPageRequest, ...args) => {
         let databases: Database[] | null = null;
         if (rowDatabases) {
           databases = rowDatabases.map(database => {
@@ -1245,8 +1245,8 @@ class Instance extends common.GrpcServiceObject {
             return databaseInstance;
           });
         }
-        const nextQuery = nexPageRequest!
-          ? extend({}, options, nexPageRequest!)
+        const nextQuery = nextPageRequest!
+          ? extend({}, options, nextPageRequest!)
           : null;
 
         callback(err, databases, nextQuery, ...args);

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -351,15 +351,18 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, backups, ...args) => {
+      (err, backups, nexPageRequest, ...args) => {
         let backupInstances: Backup[] | null = null;
         if (backups) {
           backupInstances = backups.map(backup => {
             return this.backup(backup.name!);
           });
         }
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
 
-        callback(err, backupInstances, ...args);
+        callback(err, backupInstances, nextQuery, ...args);
       }
     );
   }
@@ -545,7 +548,13 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      callback
+      (err, operations, nexPageRequest, ...args) => {
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+
+        callback!(err, operations, nextQuery, ...args);
+      }
     );
   }
 
@@ -663,7 +672,13 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      callback
+      (err, operations, nexPageRequest, ...args) => {
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+
+        callback!(err, operations, nextQuery, ...args);
+      }
     );
   }
 
@@ -1221,7 +1236,7 @@ class Instance extends common.GrpcServiceObject {
         reqOpts,
         gaxOpts,
       },
-      (err, rowDatabases, ...args) => {
+      (err, rowDatabases, nexPageRequest, ...args) => {
         let databases: Database[] | null = null;
         if (rowDatabases) {
           databases = rowDatabases.map(database => {
@@ -1230,7 +1245,11 @@ class Instance extends common.GrpcServiceObject {
             return databaseInstance;
           });
         }
-        callback(err, databases, ...args);
+        const nextQuery = nexPageRequest!
+          ? extend({}, options, nexPageRequest!)
+          : null;
+
+        callback(err, databases, nextQuery, ...args);
       }
     );
   }

--- a/test/database.ts
+++ b/test/database.ts
@@ -2073,12 +2073,15 @@ describe('Database', () => {
     });
 
     it('should create and return Session objects', done => {
+      const ERR = null;
       const SESSIONS = [{name: 'abc'}];
+      const NEXTPAGEREQUEST = null;
+      const FULLAPIRESPONSE = {};
       const SESSION_INSTANCE = {};
-      const RESPONSE = {};
+      const RESPONSE = [ERR, SESSIONS, NEXTPAGEREQUEST, FULLAPIRESPONSE];
 
       database.request = (config, callback) => {
-        callback(null, SESSIONS, RESPONSE);
+        callback(...RESPONSE);
       };
 
       database.session = name => {
@@ -2086,12 +2089,39 @@ describe('Database', () => {
         return SESSION_INSTANCE;
       };
 
-      database.getSessions((err, sessions, resp) => {
+      database.getSessions((err, sessions, nextQuery, resp) => {
         assert.ifError(err);
         assert.strictEqual(sessions[0], SESSION_INSTANCE);
-        assert.strictEqual(resp, RESPONSE);
+        assert.strictEqual(resp, FULLAPIRESPONSE);
         done();
       });
+    });
+
+    it('should return a complete nexQuery object', done => {
+      const pageSize = 1;
+      const filter = 'filter';
+      const NEXTPAGEREQUEST = {
+        database: database.formattedName_,
+        pageSize,
+        filter,
+        pageToken: 'pageToken',
+      };
+      const RESPONSE = [null, [], NEXTPAGEREQUEST, {}];
+
+      const GETSESSIONOPTIONS = {
+        pageSize,
+        filter,
+        gaxOptions: {timeout: 1000, autoPaginate: false},
+      };
+      const EXPECTEDNEXTQUERY = extend({}, GETSESSIONOPTIONS, NEXTPAGEREQUEST);
+      database.request = (config, callback) => {
+        callback(...RESPONSE);
+      };
+      function callback(err, sessions, nextQuery) {
+        assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+        done();
+      }
+      database.getSessions(GETSESSIONOPTIONS, callback);
     });
   });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -74,7 +74,6 @@ const fakePfy = extend({}, pfy, {
     assert.deepStrictEqual(options.exclude, [
       'date',
       'float',
-      'getInstanceConfigs',
       'instance',
       'int',
       'operation',
@@ -748,7 +747,7 @@ describe('Spanner', () => {
     });
 
     describe('error', () => {
-      const GAX_RESPONSE_ARGS = [new Error('Error.'), null, {}];
+      const GAX_RESPONSE_ARGS = [new Error('Error.'), null, null, {}];
 
       beforeEach(() => {
         spanner.request = (config, callback) => {
@@ -771,7 +770,7 @@ describe('Spanner', () => {
         },
       ];
 
-      const GAX_RESPONSE_ARGS = [null, INSTANCES, {}];
+      const GAX_RESPONSE_ARGS = [null, INSTANCES, null, {}];
 
       beforeEach(() => {
         spanner.request = (config, callback) => {
@@ -794,8 +793,40 @@ describe('Spanner', () => {
           assert.strictEqual(instance, fakeInstanceInstance);
           assert.strictEqual(instance!.metadata, GAX_RESPONSE_ARGS[1]![0]);
           assert.strictEqual(args[2], GAX_RESPONSE_ARGS[2]);
+          assert.strictEqual(args[3], GAX_RESPONSE_ARGS[3]);
           done();
         });
+      });
+
+      it('should return a complete nextQuery object', done => {
+        const pageSize = 1;
+        const filter = 'filter';
+        const NEXTPAGEREQUEST = {
+          parent: 'projects/' + spanner.projectId,
+          pageSize,
+          filter,
+          pageToken: 'pageToken',
+        };
+        const GAX_RESPONSE_ARGS = [null, [], NEXTPAGEREQUEST, {}];
+
+        const GETINSTANCESOPTIONS = {
+          pageSize,
+          filter,
+          gaxOptions: {timeout: 1000, autoPaginate: false},
+        };
+        const EXPECTEDNEXTQUERY = extend(
+          {},
+          GETINSTANCESOPTIONS,
+          NEXTPAGEREQUEST
+        );
+        spanner.request = (config, callback) => {
+          callback(...GAX_RESPONSE_ARGS);
+        };
+        function callback(err, instances, nextQuery) {
+          assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+          done();
+        }
+        spanner.getInstances(GETINSTANCESOPTIONS, callback);
       });
     });
   });
@@ -924,7 +955,7 @@ describe('Spanner', () => {
 
       const returnValue = {};
 
-      spanner.request = (config, callback_) => {
+      spanner.request = config => {
         assert.strictEqual(config.client, 'InstanceAdminClient');
         assert.strictEqual(config.method, 'listInstanceConfigs');
 
@@ -934,8 +965,6 @@ describe('Spanner', () => {
 
         const gaxOpts = config.gaxOpts;
         assert.deepStrictEqual(gaxOpts, options.gaxOptions);
-
-        assert.strictEqual(callback_, callback);
 
         return returnValue;
       };
@@ -1015,6 +1044,37 @@ describe('Spanner', () => {
       };
 
       spanner.getInstanceConfigs(assert.ifError);
+    });
+
+    it('should return a complete nextQuery object', done => {
+      const pageSize = 1;
+      const filter = 'filter';
+      const NEXTPAGEREQUEST = {
+        parent: 'projects/' + spanner.projectId,
+        pageSize,
+        filter,
+        pageToken: 'pageToken',
+      };
+      const RESPONSE = [null, [], NEXTPAGEREQUEST, {}];
+
+      const GETINSTANCECONFIGSOPTIONS = {
+        pageSize,
+        filter,
+        gaxOptions: {timeout: 1000, autoPaginate: false},
+      };
+      const EXPECTEDNEXTQUERY = extend(
+        {},
+        GETINSTANCECONFIGSOPTIONS,
+        NEXTPAGEREQUEST
+      );
+      spanner.request = (config, callback) => {
+        callback(...RESPONSE);
+      };
+      function callback(err, instanceConfigs, nextQuery) {
+        assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+        done();
+      }
+      spanner.getInstanceConfigs(GETINSTANCECONFIGSOPTIONS, callback);
     });
   });
 

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -984,7 +984,7 @@ describe('Instance', () => {
     });
 
     describe('error', () => {
-      const REQUEST_RESPONSE_ARGS = [new Error('Error.'), null, {}];
+      const REQUEST_RESPONSE_ARGS = [new Error('Error.'), null, null, {}];
 
       beforeEach(() => {
         instance.request = (config, callback: Function) => {
@@ -1008,7 +1008,7 @@ describe('Instance', () => {
       ];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const REQUEST_RESPONSE_ARGS: any = [null, DATABASES, {}];
+      const REQUEST_RESPONSE_ARGS: any = [null, DATABASES, null, {}];
 
       beforeEach(() => {
         instance.request = (config, callback) => {
@@ -1031,8 +1031,40 @@ describe('Instance', () => {
           assert.strictEqual(database, fakeDatabaseInstance);
           assert.strictEqual(database!.metadata, REQUEST_RESPONSE_ARGS[1][0]);
           assert.strictEqual(args[2], REQUEST_RESPONSE_ARGS[2]);
+          assert.strictEqual(args[3], REQUEST_RESPONSE_ARGS[3]);
           done();
         });
+      });
+
+      it('should return a complete nextQuery object', done => {
+        const pageSize = 1;
+        const filter = 'filter';
+        const NEXTPAGEREQUEST = {
+          parent: instance.formattedName_,
+          pageSize,
+          filter,
+          pageToken: 'pageToken',
+        };
+        const REQUEST_RESPONSE_ARGS = [null, [], NEXTPAGEREQUEST, {}];
+
+        const GETDATABASESOPTIONS = {
+          pageSize,
+          filter,
+          gaxOptions: {timeout: 1000, autoPaginate: false},
+        };
+        const EXPECTEDNEXTQUERY = extend(
+          {},
+          GETDATABASESOPTIONS,
+          NEXTPAGEREQUEST
+        );
+        instance.request = (config, callback) => {
+          callback(...REQUEST_RESPONSE_ARGS);
+        };
+        function callback(err, databases, nextQuery) {
+          assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+          done();
+        }
+        instance.getDatabases(GETDATABASESOPTIONS, callback);
       });
     });
   });
@@ -1356,7 +1388,7 @@ describe('Instance', () => {
     });
 
     describe('error', () => {
-      const REQUEST_RESPONSE_ARGS = [new Error('Error.'), null, {}];
+      const REQUEST_RESPONSE_ARGS = [new Error('Error.'), null, null, {}];
 
       beforeEach(() => {
         instance.request = (config, callback: Function) => {
@@ -1382,7 +1414,7 @@ describe('Instance', () => {
       ];
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const REQUEST_RESPONSE_ARGS: any = [null, BACKUPS, {}];
+      const REQUEST_RESPONSE_ARGS: any = [null, BACKUPS, null, {}];
 
       beforeEach(() => {
         instance.request = (config, callback) => {
@@ -1404,8 +1436,40 @@ describe('Instance', () => {
           const backup = args[1]!.pop();
           assert.strictEqual(backup, fakeBackupInstance);
           assert.strictEqual(args[2], REQUEST_RESPONSE_ARGS[2]);
+          assert.strictEqual(args[3], REQUEST_RESPONSE_ARGS[3]);
           done();
         });
+      });
+
+      it('should return a complete nextQuery object', done => {
+        const pageSize = 1;
+        const filter = 'filter';
+        const NEXTPAGEREQUEST = {
+          parent: instance.formattedName_,
+          pageSize,
+          filter,
+          pageToken: 'pageToken',
+        };
+        const REQUEST_RESPONSE_ARGS = [null, [], NEXTPAGEREQUEST, {}];
+
+        const GETBACKUPSOPTIONS = {
+          pageSize,
+          filter,
+          gaxOptions: {timeout: 1000, autoPaginate: false},
+        };
+        const EXPECTEDNEXTQUERY = extend(
+          {},
+          GETBACKUPSOPTIONS,
+          NEXTPAGEREQUEST
+        );
+        instance.request = (config, callback) => {
+          callback(...REQUEST_RESPONSE_ARGS);
+        };
+        function callback(err, backups, nextQuery) {
+          assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+          done();
+        }
+        instance.getBackups(GETBACKUPSOPTIONS, callback);
       });
     });
   });
@@ -1636,6 +1700,37 @@ describe('Instance', () => {
 
       instance.getBackupOperations(assert.ifError);
     });
+
+    it('should return a complete nextQuery object', done => {
+      const pageSize = 1;
+      const filter = 'filter';
+      const NEXTPAGEREQUEST = {
+        parent: instance.formattedName_,
+        pageSize,
+        filter,
+        pageToken: 'pageToken',
+      };
+      const RESPONSE = [null, [], NEXTPAGEREQUEST, {}];
+
+      const GETBACKUPOPSOPTIONS = {
+        pageSize,
+        filter,
+        gaxOptions: {timeout: 1000, autoPaginate: false},
+      };
+      const EXPECTEDNEXTQUERY = extend(
+        {},
+        GETBACKUPOPSOPTIONS,
+        NEXTPAGEREQUEST
+      );
+      instance.request = (config, callback) => {
+        callback(...RESPONSE);
+      };
+      function callback(err, backupOps, nextQuery) {
+        assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+        done();
+      }
+      instance.getBackupOperations(GETBACKUPOPSOPTIONS, callback);
+    });
   });
 
   describe('getDatabaseOperations', () => {
@@ -1740,6 +1835,37 @@ describe('Instance', () => {
       };
 
       instance.getDatabaseOperations(assert.ifError);
+    });
+
+    it('should return a complete nextQuery object', done => {
+      const pageSize = 1;
+      const filter = 'filter';
+      const NEXTPAGEREQUEST = {
+        parent: instance.formattedName_,
+        pageSize,
+        filter,
+        pageToken: 'pageToken',
+      };
+      const RESPONSE = [null, [], NEXTPAGEREQUEST, {}];
+
+      const GETDATABASEOPSOPTIONS = {
+        pageSize,
+        filter,
+        gaxOptions: {timeout: 1000, autoPaginate: false},
+      };
+      const EXPECTEDNEXTQUERY = extend(
+        {},
+        GETDATABASEOPSOPTIONS,
+        NEXTPAGEREQUEST
+      );
+      instance.request = (config, callback) => {
+        callback(...RESPONSE);
+      };
+      function callback(err, databaseOps, nextQuery) {
+        assert.deepStrictEqual(nextQuery, EXPECTEDNEXTQUERY);
+        done();
+      }
+      instance.getDatabaseOperations(GETDATABASEOPSOPTIONS, callback);
     });
   });
 });


### PR DESCRIPTION

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Combine a `nextPageRequest` from server with user provided custom options, this way user can just pass it to the next call as it is documented in the examples

https://github.com/googleapis/nodejs-spanner/blob/d835ba21489885f1fc092011d955c9ca5ef162ca/src/instance.ts#L1159-L1171

