### PR TITLE
fix: add close method to Spanner client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -268,6 +268,18 @@ class Spanner extends GrpcService {
     };
   }
 
+  /** Closes this Spanner client and cleans up all resources used by it. */
+  close(): void {
+    this.clients_.forEach(c => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const client = c as any;
+      if (client.operationsClient && client.operationsClient.close) {
+        client.operationsClient.close();
+      }
+      client.close();
+    });
+  }
+
   createInstance(
     name: string,
     config: CreateInstanceRequest

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -147,6 +147,7 @@ describe('Spanner with mock server', () => {
   });
 
   after(() => {
+    spanner.close();
     server.tryShutdown(() => {});
     delete process.env.SPANNER_EMULATOR_HOST;
     sandbox.restore();


### PR DESCRIPTION
Adds a close method to the Spanner client that will (try to) clean up the resources it has in use.

Calling `close` will currently close the stubs that are used directly by the underlying clients, but not yet the operations clients that are also used. Those clients will also be closed once https://github.com/googleapis/gax-nodejs/pull/1047 has been merged and has been released.

Towards #1306
