### PR TITLE
test: fix system tests after gax update

### DIFF
--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -4964,18 +4964,26 @@ function generateName(resourceType) {
 }
 
 function onPromiseOperationComplete(data) {
-  const operation = data[data.length - 2];
+  const length =
+    data[data.length - 1] === undefined ? data.length - 1 : data.length;
+  const operation = data[length - 2];
   return operation.promise();
 }
 
 function execAfterOperationComplete(callback) {
   // tslint:disable-next-line only-arrow-functions
   return function (err) {
-    // arguments = [..., op, apiResponse]
+    // arguments = [..., op, apiResponse], unless the response is Empty.
+    // arguments = [op, apiResponse, undefined] if the response is Empty.
+    const length =
+      // eslint-disable-next-line prefer-rest-params
+      arguments[arguments.length - 1] === undefined
+        ? arguments.length - 1
+        : arguments.length;
     // eslint-disable-next-line prefer-rest-params
-    const operation = arguments[arguments.length - 2];
+    const operation = arguments[length - 2];
     // eslint-disable-next-line prefer-rest-params
-    const apiResponse = arguments[arguments.length - 1];
+    const apiResponse = arguments[length - 1];
 
     if (err) {
       callback(err, apiResponse);


### PR DESCRIPTION
https://github.com/googleapis/gax-nodejs/pull/1050 changes the arguments of the response that are read by the system tests slightly. In the following specific case:
- The RPC returns a long-running operation.
- The result of the operation is Empty.
- The callback is defined as only receiving the long-running operation (and not the Empty response)

Then:
- The length of the arguments array in the callback will be 2 (Operation and IOperation) in gax 2.17.0.
- The length of the arguments array in the callback will be 3 (Operation, IOperation, undefined) in gax 2.17.1

Fixes #1423, #1424, #1425, #1426
