### PR TITLE
feat: adding support for Cross Region Backups

### DIFF
--- a/samples/backups-copy.js
+++ b/samples/backups-copy.js
@@ -1,0 +1,92 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// sample-metadata:
+//  title: Read data using an existing index.
+//  usage: node spannerCopyBackup <INSTANCE_ID> <DATABASE_ID> <PROJECT_ID>
+
+'use strict';
+
+function main(
+  instanceId = 'my-instance',
+  databaseId = 'my-database',
+  backupId = 'my-backup',
+  sourceBackupId = 'my-source-backup',
+  projectId = 'my-project-id'
+) {
+  // [START spanner_copy_backup]
+  /**
+   * TODO(developer): Uncomment these variables before running the sample.
+   */
+  // const instanceId = 'my-instance';
+  // const databaseId = 'my-database';
+  // const backupId = 'my-backup',
+  // sourceBackupId = 'my-source-backup',
+  // const projectId = 'my-project-id';
+
+  // Imports the Google Cloud Spanner client library
+  const {Spanner} = require('@google-cloud/spanner');
+  const {PreciseDate} = require('@google-cloud/precise-date');
+
+  // Instantiates a client
+  const spanner = new Spanner({
+     projectId: projectId
+   });
+
+  async function spannerCopyBackup() {
+    // Gets a reference to a Cloud Spanner instance, database and backup
+    const instance = spanner.instance(instanceId);
+    const database = instance.database(databaseId);
+    const sourceBackup = instance.backup(sourceBackupId);
+
+    // Expire source and copy backup 14 days in the future
+    const expireTime = Spanner.timestamp(Date.now() + 1000 * 60 * 60 * 24 * 14).toStruct();
+
+    // Copy the backup of the database
+    const copyBackup = instance.copy_backup(backupId, sourceBackup.formattedName_);
+    try {
+      console.log(`Creating copy of the source backup ${sourceBackup.formattedName_}.`);
+      const [, operation] = await copyBackup.create({
+        expireTime: expireTime,
+      });
+
+      console.log(`Waiting for copy backup ${copyBackup.formattedName_} to complete...`);
+      await operation.promise();
+
+      // Verify the copy backup is ready
+      const [copyBackupInfo] = await copyBackup.getMetadata();
+      if (copyBackupInfo.state === 'READY') {
+        console.log(
+          `Copy Backup ${copyBackupInfo.name} of size ` +
+            `${copyBackupInfo.sizeBytes} bytes was created at ` +
+            `${new PreciseDate(copyBackupInfo.createTime).toISOString()}`
+        );
+      } else {
+        console.error('ERROR: Copy backup is not ready.');
+      }
+    } catch (err) {
+      console.error('ERROR:', err);
+    } finally {
+      // Close the database when finished.
+      await database.close();
+    }
+  }
+  spannerCopyBackup();
+  // [END spanner_copy_backup]
+}
+process.on('unhandledRejection', err => {
+  console.error(err.message);
+  process.exitCode = 1;
+});
+main(...process.argv.slice(2));

--- a/samples/system-test/spanner.test.js
+++ b/samples/system-test/spanner.test.js
@@ -52,6 +52,7 @@ const VERSION_RETENTION_DATABASE_ID = `test-database-${CURRENT_TIME}-v`;
 const ENCRYPTED_DATABASE_ID = `test-database-${CURRENT_TIME}-enc`;
 const DEFAULT_LEADER_DATABASE_ID = `test-database-${CURRENT_TIME}-dl`;
 const BACKUP_ID = `test-backup-${CURRENT_TIME}`;
+const COPY_BACKUP_ID = `test-copy-backup-${CURRENT_TIME}`;
 const ENCRYPTED_BACKUP_ID = `test-backup-${CURRENT_TIME}-enc`;
 const CANCELLED_BACKUP_ID = `test-backup-${CURRENT_TIME}-c`;
 const LOCATION_ID = 'regional-us-central1';
