### PR TITLE
samples: PITR samples backup fix

### DIFF
--- a/samples/backups-create.js
+++ b/samples/backups-create.js
@@ -15,7 +15,13 @@
 
 'use strict';
 
-async function createBackup(instanceId, databaseId, backupId, projectId, versionTime) {
+async function createBackup(
+  instanceId,
+  databaseId,
+  backupId,
+  projectId,
+  versionTime
+) {
   // [START spanner_create_backup]
   // Imports the Google Cloud client library and precise date library
   const {Spanner} = require('@google-cloud/spanner');

--- a/samples/backups-create.js
+++ b/samples/backups-create.js
@@ -48,7 +48,7 @@ async function createBackup(instanceId, databaseId, backupId, projectId) {
     const expireTime = Date.now() + 1000 * 60 * 60 * 24 * 14;
     // Version time is the server's current time
     const query = {
-      sql: "SELECT CURRENT_TIMESTAMP() as Timestamp",
+      sql: 'SELECT CURRENT_TIMESTAMP() as Timestamp',
     };
     const [rows] = await database.run(query);
     const versionTime = rows[0].toJSON().Timestamp;

--- a/samples/backups-create.js
+++ b/samples/backups-create.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-async function createBackup(instanceId, databaseId, backupId, projectId) {
+async function createBackup(instanceId, databaseId, backupId, projectId, versionTime) {
   // [START spanner_create_backup]
   // Imports the Google Cloud client library and precise date library
   const {Spanner} = require('@google-cloud/spanner');
@@ -28,6 +28,7 @@ async function createBackup(instanceId, databaseId, backupId, projectId) {
   // const instanceId = 'my-instance';
   // const databaseId = 'my-database';
   // const backupId = 'my-backup';
+  // const versionTime = Date.now() - 1000 * 60 * 60 * 24; // One day ago
 
   // Creates a client
   const spanner = new Spanner({
@@ -46,12 +47,6 @@ async function createBackup(instanceId, databaseId, backupId, projectId) {
     const databasePath = database.formattedName_;
     // Expire backup 14 days in the future
     const expireTime = Date.now() + 1000 * 60 * 60 * 24 * 14;
-    // Version time is the server's current time
-    const query = {
-      sql: 'SELECT CURRENT_TIMESTAMP() as Timestamp',
-    };
-    const [rows] = await database.run(query);
-    const versionTime = rows[0].toJSON().Timestamp;
     // Create a backup of the state of the database at the current time.
     const [, operation] = await backup.create({
       databasePath: databasePath,

--- a/samples/backups.js
+++ b/samples/backups.js
@@ -27,7 +27,7 @@ const {deleteBackup} = require('./backups-delete');
 require('yargs')
   .demand(1)
   .command(
-    'createBackup <instanceName> <databaseName> <backupName> <projectId>',
+    'createBackup <instanceName> <databaseName> <backupName> <projectId> <versionTime>',
     'Creates a backup of a Cloud Spanner database.',
     {},
     opts =>
@@ -35,7 +35,8 @@ require('yargs')
         opts.instanceName,
         opts.databaseName,
         opts.backupName,
-        opts.projectId
+        opts.projectId,
+        Date.parse(opts.versionTime)
       )
   )
   .command(

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -845,11 +845,8 @@ describe('Spanner', () => {
     assert.include(output, 'Backups filtered by size:');
     assert.include(output, 'Ready backups filtered by create time:');
     assert.include(output, 'Get backups paginated:');
-    // BACKUP_ID should appear in each getBackups() call in the sample except
-    // in the query for 'size_bytes > 100' as the backup is empty because we
-    // create it at its earliest version time, so it should appear 6 times.
     const count = (output.match(new RegExp(`${BACKUP_ID}`, 'g')) || []).length;
-    assert.equal(count, 6);
+    assert.equal(count, 7);
   });
 
   // list_backup_operations

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -825,7 +825,7 @@ describe('Spanner', () => {
       sql: 'SELECT CURRENT_TIMESTAMP() as Timestamp',
     };
     const [rows] = await database.run(query);
-    const versionTime = rows[0].toJSON().Timestamp;
+    const versionTime = rows[0].toJSON().Timestamp.toISOString();
 
     const output = execSync(
       `${backupsCmd} createBackup ${INSTANCE_ID} ${DATABASE_ID} ${BACKUP_ID} ${PROJECT_ID} ${versionTime}`

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -819,8 +819,16 @@ describe('Spanner', () => {
 
   // create_backup
   it('should create a backup of the database', async () => {
+    const instance = spanner.instance(INSTANCE_ID);
+    const database = instance.database(DATABASE_ID);
+    const query = {
+      sql: 'SELECT CURRENT_TIMESTAMP() as Timestamp',
+    };
+    const [rows] = await database.run(query);
+    const versionTime = rows[0].toJSON().Timestamp;
+
     const output = execSync(
-      `${backupsCmd} createBackup ${INSTANCE_ID} ${DATABASE_ID} ${BACKUP_ID} ${PROJECT_ID}`
+      `${backupsCmd} createBackup ${INSTANCE_ID} ${DATABASE_ID} ${BACKUP_ID} ${PROJECT_ID} ${versionTime}`
     );
     assert.match(output, new RegExp(`Backup (.+)${BACKUP_ID} of size`));
   });


### PR DESCRIPTION
Instead of using the earliest version time of the database, uses the current time (from spanner). If we used the earliest version time of the database instead we would be creating an empty backup, since the database we are backing up is not 1 hour old (default version retention period).