### PR TITLE
fix: `Database not found` could be returned after create()

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -788,8 +788,8 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
 
         needed -= sessions.length;
       } catch (e) {
-        this.emit('createError', e);
         this._pending -= needed;
+        this.emit('createError', e);
         throw e;
       }
 

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -981,6 +981,11 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       let reads = this.options.incStep
         ? this.options.incStep
         : DEFAULTS.incStep!;
+      // Create additional sessions if the configured minimum has not been reached.
+      const min = this.options.min ? this.options.min : 0;
+      if (this.size + this.totalPending + reads < min) {
+        reads = min - this.size - this.totalPending;
+      }
       // Make sure we don't create more sessions than the pool should have.
       if (reads + this.size > this.options.max!) {
         reads = this.options.max! - this.size;

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -1943,6 +1943,7 @@ describe('Spanner with mock server', () => {
         );
         try {
           const database = newTestDatabase({
+            incStep: 1,
             min: 25,
             max: 400,
           });
@@ -1950,6 +1951,9 @@ describe('Spanner with mock server', () => {
           assert.ok(response);
           const [rows] = await database.run(selectSql);
           assert.strictEqual(rows.length, 3);
+          // Make sure the pool of the newly created database is filled.
+          const pool = database.pool_ as SessionPool;
+          assert.strictEqual(pool.size, 25);
           await database.close();
         } catch (err) {
           assert.fail(err);


### PR DESCRIPTION
The session pool could return a Database not found after calling database.create(). This would happen in the following case:
1. A database that does not yet exist is opened with a session pool config with Min > 0.
2. The fill() method of the session pool will then initiate one or more BatchCreateSessions RPCs.
3. The client application calls database.create().
4. The client application executes a query on the newly created database. While doing so, the client
   will request a session from the pool. If one of the requests from step 2 had still not finished at
   this time, its result (Database not found) could be propagated to this request.

Fixes #1219
