### PR TITLE
fix: retry PDML on Aborted and Internal errors

### DIFF
--- a/src/partial-result-stream.ts
+++ b/src/partial-result-stream.ts
@@ -500,6 +500,9 @@ export function partialResultStream(
 function isRetryableInternalError(err: grpc.ServiceError): boolean {
   return (
     err.code === grpc.status.INTERNAL &&
-    err.message.includes('Received unexpected EOS on DATA frame from server')
+    (err.message.includes(
+      'Received unexpected EOS on DATA frame from server'
+    ) ||
+      err.message.includes('Received RST_STREAM'))
   );
 }

--- a/src/partial-result-stream.ts
+++ b/src/partial-result-stream.ts
@@ -452,7 +452,12 @@ export function partialResultStream(
   };
 
   const retry = (err: grpc.ServiceError): void => {
-    if (!(err.code && retryableCodes!.includes(err.code))) {
+    if (
+      !(
+        err.code &&
+        (retryableCodes!.includes(err.code) || isRetryableInternalError(err))
+      )
+    ) {
       // This is not a retryable error, so this will flush any rows the
       // checkpoint stream has queued. After that, we will destroy the
       // user's stream with the same error.
@@ -489,5 +494,12 @@ export function partialResultStream(
       .pipe(userStream)
       .on('paused', () => requestsStream.pause())
       .on('resumed', () => requestsStream.resume())
+  );
+}
+
+function isRetryableInternalError(err: grpc.ServiceError): boolean {
+  return (
+    err.code === grpc.status.INTERNAL &&
+    err.message.includes('Received unexpected EOS on DATA frame from server')
   );
 }

--- a/test/database.ts
+++ b/test/database.ts
@@ -2235,7 +2235,6 @@ describe('Database', () => {
         'begin'
       ) as sinon.SinonStub).callsFake(callback => callback(null));
 
-      // runUpdateStub = sandbox.stub(fakePartitionedDml, 'runUpdate');
       runUpdateStub = (sandbox.stub(
         fakePartitionedDml,
         'runUpdate'

--- a/test/database.ts
+++ b/test/database.ts
@@ -2235,7 +2235,11 @@ describe('Database', () => {
         'begin'
       ) as sinon.SinonStub).callsFake(callback => callback(null));
 
-      runUpdateStub = sandbox.stub(fakePartitionedDml, 'runUpdate');
+      // runUpdateStub = sandbox.stub(fakePartitionedDml, 'runUpdate');
+      runUpdateStub = (sandbox.stub(
+        fakePartitionedDml,
+        'runUpdate'
+      ) as sinon.SinonStub).callsFake((_, callback) => callback(null));
     });
 
     it('should get a read only session from the pool', () => {
@@ -2289,10 +2293,10 @@ describe('Database', () => {
 
       database.runPartitionedUpdate(QUERY, fakeCallback);
 
-      const [query, callback] = runUpdateStub.lastCall.args;
+      const [query] = runUpdateStub.lastCall.args;
 
       assert.strictEqual(query, QUERY);
-      assert.strictEqual(callback, fakeCallback);
+      assert.ok(fakeCallback.calledOnce);
     });
 
     it('should release the session on transaction end', () => {

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -2264,6 +2264,60 @@ describe('Spanner with mock server', () => {
       }
       await database.close();
     });
+
+    describe('pdml', () => {
+      it('should retry on aborted error', async () => {
+        const database = newTestDatabase();
+        spannerMock.setExecutionTime(
+          spannerMock.executeStreamingSql,
+          SimulatedExecutionTime.ofError({
+            code: grpc.status.ABORTED,
+            message: 'Transaction aborted',
+            metadata: MockSpanner.createMinimalRetryDelayMetadata(),
+            streamIndex: 1,
+          } as MockError)
+        );
+        const [updateCount] = await database.runPartitionedUpdate(updateSql);
+        assert.strictEqual(updateCount, 2);
+        await database.close();
+      });
+
+      it('should retry on specific internal error', async () => {
+        const database = newTestDatabase();
+        spannerMock.setExecutionTime(
+          spannerMock.executeStreamingSql,
+          SimulatedExecutionTime.ofError({
+            code: grpc.status.INTERNAL,
+            message: 'Received unexpected EOS on DATA frame from server',
+            streamIndex: 1,
+          } as MockError)
+        );
+        const [updateCount] = await database.runPartitionedUpdate(updateSql);
+        assert.strictEqual(updateCount, 2);
+        await database.close();
+      });
+
+      it('should fail on generic internal error', async () => {
+        const database = newTestDatabase();
+        spannerMock.setExecutionTime(
+          spannerMock.executeStreamingSql,
+          SimulatedExecutionTime.ofError({
+            code: grpc.status.INTERNAL,
+            message: 'Generic internal error',
+            streamIndex: 1,
+          } as MockError)
+        );
+        try {
+          await database.runPartitionedUpdate(updateSql);
+          assert.fail('missing expected INTERNAL error');
+        } catch (err) {
+          assert.strictEqual(err.code, grpc.status.INTERNAL);
+          assert.ok(err.message.includes('Generic internal error'));
+        } finally {
+          await database.close();
+        }
+      });
+    });
   });
 
   describe('instanceAdmin', () => {


### PR DESCRIPTION
PDML statements should be retried on the following errors:
* ABORTED: Retry using a new transaction
* INTERNAL(Received unexpected EOS on DATA frame from server):
    Retry using the same transaction and any resume token that was received.

Fixes #1197, #1177
