### PR TITLE
fix: unknown errors should not be retried

### DIFF
--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -29,7 +29,7 @@ import {Database} from './database';
 const jsonProtos = require('../protos/protos.json');
 const RETRY_INFO = 'google.rpc.retryinfo-bin';
 
-const RETRYABLE: grpc.status[] = [grpc.status.ABORTED, grpc.status.UNKNOWN];
+const RETRYABLE: grpc.status[] = [grpc.status.ABORTED];
 
 // tslint:disable-next-line variable-name
 const RetryInfo = Root.fromJSON(jsonProtos).lookup('google.rpc.RetryInfo');


### PR DESCRIPTION
Unknown errors that are returned during a transaction should not cause the entire transaction to be automatically retried, as there is no absolute guarantee that the initial attempt did not succeed. A `Transaction Outcome Unknown` (or other Unknown)
error could be returned by the `Commit` RPC, and in that case there is a possibility that the transaction was actually committed.

Fixes #1387
