### PR TITLE
test: unskip "should list database operations"

### DIFF
--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -884,9 +884,7 @@ describe('Spanner', () => {
   });
 
   // list_database_operations
-  // Skipped due to a backend issue with specifying a filter when calling
-  // ListDatabaseOperations.
-  it.skip('should list database operations in the instance', async () => {
+  it('should list database operations in the instance', async () => {
     const output = execSync(
       `${backupsCmd} getDatabaseOperations ${INSTANCE_ID} ${PROJECT_ID}`
     );


### PR DESCRIPTION
This sample doesn't use a `metadata.<fieldName>` filter so is not affected by the production issue.

Towards #1245