### PR TITLE
test: fix NUMERIC toJSON test expectation

### DIFF
--- a/test/codec.ts
+++ b/test/codec.ts
@@ -184,7 +184,7 @@ describe('codec', () => {
       const value = '8.01911';
       const numeric = new codec.Numeric(value);
 
-      assert.strictEqual(numeric.toJSON(), '8.01911e+0');
+      assert.strictEqual(numeric.toJSON(), value);
     });
   });
 


### PR DESCRIPTION
Original change was made in #1244 during the big.js version bump but this now seems to fail the tests so reverting the change.
