### PR TITLE
deps: bump google-gax to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "events-intercept": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^7.0.0",
-    "google-gax": "^2.9.2",
+    "google-gax": "^2.12.0",
     "grpc-gcp": "^0.3.2",
     "is": "^3.2.1",
     "lodash.snakecase": "^4.1.1",


### PR DESCRIPTION
Version 2.11.0 and later of google-gax contains a fix that should reduce memory consumption somewhat when opening and closing clients multiple times.

Updates #1306
