### PR TITLE
fix(sample): run "spanner_batch_client" independently

### DIFF
--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -422,18 +422,13 @@ describe('Spanner', () => {
     assert.match(output, /SingerId: 2, AlbumId: 2, MarketingBudget: 300000/);
   });
 
-  // create_query_partitions
-  it('should create query partitions', async () => {
-    const instance = spanner.instance(INSTANCE_ID);
-    const database = instance.database(DATABASE_ID);
-    const [transaction] = await database.createBatchTransaction();
-    const identifier = JSON.stringify(transaction.identifier());
-
+  // batch_client
+  it('should create and execute query partitions', async () => {
     const output = execSync(
-      `${batchCmd} create-query-partitions ${INSTANCE_ID} ${DATABASE_ID} '${identifier}' ${PROJECT_ID}`
+      `${batchCmd} create-and-execute-query-partitions ${INSTANCE_ID} ${DATABASE_ID} ${PROJECT_ID}`
     );
     assert.match(output, /Successfully created \d query partitions\./);
-    await transaction.close();
+    assert.match(output, /Successfully received \d from executed partitions\./);
   });
 
   // execute_partition


### PR DESCRIPTION
To run the sample previously, we had to separately create a batch transaction, then pass in the session/transaction identifier. Now, the sample creates the partitions and executes paritions all in one sample. This also makes the sample consistent with that of other [languages](https://cloud.google.com/spanner/docs/reads#read_data_in_parallel).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1316 🦕