@@ -214,6 +215,7 @@ describe('Spanner', () => {
       await Promise.all([
         instance.backup(BACKUP_ID).delete(GAX_OPTIONS),
         instance.backup(ENCRYPTED_BACKUP_ID).delete(GAX_OPTIONS),
+        instance.backup(COPY_BACKUP_ID).delete(GAX_OPTIONS),
         instance.backup(CANCELLED_BACKUP_ID).delete(GAX_OPTIONS),
       ]);
       await instance.delete(GAX_OPTIONS);
@@ -223,6 +225,7 @@ describe('Spanner', () => {
         instance.database(RESTORE_DATABASE_ID).delete(),
         instance.database(ENCRYPTED_RESTORE_DATABASE_ID).delete(),
         instance.backup(BACKUP_ID).delete(GAX_OPTIONS),
+        instance.backup(COPY_BACKUP_ID).delete(GAX_OPTIONS),
         instance.backup(ENCRYPTED_BACKUP_ID).delete(GAX_OPTIONS),
         instance.backup(CANCELLED_BACKUP_ID).delete(GAX_OPTIONS),
       ]);
@@ -1019,6 +1022,16 @@ describe('Spanner', () => {
       new RegExp(`Backup (.+)${ENCRYPTED_BACKUP_ID} of size`)
     );
     assert.include(output, `using encryption key ${key.name}`);
+  });
+
+  // copy_backup
+  it('should create a copy of a backup', async () => {
+    const instance = spanner.instance(INSTANCE_ID);
+
+    const output = execSync(
+      `node backups-copy.js ${INSTANCE_ID} ${DATABASE_ID} ${COPY_BACKUP_ID} ${BACKUP_ID} ${PROJECT_ID}`
+    );
+    assert.match(output, new RegExp(`(.*)Copy Backup (.*)${COPY_BACKUP_ID} of size(.*)`));
   });
 
   // cancel_backup

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -249,6 +249,16 @@ class Instance extends common.GrpcServiceObject {
     return new Backup(this, backupId);
   }
 
+  copy_backup(backupId: string, sourceBackupId: string): Backup {
+    if (!backupId || !sourceBackupId) {
+      throw new Error(
+        'A backup ID and source backup ID is required to create a Backup.'
+      );
+    }
+
+    return new Backup(this, backupId, sourceBackupId);
+  }
+
   getBackups(options?: GetBackupsOptions): Promise<GetBackupsResponse>;
   getBackups(callback: GetBackupsCallback): void;
   getBackups(options: GetBackupsOptions, callback: GetBackupsCallback): void;

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1263,19 +1263,23 @@ describe('Spanner', () => {
         backup1Operation.metadata!.name,
         `${instance.formattedName_}/backups/${backup1Name}`
       );
-      assert.strictEqual(
-        backup1Operation.metadata!.database,
-        database1.formattedName_
-      );
+
+      if ('database' in backup1Operation.metadata) 
+        assert.strictEqual(
+          backup1Operation.metadata!.database,
+          database1.formattedName_
+        );
 
       assert.strictEqual(
         backup2Operation.metadata!.name,
         `${instance.formattedName_}/backups/${backup2Name}`
       );
-      assert.strictEqual(
-        backup2Operation.metadata!.database,
-        database2.formattedName_
-      );
+
+      if ('database' in backup2Operation.metadata) 
+        assert.strictEqual(
+          backup2Operation.metadata!.database,
+          database2.formattedName_
+        );
 
       // Wait for backups to finish.
       await backup1Operation.promise();

--- a/test/instance.ts
+++ b/test/instance.ts
@@ -1457,6 +1457,12 @@ describe('Instance', () => {
         },
       ];
 
+      const COPY_BACKUPS = [
+        {
+          expireTime: new PreciseDate(1000),
+        },
+      ];
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const REQUEST_RESPONSE_ARGS: any = [null, BACKUPS, null, {}];
 
@@ -1629,6 +1635,7 @@ describe('Instance', () => {
 
   describe('backup', () => {
     const BACKUP_NAME = 'backup-name';
+    const COPY_BACKUP_NAME = 'copy-backup-name';
 
     it('should throw if a backup ID is not provided', () => {
       assert.throws(() => {
@@ -1641,6 +1648,14 @@ describe('Instance', () => {
       assert(backup instanceof FakeBackup);
       assert.strictEqual(backup.calledWith_[0], instance);
       assert.strictEqual(backup.calledWith_[1], BACKUP_NAME);
+    });
+
+    it('should return an instance of Copy Backup', () => {
+      const copy_backup = instance.copy_backup(COPY_BACKUP_NAME, BACKUP_NAME) as {} as FakeBackup;
+      assert(copy_backup instanceof FakeBackup);
+      assert.strictEqual(copy_backup.calledWith_[0], instance);
+      assert.strictEqual(copy_backup.calledWith_[1], COPY_BACKUP_NAME);
+      assert.strictEqual(copy_backup.calledWith_[2], BACKUP_NAME);
     });
   });
 


### PR DESCRIPTION
Adding support and samples for Cloud Spanner Cross-Region Backups. This feature allows customers to copy the backup to instances in different regions after creating a backup of the database. The following PR adds the following functionalities:

1. Support for copy_backup in the Node client
2. Tests for copy_backup
3. Samples for copy_backup