### PR TITLE
feat: support setting `optimizerStatisticsPackage`

### DIFF
--- a/samples/queryoptions.js
+++ b/samples/queryoptions.js
@@ -33,7 +33,14 @@ async function databaseWithQueryOptions(instanceId, databaseId, projectId) {
 
   // Gets a reference to a Cloud Spanner instance and database
   const instance = spanner.instance(instanceId);
-  const database = instance.database(databaseId, {}, {optimizerVersion: '1'});
+  const database = instance.database(
+    databaseId,
+    {},
+    {
+      optimizerVersion: '1',
+      optimizerStatisticsPackage: 'auto_20191128_14_47_22UTC',
+    }
+  );
 
   const query = {
     sql: `SELECT AlbumId, AlbumTitle, MarketingBudget
@@ -90,6 +97,7 @@ async function queryWithQueryOptions(instanceId, databaseId, projectId) {
           ORDER BY AlbumTitle`,
     queryOptions: {
       optimizerVersion: 'latest',
+      optimizerStatisticsPackage: 'latest',
     },
   };
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -388,6 +388,10 @@ class Database extends common.GrpcServiceObject {
     if (process.env.SPANNER_OPTIMIZER_VERSION) {
       options.optimizerVersion = process.env.SPANNER_OPTIMIZER_VERSION;
     }
+    if (process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE) {
+      options.optimizerStatisticsPackage =
+        process.env.SPANNER_OPTIMIZER_STATISTICS_PACKAGE;
+    }
     return options;
   }
 


### PR DESCRIPTION
`optimizerStatisticsPackage` can be set in `QueryOptions` when running Cloud Spanner queries.
    
Can be configured through the following mechanisms:    
1. Through the `SPANNER_OPTIMIZER_STATISTICS_PACKAGE` environment variable.
1. At `Database` level using `spanner.instance('instance-name').database('database-name', sessionPoolOptions, queryOptions)`.
1. At query level using `ExecuteSqlRequest.queryOptions`.
    
If the options are configured through multiple mechanisms then:    
1. Options set at an environment variable level will override options configured at the `Database` level.
1. Options set at a query-level will override options set at either the `Database` or environment variable level.
    
If no options are set, the optimizer statistics package will default to:    
1. The optimizer statistics package the database is pinned to in the backend.
1. If the database is not pinned to a specific statistics package, then the Cloud Spanner backend will use the "latest" version.
