### PR TITLE
fix: never try to create a negative number of sessions

### DIFF
--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -1052,10 +1052,10 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       if (reads > 0) {
         this._pending += reads;
         promises.push(
-            new Promise((resolve, reject) => {
-              this._pending -= reads;
-              this._createSessions({reads, writes: 0}).catch(reject);
-            })
+          new Promise((resolve, reject) => {
+            this._pending -= reads;
+            this._createSessions({reads, writes: 0}).catch(reject);
+          })
         );
       }
     }

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -1052,10 +1052,10 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       if (reads > 0) {
         this._pending += reads;
         promises.push(
-            new Promise((resolve, reject) => {
-              this._pending -= reads;
-              this._createSessions({reads, writes: 0}).catch(reject);
-            })
+          new Promise((_, reject) => {
+            this._pending -= reads;
+            this._createSessions({reads, writes: 0}).catch(reject);
+          })
         );
       }
     }


### PR DESCRIPTION
The session pool should never try to create a negative number of sessions. Especially the `_fill` method could try that, as it would create `this.options.min! - this.size` sessions. That works well for an empty session pool, but not for one that has already been filled, and can cause the `_pending` value to become negative.

It might be that the `_fill` method could cause the strange statistics that we see in #1465 if the following happens:
1. `_fill` is called after the session pool has been initialized (i.e. there is at least 1 session in the pool)
2. `_pending` is increased with a negative number, potentially causing it to become negative: https://github.com/googleapis/nodejs-spanner/blob/b193122d782e47334522dc428444834f840f31aa/src/session-pool.ts#L827
3. The [loop for creating sessions](https://github.com/googleapis/nodejs-spanner/blob/b193122d782e47334522dc428444834f840f31aa/src/session-pool.ts#L831) is never executed, which also means that `_pending` is never updated when the sessions are created or the creation fails.

Updates #1465 
