### PR TITLE
fix(deps): remove @types/big.js from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.5.1",
-    "@types/big.js": "^6.0.0",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
     "@types/concat-stream": "^1.6.0",
     "@types/extend": "^3.0.0",
     "@types/is": "0.0.21",
@@ -117,8 +118,6 @@
     "tmp": "^0.2.0",
     "typescript": "^3.8.3",
     "uuid": "^8.0.0",
-    "yargs": "^16.0.0",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "yargs": "^16.0.0"
   }
 }


### PR DESCRIPTION
While `npm install` it gives below warning:
`npm WARN The package @types/big.js is included as both a dev and production dependency.`

It also re-arrange dependencies in order. 
