### PR TITLE
feat: accept gaxOptions in Database and Session #delete()

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -21,7 +21,8 @@ import {
   ServiceObjectConfig,
   GetConfig,
 } from '@google-cloud/common';
-import {GrpcServiceObject} from './common-grpc/service-object';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const common = require('./common-grpc/service-object');
 import {promisify, promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import * as extend from 'extend';
@@ -199,7 +200,10 @@ export type BatchCreateSessionsCallback = ResourceCallback<
   spannerClient.spanner.v1.IBatchCreateSessionsResponse
 >;
 
-export type DatabaseDeleteCallback = NormalCallback<r.Response>;
+export type DatabaseDeleteResponse = [databaseAdmin.protobuf.IEmpty];
+export type DatabaseDeleteCallback = NormalCallback<
+  databaseAdmin.protobuf.IEmpty
+>;
 
 export interface CancelableDuplex extends Duplex {
   cancel(): void;
@@ -238,7 +242,7 @@ interface DatabaseRequest {
  * const instance = spanner.instance('my-instance');
  * const database = instance.database('my-database');
  */
-class Database extends GrpcServiceObject {
+class Database extends common.GrpcServiceObject {
   private instance: Instance;
   formattedName_: string;
   pool_: SessionPoolInterface;
@@ -805,8 +809,9 @@ class Database extends GrpcServiceObject {
       }
     });
   }
-  delete(): Promise<[r.Response]>;
+  delete(gaxOptions?: CallOptions): Promise<DatabaseDeleteResponse>;
   delete(callback: DatabaseDeleteCallback): void;
+  delete(gaxOptions: CallOptions, callback: DatabaseDeleteCallback): void;
   /**
    * Delete the database.
    *
@@ -814,8 +819,11 @@ class Database extends GrpcServiceObject {
    *
    * @see {@link v1.DatabaseAdminClient#dropDatabase}
    * @see [DropDatabase API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase)
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   *
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {DatabaseDeleteCallback} [callback] Callback function.
+   * @returns {Promise<DatabaseDeleteResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -839,7 +847,15 @@ class Database extends GrpcServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  delete(callback?: DatabaseDeleteCallback): void | Promise<[r.Response]> {
+  delete(
+    optionsOrCallback?: CallOptions | DatabaseDeleteCallback,
+    cb?: DatabaseDeleteCallback
+  ): void | Promise<DatabaseDeleteResponse> {
+    const gaxOpts =
+      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+    const callback =
+      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
+
     const reqOpts: databaseAdmin.spanner.admin.database.v1.IDropDatabaseRequest = {
       database: this.formattedName_,
     };
@@ -849,6 +865,7 @@ class Database extends GrpcServiceObject {
           client: 'DatabaseAdminClient',
           method: 'dropDatabase',
           reqOpts,
+          gaxOpts,
         },
         callback!
       );

--- a/src/session.ts
+++ b/src/session.ts
@@ -18,7 +18,8 @@
  * @module spanner/session
  */
 
-import {GrpcServiceObject} from './common-grpc/service-object';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const common = require('./common-grpc/service-object');
 import {promisifyAll} from '@google-cloud/promisify';
 import * as extend from 'extend';
 import * as r from 'teeny-request';
@@ -34,7 +35,7 @@ import {
   CreateSessionCallback,
   CreateSessionOptions,
 } from './database';
-import {ServiceObjectConfig, DeleteCallback} from '@google-cloud/common';
+import {ServiceObjectConfig} from '@google-cloud/common';
 import {NormalCallback} from './common';
 import {grpc, CallOptions} from 'google-gax';
 
@@ -55,7 +56,9 @@ export type GetSessionMetadataResponse = [google.spanner.v1.ISession];
 
 export type KeepAliveCallback = NormalCallback<google.spanner.v1.IResultSet>;
 export type KeepAliveResponse = [google.spanner.v1.IResultSet];
-export type DeleteResponse = [r.Response];
+export type DeleteSessionResponse = [google.protobuf.IEmpty];
+export type DeleteSessionCallback = NormalCallback<google.protobuf.IEmpty>;
+
 /**
  * Create a Session object to interact with a Cloud Spanner session.
  *
@@ -94,7 +97,7 @@ export type DeleteResponse = [r.Response];
  * //-
  * const session = database.session('session-name');
  */
-export class Session extends GrpcServiceObject {
+export class Session extends common.GrpcServiceObject {
   id!: string;
   formattedName_?: string;
   type?: types;
@@ -238,8 +241,9 @@ export class Session extends GrpcServiceObject {
       this.formattedName_ = Session.formatName_(database.formattedName_, name);
     }
   }
-  delete(): Promise<DeleteResponse>;
-  delete(callback: DeleteCallback): void;
+  delete(gaxOptions?: CallOptions): Promise<DeleteSessionResponse>;
+  delete(callback: DeleteSessionCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteSessionCallback): void;
   /**
    * Delete a session.
    *
@@ -248,8 +252,10 @@ export class Session extends GrpcServiceObject {
    * @see {@link v1.SpannerClient#deleteSession}
    * @see [DeleteSession API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.DeleteSession)
    *
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {object} [gaxOptions] Request configuration options, outlined here:
+   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {DeleteSessionCallback} [callback] Callback function.
+   * @returns {Promise<DeleteSessionResponse>}
    *
    * @example
    * session.delete(function(err, apiResponse) {
@@ -267,7 +273,15 @@ export class Session extends GrpcServiceObject {
    *   const apiResponse = data[0];
    * });
    */
-  delete(callback?: DeleteCallback): void | Promise<DeleteResponse> {
+  delete(
+    optionsOrCallback?: CallOptions | DeleteSessionCallback,
+    cb?: DeleteSessionCallback
+  ): void | Promise<DeleteSessionResponse> {
+    const gaxOpts =
+      typeof optionsOrCallback === 'object' ? optionsOrCallback : {};
+    const callback =
+      typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
+
     const reqOpts = {
       name: this.formattedName_,
     };
@@ -276,6 +290,7 @@ export class Session extends GrpcServiceObject {
         client: 'SpannerClient',
         method: 'deleteSession',
         reqOpts,
+        gaxOpts,
       },
       callback!
     );

--- a/test/database.ts
+++ b/test/database.ts
@@ -710,6 +710,17 @@ describe('Database', () => {
 
       database.delete(assert.ifError);
     });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+
+      database.request = config => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+
+      database.delete(gaxOptions, assert.ifError);
+    });
   });
 
   describe('exists', () => {

--- a/test/session.ts
+++ b/test/session.ts
@@ -246,6 +246,16 @@ describe('Session', () => {
       const returnValue = session.delete(callback);
       assert.strictEqual(returnValue, requestReturnValue);
     });
+
+    it('should accept gaxOptions', done => {
+      const gaxOptions = {};
+
+      session.request = config => {
+        assert.strictEqual(config.gaxOpts, gaxOptions);
+        done();
+      };
+      session.delete(gaxOptions, assert.ifError);
+    });
   });
 
   describe('getMetadata', () => {


### PR DESCRIPTION

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


