### PR TITLE
docs: add missing JSDoc for table API 

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -110,6 +110,8 @@ class Table {
    * Create a table.
    *
    * @param {string} schema See {@link Database#createTable}.
+   * @param {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {CreateTableCallback} [callback] Callback function.
    * @returns {Promise<CreateTableResponse>}
    *
@@ -174,11 +176,9 @@ class Table {
    * @see [StreamingRead API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.StreamingRead)
    * @see [ReadRequest API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.ReadRequest)
    *
-   * @param {ReadRequest} query Configuration object. See official
-   *     [`ReadRequest`](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.ReadRequest).
-   *     API documentation.
+   * @param {ReadRequest} query Configuration object, describing what to read from the table..
    * @param {TimestampBounds} [options] [Transaction options](https://cloud.google.com/spanner/docs/timestamp-bounds).
-   * @returns {ReadableStream}
+   * @returns {PartialResultStream} A readable stream that emits rows.
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -260,6 +260,19 @@ class Table {
   delete(callback: DropTableCallback): void;
   delete(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
+   * @typedef {array} DropTableResponse
+   * @property {Operation} 1 An {@link Operation} object that can be used to check
+   *     the status of the request.
+   * @property {object} 2 The full API response.
+   */
+  /**
+   * @callback DropTableCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Operation} operation An {@link Operation} object that can be used to
+   *     check the status of the request.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Delete the table. Not to be confused with {@link Table#deleteRows}.
    *
    * Wrapper around {@link Database#updateSchema}.
@@ -267,10 +280,10 @@ class Table {
    * @see {@link Database#updateSchema}
    *
    * @throws {TypeError} If any arguments are passed in.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
-   * @param {LongRunningOperationCallback} [callback] Callback function.
-   * @returns {Promise<LongRunningOperationResponse>}
+   * @param {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {DropTableCallback} [callback] Callback function.
+   * @returns {Promise<DropTableResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -330,6 +343,15 @@ class Table {
     callback: DeleteRowsCallback
   ): void;
   /**
+   * @typedef {array} DeleteRowsResponse
+   * @property {CommitResponse} 0 The commit response.
+   */
+  /**
+   * @callback DeleteRowsCallback
+   * @param {?Error} error Request error, if any.
+   * @param {CommitResponse} apiResponse The full API response.
+   */
+  /**
    * Delete rows from this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
@@ -337,9 +359,10 @@ class Table {
    * @param {array} keys The keys for the rows to delete. If using a
    *     composite key, provide an array within this array. See the example
    * below.
-   * @param {DeleteRowsOptions} [options] Options for configuring the request.
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {DeleteRowsCallback} [callback] Callback function.
+   * @returns {Promise<DeleteRowsResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -391,15 +414,29 @@ class Table {
   drop(callback: DropTableCallback): void;
   drop(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
+   * @typedef {array} DropTableResponse
+   * @property {Operation} 1 An {@link Operation} object that can be used to check
+   *     the status of the request.
+   * @property {object} 2 The full API response.
+   */
+  /**
+   * @callback DropTableCallback
+   * @param {?Error} err Request error, if any.
+   * @param {Operation} operation An {@link Operation} object that can be used to
+   *     check the status of the request.
+   * @param {object} apiResponse The full API response.
+   */
+  /**
    * Drop the table.
    *
    * @see {@link Table#delete}
    * @see {@link Database#updateSchema}
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
-   * @param {LongRunningOperationCallback} [callback] Callback function.
-   * @returns {Promise<LongRunningOperationResponse>}
+   * @param {object} [gaxOptions] Request configuration options.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more
+   *     details.
+   * @param {DropTableCallback} [callback] Callback function.
+   * @returns {Promise<DropTableResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -455,15 +492,25 @@ class Table {
     callback: InsertRowsCallback
   ): void;
   /**
+   * @typedef {array} InsertRowsResponse
+   * @property {CommitResponse} 0 The commit response.
+   */
+  /**
+   * @callback InsertRowsCallback
+   * @param {?Error} error Request error, if any.
+   * @param {CommitResponse} apiResponse The full API response.
+   */
+  /**
    * Insert rows of data into this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {InsertRowsOptions} [options] Options for configuring the request.
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {InsertRowsCallback} [callback] Callback function.
+   * @returns {Promise<InsertRowsResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -532,23 +579,6 @@ class Table {
   ): void;
   /**
    * Configuration object, describing what to read from the table.
-   *
-   * @typedef {object} TableReadRequestOptions
-   * @property {string[]} columns The columns of the table to be returned for each
-   *     row matching this query.
-   * @property {string[]|string[][]} keys The primary keys of the rows in this table to be
-   *     yielded. If using a composite key, provide an array within this array.
-   *     See the example below.
-   * @property {string} [index] The name of an index on the table.
-   * @property {boolean} [json=false] Receive the rows as serialized objects. This
-   *     is the equivalent of calling `toJSON()` on each row.
-   * @property {object} [jsonOptions] Configuration options for the serialized
-   *     objects.
-   * @property {boolean} [jsonOptions.wrapNumbers=false] Protect large integer
-   *     values outside of the range of JavaScript Number.
-   * @property {object} [keySet] Defines a collection of keys and/or key ranges to
-   *     read.
-   * @property {number} [limit] The number of rows to yield.
    */
   /**
    * @typedef {array} TableReadResponse
@@ -712,15 +742,25 @@ class Table {
     callback: ReplaceRowsCallback
   ): void;
   /**
+   * @typedef {array} ReplaceRowsResponse
+   * @property {CommitResponse} 0 The commit response.
+   */
+  /**
+   * @callback ReplaceRowsCallback
+   * @param {?Error} error Request error, if any.
+   * @param {CommitResponse} apiResponse The full API response.
+   */
+  /**
    * Replace rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {ReplaceRowsOptions} [options] Options for configuring the request.
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {ReplaceRowsCallback} [callback] Callback function.
+   * @returns {Promise<ReplaceRowsResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -774,15 +814,25 @@ class Table {
     callback: UpdateRowsCallback
   ): void;
   /**
+   * @typedef {array} UpdateRowsResponse
+   * @property {CommitResponse} 0 The commit response.
+   */
+  /**
+   * @callback UpdateRowsCallback
+   * @param {?Error} error Request error, if any.
+   * @param {CommitResponse} apiResponse The full API response.
+   */
+  /**
    * Update rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {UpdateRowsOptions} [options] Options for configuring the request.
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {UpdateRowsCallback} [callback] Callback function.
+   * @returns {Promise<UpdateRowsResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');
@@ -840,6 +890,15 @@ class Table {
     callback: UpsertRowsCallback
   ): void;
   /**
+   * @typedef {array} UpsertRowsResponse
+   * @property {CommitResponse} 0 The commit response.
+   */
+  /**
+   * @callback UpsertRowsCallback
+   * @param {?Error} error Request error, if any.
+   * @param {CommitResponse} apiResponse The full API response.
+   */
+  /**
    * Insert or update rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
@@ -847,9 +906,10 @@ class Table {
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
    *
-   * @param {UpsertRowsOptions} [options] Options for configuring the request.
-   * @param {BasicCallback} [callback] Callback function.
-   * @returns {Promise<BasicResponse>}
+   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   * @param {UpsertRowsCallback} [callback] Callback function.
+   * @returns {Promise<UpsertRowsResponse>}
    *
    * @example
    * const {Spanner} = require('@google-cloud/spanner');

--- a/src/table.ts
+++ b/src/table.ts
@@ -352,6 +352,16 @@ class Table {
    * @param {CommitResponse} apiResponse The full API response.
    */
   /**
+   * @typedef {object} DeleteRowsOptions
+   * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
+   *     with the commit request.
+   * @property {boolean} returnCommitStats Include statistics related to the
+   *     transaction in the {@link CommitResponse}.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
+   */
+  /**
    * Delete rows from this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
@@ -359,7 +369,7 @@ class Table {
    * @param {array} keys The keys for the rows to delete. If using a
    *     composite key, provide an array within this array. See the example
    * below.
-   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   * @param {DeleteRowsOptions|CallOptions} [options] Options for configuring the request.
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {DeleteRowsCallback} [callback] Callback function.
    * @returns {Promise<DeleteRowsResponse>}
@@ -501,13 +511,23 @@ class Table {
    * @param {CommitResponse} apiResponse The full API response.
    */
   /**
+   * @typedef {object} InsertRowsOptions
+   * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
+   *     with the commit request.
+   * @property {boolean} returnCommitStats Include statistics related to the
+   *     transaction in the {@link CommitResponse}.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
+   */
+  /**
    * Insert rows of data into this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   * @param {InsertRowsOptions|CallOptions} [options] Options for configuring the request.
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {InsertRowsCallback} [callback] Callback function.
    * @returns {Promise<InsertRowsResponse>}
@@ -751,13 +771,23 @@ class Table {
    * @param {CommitResponse} apiResponse The full API response.
    */
   /**
+   * @typedef {object} ReplaceRowsOptions
+   * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
+   *     with the commit request.
+   * @property {boolean} returnCommitStats Include statistics related to the
+   *     transaction in the {@link CommitResponse}.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
+   */
+  /**
    * Replace rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   * @param {ReplaceRowsOptions|CallOptions} [options] Options for configuring the request.
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {ReplaceRowsCallback} [callback] Callback function.
    * @returns {Promise<ReplaceRowsResponse>}
@@ -823,13 +853,23 @@ class Table {
    * @param {CommitResponse} apiResponse The full API response.
    */
   /**
+   * @typedef {object} UpdateRowsOptions
+   * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
+   *     with the commit request.
+   * @property {boolean} returnCommitStats Include statistics related to the
+   *     transaction in the {@link CommitResponse}.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
+   */
+  /**
    * Update rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
    *
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
-   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   * @param {UpdateRowsOptions|CallOptions} [options] Options for configuring the request.
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {UpdateRowsCallback} [callback] Callback function.
    * @returns {Promise<UpdateRowsResponse>}
@@ -899,6 +939,16 @@ class Table {
    * @param {CommitResponse} apiResponse The full API response.
    */
   /**
+   * @typedef {object} UpsertRowsOptions
+   * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
+   *     with the commit request.
+   * @property {boolean} returnCommitStats Include statistics related to the
+   *     transaction in the {@link CommitResponse}.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
+   */
+  /**
    * Insert or update rows of data within this table.
    *
    * @see [Commit API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Commit)
@@ -906,7 +956,7 @@ class Table {
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
    *
-   * @param {CommitOptions|CallOptions} [options] Options for configuring the request.
+   * @param {UpsertRowsOptions|CallOptions} [options] Options for configuring the request.
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @param {UpsertRowsCallback} [callback] Callback function.
    * @returns {Promise<UpsertRowsResponse>}

--- a/src/table.ts
+++ b/src/table.ts
@@ -261,9 +261,9 @@ class Table {
   delete(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
    * @typedef {array} DropTableResponse
-   * @property {Operation} 1 An {@link Operation} object that can be used to check
+   * @property {Operation} 0 An {@link Operation} object that can be used to check
    *     the status of the request.
-   * @property {object} 2 The full API response.
+   * @property {object} 1 The full API response.
    */
   /**
    * @callback DropTableCallback
@@ -425,9 +425,9 @@ class Table {
   drop(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
    * @typedef {array} DropTableResponse
-   * @property {Operation} 1 An {@link Operation} object that can be used to check
+   * @property {Operation} 0 An {@link Operation} object that can be used to check
    *     the status of the request.
-   * @property {object} 2 The full API response.
+   * @property {object} 1 The full API response.
    */
   /**
    * @callback DropTableCallback
@@ -602,7 +602,7 @@ class Table {
    */
   /**
    * @typedef {array} TableReadResponse
-   * @property {array[]} 1 Rows are returned as an array of object arrays. Each
+   * @property {array[]} 0 Rows are returned as an array of object arrays. Each
    *     object has a `name` and `value` property. To get a serialized object,
    *     call `toJSON()`. Optionally, provide an options object to `toJSON()`
    *     specifying `wrapNumbers: true` to protect large integer values outside

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -405,12 +405,13 @@ export class Snapshot extends EventEmitter {
    * @property {string} table The name of the table in the database to be read.
    * @property {string[]} columns The columns of the table to be returned for each
    *     row matching this query.
-   * @property {string[]|string[][]} keys The primary keys of the rows in this table to be
+   * @property {string[]|string[][]} keys The primary or index keys of the rows in this table to be
    *     yielded. If using a composite key, provide an array within this array.
    *     See the example below.
    * @property {KeyRange[]} [ranges] An alternative to the keys property; this can
    *     be used to define a range of keys to be yielded.
-   * @property {string} [index] The name of an index on the table.
+   * @property {string} [index] The name of an index on the table if a
+   *     different index than the primary key should be used to determine which rows to return.
    * @property {boolean} [json=false] Receive the rows as serialized objects. This
    *     is the equivalent of calling `toJSON()` on each row.
    * @property {JSONOptions} [jsonOptions] Configuration options for the serialized
@@ -418,16 +419,9 @@ export class Snapshot extends EventEmitter {
    * @property {object} [keySet] Defines a collection of keys and/or key ranges to
    *     read.
    * @property {number} [limit] The number of rows to yield.
-   * @property {Buffer} [resumeToken]
-   *     If this request is resuming a previously interrupted read,
-   *     `resume_token` should be copied from the last
-   *     {@link google.spanner.v1.PartialResultSet|PartialResultSet} yielded before the interruption. Doing this
-   *     enables the new read to resume where the last read left off. The
-   *     rest of the request parameters must exactly match the request
-   *     that yielded this token.
    * @property {Buffer} [partitionToken]
    *     If present, results will be restricted to the specified partition
-   *     previously created using PartitionRead().    There must be an exact
+   *     previously created using PartitionRead(). There must be an exact
    *     match for the values of fields common to this message and the
    *     PartitionReadRequest message used to create this partition_token.
    * @property {google.spanner.v1.RequestOptions} [requestOptions]

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -402,15 +402,38 @@ export class Snapshot extends EventEmitter {
    * @see [ReadRequest API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.ReadRequest)
    *
    * @typedef {object} ReadRequest
-   * @property {string[]|string[][]} [keys] The primary keys of the rows in this table to be
+   * @property {string} table The name of the table in the database to be read.
+   * @property {string[]} columns The columns of the table to be returned for each
+   *     row matching this query.
+   * @property {string[]|string[][]} keys The primary keys of the rows in this table to be
    *     yielded. If using a composite key, provide an array within this array.
    *     See the example below.
    * @property {KeyRange[]} [ranges] An alternative to the keys property; this can
-   *       be used to define a range of keys to be yielded.
+   *     be used to define a range of keys to be yielded.
+   * @property {string} [index] The name of an index on the table.
    * @property {boolean} [json=false] Receive the rows as serialized objects. This
    *     is the equivalent of calling `toJSON()` on each row.
-   * @property {JSONOptions} [jsonOptions] Configuration options for the
-   *     serialized objects.
+   * @property {JSONOptions} [jsonOptions] Configuration options for the serialized
+   *     objects.
+   * @property {object} [keySet] Defines a collection of keys and/or key ranges to
+   *     read.
+   * @property {number} [limit] The number of rows to yield.
+   * @property {Buffer} [resumeToken]
+   *     If this request is resuming a previously interrupted read,
+   *     `resume_token` should be copied from the last
+   *     {@link google.spanner.v1.PartialResultSet|PartialResultSet} yielded before the interruption. Doing this
+   *     enables the new read to resume where the last read left off. The
+   *     rest of the request parameters must exactly match the request
+   *     that yielded this token.
+   * @property {Buffer} [partitionToken]
+   *     If present, results will be restricted to the specified partition
+   *     previously created using PartitionRead().    There must be an exact
+   *     match for the values of fields common to this message and the
+   *     PartitionReadRequest message used to create this partition_token.
+   * @property {google.spanner.v1.RequestOptions} [requestOptions]
+   *     Common options for this request.
+   * @property {object} [gaxOptions]
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    */
   /**
    * Create a readable object stream to receive rows from the database using key


### PR DESCRIPTION
Towards #1378
