### PR TITLE
docs: fix jsdoc in Table.insert()

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -68,7 +68,9 @@ type IBackupTranslatedEnum = TranslateEnumKeys<
 export type GetMetadataResponse = [IBackupTranslatedEnum];
 type GetMetadataCallback = RequestCallback<IBackupTranslatedEnum>;
 
-type UpdateExpireTimeCallback = RequestCallback<databaseAdmin.spanner.admin.database.v1.IBackup>;
+type UpdateExpireTimeCallback = RequestCallback<
+  databaseAdmin.spanner.admin.database.v1.IBackup
+>;
 
 type DeleteCallback = RequestCallback<databaseAdmin.protobuf.IEmpty>;
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -205,7 +205,9 @@ export type BatchCreateSessionsCallback = ResourceCallback<
 >;
 
 export type DatabaseDeleteResponse = [databaseAdmin.protobuf.IEmpty];
-export type DatabaseDeleteCallback = NormalCallback<databaseAdmin.protobuf.IEmpty>;
+export type DatabaseDeleteCallback = NormalCallback<
+  databaseAdmin.protobuf.IEmpty
+>;
 
 export interface CancelableDuplex extends Duplex {
   cancel(): void;
@@ -1292,7 +1294,9 @@ class Database extends common.GrpcServiceObject {
     const reqOpts: databaseAdmin.spanner.admin.database.v1.IGetDatabaseDdlRequest = {
       database: this.formattedName_,
     };
-    this.request<databaseAdmin.spanner.admin.database.v1.IGetDatabaseDdlResponse>(
+    this.request<
+      databaseAdmin.spanner.admin.database.v1.IGetDatabaseDdlResponse
+    >(
       {
         client: 'DatabaseAdminClient',
         method: 'getDatabaseDdl',

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -84,7 +84,9 @@ export interface CreateDatabaseOptions
 export type GetDatabasesOptions = PagedOptions;
 export type CreateInstanceCallback = LongRunningCallback<Instance>;
 export type CreateDatabaseCallback = LongRunningCallback<Database>;
-export type DeleteInstanceCallback = NormalCallback<instanceAdmin.protobuf.IEmpty>;
+export type DeleteInstanceCallback = NormalCallback<
+  instanceAdmin.protobuf.IEmpty
+>;
 
 export type ExistsInstanceCallback = NormalCallback<boolean>;
 export type GetDatabasesCallback = RequestCallback<

--- a/src/session.ts
+++ b/src/session.ts
@@ -49,7 +49,9 @@ export const enum types {
   ReadWrite = 'readwrite',
 }
 
-export type GetSessionMetadataCallback = NormalCallback<google.spanner.v1.ISession>;
+export type GetSessionMetadataCallback = NormalCallback<
+  google.spanner.v1.ISession
+>;
 export type GetSessionMetadataResponse = [google.spanner.v1.ISession];
 
 export type KeepAliveCallback = NormalCallback<google.spanner.v1.IResultSet>;

--- a/src/table.ts
+++ b/src/table.ts
@@ -461,7 +461,7 @@ class Table {
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {DeleteRowsOptions} [options] Options for configuring the request.
+   * @param {InsertRowsOptions} [options] Options for configuring the request.
    * @param {BasicCallback} [callback] Callback function.
    * @returns {Promise<BasicResponse>}
    *

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -113,7 +113,9 @@ export type BatchUpdateResponse = [
 ];
 export type BeginResponse = [spannerClient.spanner.v1.ITransaction];
 
-export type BeginTransactionCallback = NormalCallback<spannerClient.spanner.v1.ITransaction>;
+export type BeginTransactionCallback = NormalCallback<
+  spannerClient.spanner.v1.ITransaction
+>;
 export type CommitResponse = [spannerClient.spanner.v1.ICommitResponse];
 
 export type ReadResponse = [Rows];
@@ -151,7 +153,9 @@ export interface RunUpdateCallback {
   (err: null | grpc.ServiceError, rowCount: number): void;
 }
 
-export type CommitCallback = NormalCallback<spannerClient.spanner.v1.ICommitResponse>;
+export type CommitCallback = NormalCallback<
+  spannerClient.spanner.v1.ICommitResponse
+>;
 
 /**
  * @typedef {object} TimestampBounds


### PR DESCRIPTION
JSdoc incorrectly had DeleteRowsOptions as options param to Table.insert()

Fixes #1369 🦕
