### PR TITLE
feat!: restore() now accepts RestoreOptions

### DIFF
--- a/test/database.ts
+++ b/test/database.ts
@@ -2728,12 +2728,10 @@ describe('Database', () => {
     });
 
     it('should accept gaxOpts', done => {
-      const options = {
-        timeout: 1000,
-      };
+      const options = {gaxOptions: {timeout: 1000}};
 
       database.request = config => {
-        assert.deepStrictEqual(config.gaxOpts, options);
+        assert.deepStrictEqual(config.gaxOpts, options.gaxOptions);
         done();
       };
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -2731,7 +2731,7 @@ describe('Database', () => {
       const options = {gaxOptions: {timeout: 1000}};
 
       database.request = config => {
-        assert.deepStrictEqual(config.gaxOpts, options.gaxOptions);
+        assert.strictEqual(config.gaxOpts, options.gaxOptions);
         done();
       };
 


### PR DESCRIPTION
### ⚠ BREAKING CHANGE

`database.restore()` previously took `CallOptions` as an optional argument. Now the argument's type is `RestoreOptions`, which internally includes a field for `CallOptions`.

Previously:
```
database.restore('my-backup', {timeout: 1000});
```

Now:
```
database.restore('my-backup', {gaxOptions: {timeout: 1000}});
```
