### PR TITLE
feat: return ResultSetMetadata for query

### DIFF
--- a/src/partial-result-stream.ts
+++ b/src/partial-result-stream.ts
@@ -492,9 +492,6 @@ export function partialResultStream(
         lastResumeToken = row.resumeToken;
       })
       .pipe(userStream)
-      // .on('response', response => {
-      //   console.log(response);
-      // })
       .on('paused', () => requestsStream.pause())
       .on('resumed', () => requestsStream.resume())
   );

--- a/src/partial-result-stream.ts
+++ b/src/partial-result-stream.ts
@@ -492,6 +492,9 @@ export function partialResultStream(
         lastResumeToken = row.resumeToken;
       })
       .pipe(userStream)
+      // .on('response', response => {
+      //   console.log(response);
+      // })
       .on('paused', () => requestsStream.pause())
       .on('resumed', () => requestsStream.resume())
   );

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1998,6 +1998,27 @@ describe('Spanner', () => {
         DATABASE.run('SELECT 1', done);
       });
 
+      it('should return metadata', async () => {
+        const [rows, , metadata] = await DATABASE.run({
+          sql: `SELECT * FROM ${TABLE_NAME} WHERE SingerId=@id`,
+          params: {id: ID},
+        });
+        assert.strictEqual(rows.length, 1);
+        assert.deepStrictEqual(rows[0].toJSON(), EXPECTED_ROW);
+        assert.ok(metadata);
+        assert.strictEqual(metadata.rowType!.fields!.length, 10);
+        assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
+        assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
+        assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
+        assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
+      });
+
       it('should fail invalid queries', done => {
         DATABASE.run('SELECT Apples AND Oranges', err => {
           assert.strictEqual(err!.code, 3);

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -252,7 +252,7 @@ describe('codec', () => {
       assert.deepStrictEqual(json, {name: 'value'});
     });
 
-    it('should not return nameless values', () => {
+    it('should not return nameless values by default', () => {
       const row = [
         {
           value: 'value',
@@ -263,9 +263,24 @@ describe('codec', () => {
       assert.deepStrictEqual(json, {});
     });
 
+    it('should return nameless values when requested', () => {
+      const row = [
+        {
+          value: 'value',
+        },
+      ];
+
+      const json = codec.convertFieldsToJson(row, {includeNameless: true});
+      assert.deepStrictEqual(json, {_0: 'value'});
+    });
+
     describe('structs', () => {
       it('should not wrap structs by default', () => {
-        const options = {wrapNumbers: false, wrapStructs: false};
+        const options = {
+          wrapNumbers: false,
+          wrapStructs: false,
+          includeNameless: false,
+        };
         const fakeStructJson = {};
 
         const struct = new codec.Struct();

--- a/test/mockserver/mockspanner.ts
+++ b/test/mockserver/mockspanner.ts
@@ -1000,6 +1000,24 @@ export function createLargeResultSet(): protobuf.ResultSet {
   });
 }
 
+export function createSelect1ResultSet(): protobuf.ResultSet {
+  const fields = [
+    protobuf.StructType.Field.create({
+      name: '',
+      type: protobuf.Type.create({code: protobuf.TypeCode.INT64}),
+    }),
+  ];
+  const metadata = new protobuf.ResultSetMetadata({
+    rowType: new protobuf.StructType({
+      fields,
+    }),
+  });
+  return protobuf.ResultSet.create({
+    metadata,
+    rows: [{values: [{stringValue: '1'}]}],
+  });
+}
+
 function generateRandomString(length: number) {
   let result = '';
   const characters =

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -65,6 +65,7 @@ function numberToEnglishWord(num: number): string {
 describe('Spanner with mock server', () => {
   let sandbox: sinon.SinonSandbox;
   const selectSql = 'SELECT NUM, NAME FROM NUMBERS';
+  const select1 = 'SELECT 1';
   const invalidSql = 'SELECT * FROM FOO';
   const insertSql = "INSERT INTO NUMBER (NUM, NAME) VALUES (4, 'Four')";
   const updateSql = "UPDATE NUMBER SET NAME='Unknown' WHERE NUM IN (5, 6)";
@@ -103,6 +104,10 @@ describe('Spanner with mock server', () => {
     spannerMock.putStatementResult(
       selectSql,
       mock.StatementResult.resultSet(mock.createSimpleResultSet())
+    );
+    spannerMock.putStatementResult(
+      select1,
+      mock.StatementResult.resultSet(mock.createSelect1ResultSet())
     );
     spannerMock.putStatementResult(
       invalidSql,
@@ -184,6 +189,44 @@ describe('Spanner with mock server', () => {
           assert.strictEqual(row.NUM, i);
           assert.strictEqual(row.NAME, numberToEnglishWord(i));
         });
+      } finally {
+        await database.close();
+      }
+    });
+
+    it('should receive metadata', async () => {
+      // The query to execute
+      const query = {
+        sql: selectSql,
+      };
+      const database = newTestDatabase();
+      try {
+        const [rows, , metadata] = await database.run(query);
+        assert.strictEqual(rows.length, 3);
+        assert.ok(metadata);
+        assert.strictEqual(metadata.rowType!.fields!.length, 2);
+        assert.strictEqual(metadata.rowType!.fields![0].name, 'NUM');
+        assert.strictEqual(metadata.rowType!.fields![1].name, 'NAME');
+      } finally {
+        await database.close();
+      }
+    });
+
+    it('should return result without column name in JSON', async () => {
+      // The query to execute
+      const query = {
+        sql: select1,
+        json: true,
+        jsonOptions: {includeNameless: true},
+      } as ExecuteSqlRequest;
+      const database = newTestDatabase();
+      try {
+        const [rows, , metadata] = await database.run(query);
+        assert.strictEqual(rows.length, 1);
+        assert.ok(metadata);
+        assert.strictEqual(metadata.rowType!.fields!.length, 1);
+        assert.strictEqual(metadata.rowType!.fields![0].name, '');
+        assert.strictEqual(rows[0]['_0'], 1);
       } finally {
         await database.close();
       }


### PR DESCRIPTION
Returns the ResultSetMetadata for queries. This makes it easier to create a generic view of the results of a query.

This change also adds the option of returning the values of nameless columns in JSON results. These were previously always filtered away. Setting the option `includeNameless: true` in `JSONOptions` will now include these values as well.

Fixes #1307
