### PR TITLE
docs: improve docs for gaxoptions

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -128,9 +128,9 @@ class Backup {
    *     encryptionConfig An encryption configuration describing the
    *     encryption type and key resources in Cloud KMS to be used to encrypt
    *     the backup.
-   * @property {CallOptions} [gaxOptions] The request configuration options
-   *     outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @property {CallOptions} [gaxOptions] The request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} CreateBackupResponse
@@ -153,8 +153,8 @@ class Backup {
    * @method Backup#create
    * @param {CreateBackupOptions} options Parameters for creating a backup.
    * @param {CallOptions} [options.gaxOptions] The request configuration
-   *     options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   *     options, See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {CreateBackupCallback} [callback] Callback function.
    * @returns {Promise<CreateBackupResponse>} When resolved, the backup
    *     operation will have started, but will not have necessarily completed.
@@ -246,8 +246,9 @@ class Backup {
    * @see {@link #getExpireTime}
    *
    * @method Backup#getMetadata
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetMetadataCallback} [callback] Callback function.
    * @returns {Promise<GetMetadataResponse>}
    *
@@ -415,8 +416,9 @@ class Backup {
    * @method Backup#updateExpireTime
    * @param {string|number|google.protobuf.Timestamp|external:PreciseDate}
    *     expireTime The expiry time to update with.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {UpdateExpireTimeCallback} [callback] Callback function.
    * @returns {Promise<google.spanner.admin.database.v1.IBackup>} When resolved,
    *     the backup's expire time will have been updated.
@@ -474,8 +476,9 @@ class Backup {
    * Deletes a backup.
    *
    * @method Backup#delete
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DeleteBackupCallback} [callback] Callback function.
    * @returns {Promise<void>} When resolved, the backup will have been deleted.
    *

--- a/src/batch-transaction.ts
+++ b/src/batch-transaction.ts
@@ -107,8 +107,9 @@ class BatchTransaction extends Snapshot {
    * @param {string|object} query A SQL query or
    *     [`ExecuteSqlRequest`](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.ExecuteSqlRequest)
    *     object.
-   * @param {object} [query.gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @param {object} [query.gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {object} [query.params] A map of parameter name to values.
    * @param {object} [query.partitionOptions] A map of partition options.
    * @param {object} [query.types] A map of parameter types.
@@ -188,8 +189,9 @@ class BatchTransaction extends Snapshot {
    * @typedef {object} ReadPartition
    * @mixes ReadRequestOptions
    * @property {string} partitionToken The partition token.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} CreateReadPartitionsResponse
@@ -239,8 +241,8 @@ class BatchTransaction extends Snapshot {
    *
    * @param {ReadPartition|QueryParition} partition The partition object.
    * @param {object} [partition.gaxOptions] Request configuration options,
-   *     outlined here:
-   * https://googleapis.github.io/gax-nodejs/CallSettings.html.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {TransactionRequestReadCallback|RunCallback} [callback] Callback
    *     function.
    * @returns {Promise<RunResponse>|Promise<TransactionRequestReadResponse>}

--- a/src/database.ts
+++ b/src/database.ts
@@ -652,8 +652,9 @@ class Database extends common.GrpcServiceObject {
    *   * Label values must be between 0 and 63 characters long and must conform
    *     to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
    *   * No more than 64 labels can be associated with a given session.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} CreateSessionResponse
@@ -782,8 +783,9 @@ class Database extends common.GrpcServiceObject {
    * @see {@link Database#updateSchema}
    *
    * @param {string} schema A DDL CREATE statement describing the table.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {CreateTableCallback} [callback] Callback function.
    * @returns {Promise<CreateTableResponse>}
    *
@@ -880,8 +882,9 @@ class Database extends common.GrpcServiceObject {
    * @see {@link v1.DatabaseAdminClient#dropDatabase}
    * @see [DropDatabase API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.DropDatabase)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DatabaseDeleteCallback} [callback] Callback function.
    * @returns {Promise<DatabaseDeleteResponse>}
    *
@@ -949,8 +952,9 @@ class Database extends common.GrpcServiceObject {
    * Check if a database exists.
    *
    * @method Database#exists
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DatabaseExistsCallback} [callback] Callback function.
    * @returns {Promise<DatabaseExistsResponse>}
    *
@@ -1094,8 +1098,9 @@ class Database extends common.GrpcServiceObject {
    *
    * @see {@link v1.DatabaseAdminClient#getDatabase}
    * @see [GetDatabase API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.GetDatabase)
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetMetadataCallback} [callback] Callback function.
    * @returns {Promise<GetMetadataResponse>}
    *
@@ -1173,8 +1178,9 @@ class Database extends common.GrpcServiceObject {
    * @see {@link #getMetadata}
    *
    * @method Database#getRestoreInfo
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetRestoreInfoCallback} [callback] Callback function.
    * @returns {Promise<IRestoreInfoTranslatedEnum | undefined>} When resolved,
    *     contains the restore information for the database if it was restored
@@ -1215,8 +1221,9 @@ class Database extends common.GrpcServiceObject {
    * @see {@link #getMetadata}
    *
    * @method Database#getState
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetStateCallback} [callback] Callback function.
    * @returns {Promise<EnumKey<typeof, databaseAdmin.spanner.admin.database.v1.Database.State> | undefined>}
    *     When resolved, contains the current state of the database if the state
@@ -1266,8 +1273,9 @@ class Database extends common.GrpcServiceObject {
    * @see [Data Definition Language (DDL)](https://cloud.google.com/spanner/docs/data-definition-language)
    * @see [GetDatabaseDdl API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.GetDatabaseDdl)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetSchemaCallback} [callback] Callback function.
    * @returns {Promise<GetSchemaResponse>}
    *
@@ -1339,8 +1347,9 @@ class Database extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetSessionsResponse
@@ -1700,8 +1709,9 @@ class Database extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetDatabaseOperationsCallback} [callback] Callback function.
    */
   /**
@@ -1715,8 +1725,9 @@ class Database extends common.GrpcServiceObject {
    * @see {@link Instance.getDatabaseOperations}
    *
    * @param {GetDatabaseOperationsOptions} [options] Contains query object for
-   *     listing database operations and request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   *     listing database operations and request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @returns {Promise<GetDatabaseOperationsResponse>} When resolved, contains
    *     a paged list of database operations.
    *
@@ -1863,9 +1874,9 @@ class Database extends common.GrpcServiceObject {
    *     encryptionConfig An encryption configuration describing
    *     the encryption type and key resources in Cloud KMS used to
    *     encrypt/decrypt the database to restore to.
-   * @property {CallOptions} [gaxOptions] The request configuration options
-   *     outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @property {CallOptions} [gaxOptions] The request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} RestoreDatabaseResponse
@@ -1889,8 +1900,9 @@ class Database extends common.GrpcServiceObject {
    * necessarily have completed.
    *
    * @param backupPath The path of the backup to restore.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @returns Promise<RestoreDatabaseResponse> When resolved, contains the restore operation.
    *
    * @example
@@ -2694,8 +2706,9 @@ class Database extends common.GrpcServiceObject {
    * @param {string|string[]|object} statements An array of database DDL
    *     statements, or an
    *     [`UpdateDatabaseDdlRequest` object](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.UpdateDatabaseDdlRequest).
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {LongRunningOperationCallback} [callback] Callback function.
    * @returns {Promise<LongRunningOperationResponse>}
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,8 +424,9 @@ class Spanner extends GrpcService {
    * Query object for listing instances.
    *
    * @typedef {object} GetInstancesOptions
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @property {string} [filter] An expression for filtering the results of the
    *     request. Filter rules are case insensitive. The fields eligible for
    *     filtering are:
@@ -644,9 +645,9 @@ class Spanner extends GrpcService {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
-
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetInstanceConfigsResponse

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -262,8 +262,9 @@ class Instance extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetBackupsResponse
@@ -287,8 +288,8 @@ class Instance extends common.GrpcServiceObject {
    *
    * @param {GetBackupsOptions} [options] The query object for listing backups.
    * @param {gax.CallOptions} [options.gaxOptions] The request configuration
-   *     options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   *     options, See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @returns {Promise<GetBackupsResponse>} When resolved, contains a paged list
    *     of backups.
    *
@@ -461,8 +462,9 @@ class Instance extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetBackupOperationsResponse
@@ -486,8 +488,8 @@ class Instance extends common.GrpcServiceObject {
    * @param {GetBackupOperationsOptions} [options] The query object for listing
    *     backup operations.
    * @param {gax.CallOptions} [options.gaxOptions] The request configuration
-   *     options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   *     options, See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @returns {Promise<GetBackupOperationsResponse>} When resolved, contains a
    *     paged list of backup operations.
    *
@@ -585,8 +587,9 @@ class Instance extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetDatabaseOperationsResponse
@@ -610,8 +613,8 @@ class Instance extends common.GrpcServiceObject {
    * @param {GetDatabaseOperationsOptions} [options] The query object for
    *     listing database operations.
    * @param {gax.CallOptions} [options.gaxOptions] The request configuration
-   *     options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   *     options, See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @returns {Promise<GetDatabaseOperationsResponse>} When resolved, contains a
    *     paged list of database operations.
    *
@@ -907,8 +910,9 @@ class Instance extends common.GrpcServiceObject {
    * @see {@link v1.InstanceAdminClient#deleteInstance}
    * @see [DeleteInstance API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.InstanceAdmin.DeleteInstance)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DeleteInstanceCallback} [callback] Callback function.
    * @returns {Promise<DeleteInstanceResponse>}
    *
@@ -987,8 +991,9 @@ class Instance extends common.GrpcServiceObject {
    * Check if an instance exists.
    *
    * @method Instance#exists
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {InstanceExistsCallback} [callback] Callback function.
    * @returns {Promise<InstanceExistsResponse>}
    *
@@ -1144,8 +1149,9 @@ class Instance extends common.GrpcServiceObject {
    * @property {number} [pageSize] Maximum number of results per page.
    * @property {string} [pageToken] A previously-returned page token
    *     representing part of the larger set of results to view.
-   * @property {object} [gaxOptions] Request configuration options, outlined
-   *     here: https://googleapis.github.io/gax-nodejs/global.html#CallOptions.
+   * @property {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {array} GetDatabasesResponse
@@ -1458,8 +1464,9 @@ class Instance extends common.GrpcServiceObject {
    * @see [UpdateInstance API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.InstanceAdmin.UpdateInstance)
    *
    * @param {object} metadata The metadata you wish to set.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {SetInstanceMetadataCallback} [callback] Callback function.
    * @returns {Promise<LongRunningOperationResponse>}
    *

--- a/src/session.ts
+++ b/src/session.ts
@@ -255,8 +255,9 @@ export class Session extends common.GrpcServiceObject {
    * @see {@link v1.SpannerClient#deleteSession}
    * @see [DeleteSession API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.DeleteSession)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DeleteSessionCallback} [callback] Callback function.
    * @returns {Promise<DeleteSessionResponse>}
    *
@@ -324,8 +325,9 @@ export class Session extends common.GrpcServiceObject {
    * @see {@link v1.SpannerClient#getSession}
    * @see [GetSession API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.GetSession)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {GetSessionMetadataCallback} [callback] Callback function.
    * @returns {Promise<GetSessionMetadataResponse>}
    *
@@ -374,8 +376,9 @@ export class Session extends common.GrpcServiceObject {
   /**
    * Ping the session with `SELECT 1` to prevent it from expiring.
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {BasicCallback} [callback] Callback function.
    * @returns {Promise<BasicResponse>}
    *

--- a/src/table.ts
+++ b/src/table.ts
@@ -111,7 +111,8 @@ class Table {
    *
    * @param {string} schema See {@link Database#createTable}.
    * @param {object} [gaxOptions]
-   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {CreateTableCallback} [callback] Callback function.
    * @returns {Promise<CreateTableResponse>}
    *
@@ -281,7 +282,8 @@ class Table {
    *
    * @throws {TypeError} If any arguments are passed in.
    * @param {object} [gaxOptions]
-   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DropTableCallback} [callback] Callback function.
    * @returns {Promise<DropTableResponse>}
    *
@@ -370,7 +372,8 @@ class Table {
    *     composite key, provide an array within this array. See the example
    * below.
    * @param {DeleteRowsOptions|CallOptions} [options] Options for configuring the request.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DeleteRowsCallback} [callback] Callback function.
    * @returns {Promise<DeleteRowsResponse>}
    *
@@ -443,8 +446,8 @@ class Table {
    * @see {@link Database#updateSchema}
    *
    * @param {object} [gaxOptions] Request configuration options.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more
-   *     details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {DropTableCallback} [callback] Callback function.
    * @returns {Promise<DropTableResponse>}
    *
@@ -528,7 +531,8 @@ class Table {
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
    * @param {InsertRowsOptions|CallOptions} [options] Options for configuring the request.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {InsertRowsCallback} [callback] Callback function.
    * @returns {Promise<InsertRowsResponse>}
    *
@@ -788,7 +792,8 @@ class Table {
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
    * @param {ReplaceRowsOptions|CallOptions} [options] Options for configuring the request.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {ReplaceRowsCallback} [callback] Callback function.
    * @returns {Promise<ReplaceRowsResponse>}
    *
@@ -870,7 +875,8 @@ class Table {
    * @param {object|object[]} rows A map of names to values of data to insert
    *     into this table.
    * @param {UpdateRowsOptions|CallOptions} [options] Options for configuring the request.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {UpdateRowsCallback} [callback] Callback function.
    * @returns {Promise<UpdateRowsResponse>}
    *
@@ -957,7 +963,8 @@ class Table {
    *     into this table.
    *
    * @param {UpsertRowsOptions|CallOptions} [options] Options for configuring the request.
-   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {UpsertRowsCallback} [callback] Callback function.
    * @returns {Promise<UpsertRowsResponse>}
    *

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -308,8 +308,9 @@ export class Snapshot extends EventEmitter {
    *
    * @see [BeginTransaction API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.BeginTransaction)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {TransactionBeginCallback} [callback] Callback function.
    * @returns {Promise<TransactionBeginResponse>}
    *
@@ -427,7 +428,8 @@ export class Snapshot extends EventEmitter {
    * @property {google.spanner.v1.RequestOptions} [requestOptions]
    *     Common options for this request.
    * @property {object} [gaxOptions]
-   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
+   *     Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * Create a readable object stream to receive rows from the database using key
@@ -1340,8 +1342,9 @@ export class Transaction extends Dml {
    *     object.
    * @param {object} [query.params] A map of parameter name to values.
    * @param {object} [query.types] A map of parameter types.
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {BatchUpdateOptions} [options] Options for configuring the request.
    * @param {RunUpdateCallback} [callback] Callback function.
    * @returns {Promise<RunUpdateResponse>}
@@ -1482,9 +1485,9 @@ export class Transaction extends Dml {
    *     with the commit request.
    * @property {boolean} returnCommitStats Include statistics related to the
    *     transaction in the {@link CommitResponse}.
-   * @property {CallOptions} [gaxOptions] The request configuration options
-   *     outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @property {CallOptions} [gaxOptions] The request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    */
   /**
    * @typedef {object} CommitResponse
@@ -1756,8 +1759,9 @@ export class Transaction extends Dml {
    * @see {@link v1.SpannerClient#rollback}
    * @see [Rollback API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.Spanner.Rollback)
    *
-   * @param {object} [gaxOptions] Request configuration options, outlined here:
-   *     https://googleapis.github.io/gax-nodejs/classes/CallSettings.html.
+   * @param {object} [gaxOptions] Request configuration options,
+   *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
+   *     for more details.
    * @param {BasicCallback} [callback] Callback function.
    * @returns {Promise<BasicResponse>}
    *


### PR DESCRIPTION
Towards #1378

Currently It shows:
![current](https://user-images.githubusercontent.com/46327204/120751986-85412400-c526-11eb-81e2-19c7397699fd.PNG)

Now it will show:
![now](https://user-images.githubusercontent.com/46327204/120752003-8bcf9b80-c526-11eb-8c17-ec9c57a51f0a.PNG)

