### PR TITLE
test: skip tests that filter on get operations

### DIFF
--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -841,7 +841,9 @@ describe('Spanner', () => {
   });
 
   // list_backup_operations
-  it('should list backup operations in the instance', async () => {
+  // Skipped due to a backend issue with specifying a filter when calling
+  // ListBackupOperations.
+  it.skip('should list backup operations in the instance', async () => {
     const output = execSync(
       `${backupsCmd} getBackupOperations ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
@@ -882,7 +884,9 @@ describe('Spanner', () => {
   });
 
   // list_database_operations
-  it('should list database operations in the instance', async () => {
+  // Skipped due to a backend issue with specifying a filter when calling
+  // ListDatabaseOperations.
+  it.skip('should list database operations in the instance', async () => {
     const output = execSync(
       `${backupsCmd} getDatabaseOperations ${INSTANCE_ID} ${PROJECT_ID}`
     );

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1070,7 +1070,9 @@ describe('Spanner', () => {
       );
     });
 
-    it('should list database operations on an instance', async function () {
+    // Skipped due to a backend issue with specifying a filter when calling
+    // ListDatabaseOperations.
+    it.skip('should list database operations on an instance', async function () {
       if (IS_EMULATOR_ENABLED) {
         this.skip();
       }
@@ -1400,7 +1402,9 @@ describe('Spanner', () => {
       }
     });
 
-    it('should list backup operations', async () => {
+    // Skipped due to a backend issue with specifying a filter when calling
+    // ListBackupOperations.
+    it.skip('should list backup operations', async () => {
       // List operations and ensure operation for current backup exists.
       // Without a filter.
       const [operationsWithoutFilter] = await instance.getBackupOperations();


### PR DESCRIPTION
Due to a backend bug, if a filter is specified on a ListDatabaseOperations or ListBackupOperations RPCs, the call fails with `Error: 3 INVALID_ARGUMENT: Invalid ListDatabaseOperations request.`

The issue is being investigated by the Spanner team. Skipping these tests in the meantime to unblock merging PRs. #1245 will be used to track unskipping the tests when a fix is available.

Fixes #1241, #1242, #1243 🦕
