### PR TITLE
feat: add option to disable grpc-gcp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,14 +230,18 @@ class Spanner extends GrpcService {
         libName: 'gccl',
         libVersion: require('../../package.json').version,
         scopes,
-        // Enable grpc-gcp support
-        'grpc.callInvocationTransformer': grpcGcp.gcpCallInvocationTransformer,
-        'grpc.channelFactoryOverride': grpcGcp.gcpChannelFactoryOverride,
-        'grpc.gcpApiConfig': grpcGcp.createGcpApiConfig(gcpApiConfig),
         grpc,
       },
       options || {}
     ) as {} as SpannerOptions;
+    if (!process.env.SPANNER_DISABLE_GCP) {
+      // Enable grpc-gcp support
+      options = Object.assign(options, {
+        'grpc.callInvocationTransformer': grpcGcp.gcpCallInvocationTransformer,
+        'grpc.channelFactoryOverride': grpcGcp.gcpChannelFactoryOverride,
+        'grpc.gcpApiConfig': grpcGcp.createGcpApiConfig(gcpApiConfig),
+      });
+    }
     const emulatorHost = Spanner.getSpannerEmulatorHost();
     if (
       emulatorHost &&


### PR DESCRIPTION
Adds an option to disable grpc-gcp as it seems that it causes a higher memory footprint than
when working without.

Towards #1462
