### PR TITLE
fix(cloud-rad): move comments for TSDoc

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -117,8 +117,6 @@ class Backup {
     };
   }
 
-  create(options: CreateBackupOptions): Promise<CreateBackupResponse>;
-  create(options: CreateBackupOptions, callback: CreateBackupCallback): void;
   /**
    * @typedef {object} CreateBackupOptions
    * @property {string} databasePath The database path.
@@ -183,6 +181,8 @@ class Backup {
    * await backupOperation.promise();
    * ```
    */
+  create(options: CreateBackupOptions): Promise<CreateBackupResponse>;
+  create(options: CreateBackupOptions, callback: CreateBackupCallback): void;
   create(
     options: CreateBackupOptions,
     callback?: CreateBackupCallback
@@ -229,9 +229,6 @@ class Backup {
     );
   }
 
-  getMetadata(gaxOptions?: CallOptions): Promise<GetMetadataResponse>;
-  getMetadata(callback: GetMetadataCallback): void;
-  getMetadata(gaxOptions: CallOptions, callback: GetMetadataCallback): void;
   /**
    * @typedef {array} GetMetadataResponse
    * @property {object} 0 The {@link Backup} metadata.
@@ -266,6 +263,9 @@ class Backup {
    * console.log(`${backupInfo.name}: size=${backupInfo.sizeBytes}`);
    * ```
    */
+  getMetadata(gaxOptions?: CallOptions): Promise<GetMetadataResponse>;
+  getMetadata(callback: GetMetadataCallback): void;
+  getMetadata(gaxOptions: CallOptions, callback: GetMetadataCallback): void;
   getMetadata(
     gaxOptionsOrCallback?: CallOptions | GetMetadataCallback,
     cb?: GetMetadataCallback
@@ -298,12 +298,6 @@ class Backup {
     );
   }
 
-  getState(): Promise<
-    | EnumKey<typeof databaseAdmin.spanner.admin.database.v1.Backup.State>
-    | undefined
-    | null
-  >;
-  getState(callback: GetStateCallback): void;
   /**
    * Retrieves the state of the backup.
    *
@@ -326,6 +320,12 @@ class Backup {
    * const backupCompleted = (state === 'READY');
    * ```
    */
+  getState(): Promise<
+    | EnumKey<typeof databaseAdmin.spanner.admin.database.v1.Backup.State>
+    | undefined
+    | null
+  >;
+  getState(callback: GetStateCallback): void;
   async getState(): Promise<
     | EnumKey<typeof databaseAdmin.spanner.admin.database.v1.Backup.State>
     | undefined
@@ -335,8 +335,6 @@ class Backup {
     return backupInfo.state;
   }
 
-  getExpireTime(): Promise<PreciseDate | undefined>;
-  getExpireTime(callback: GetExpireTimeCallback): void;
   /**
    * Retrieves the expiry time of the backup.
    *
@@ -357,13 +355,13 @@ class Backup {
    * console.log(`Backup expires on ${expireTime.toISOString()}`);
    * ```
    */
+  getExpireTime(): Promise<PreciseDate | undefined>;
+  getExpireTime(callback: GetExpireTimeCallback): void;
   async getExpireTime(): Promise<PreciseDate | undefined> {
     const [backupInfo] = await this.getMetadata();
     return new PreciseDate(backupInfo.expireTime as DateStruct);
   }
 
-  exists(): Promise<boolean>;
-  exists(callback: ExistsCallback): void;
   /**
    * Checks whether the backup exists.
    *
@@ -383,6 +381,8 @@ class Backup {
    * console.log(`Does backup exist? ${alreadyExists}`);
    * ```
    */
+  exists(): Promise<boolean>;
+  exists(callback: ExistsCallback): void;
   async exists(): Promise<boolean> {
     try {
       // Attempt to read metadata to determine whether backup exists
@@ -398,22 +398,6 @@ class Backup {
     }
   }
 
-  updateExpireTime(
-    expireTime: string | number | p.ITimestamp | PreciseDate
-  ): Promise<databaseAdmin.spanner.admin.database.v1.IBackup>;
-  updateExpireTime(
-    expireTime: string | number | p.ITimestamp | PreciseDate,
-    gaxOptions?: CallOptions
-  ): Promise<databaseAdmin.spanner.admin.database.v1.IBackup>;
-  updateExpireTime(
-    expireTime: string | number | p.ITimestamp | PreciseDate,
-    callback: UpdateExpireTimeCallback
-  ): void;
-  updateExpireTime(
-    expireTime: string | number | p.ITimestamp | PreciseDate,
-    gaxOptions: CallOptions,
-    callback: UpdateExpireTimeCallback
-  ): void;
   /**
    * @callback UpdateExpireTimeCallback
    * @param {?Error} err Request error, if any.
@@ -446,6 +430,22 @@ class Backup {
    * await backup.updateExpireTime(newExpireTime);
    * ```
    */
+  updateExpireTime(
+    expireTime: string | number | p.ITimestamp | PreciseDate
+  ): Promise<databaseAdmin.spanner.admin.database.v1.IBackup>;
+  updateExpireTime(
+    expireTime: string | number | p.ITimestamp | PreciseDate,
+    gaxOptions?: CallOptions
+  ): Promise<databaseAdmin.spanner.admin.database.v1.IBackup>;
+  updateExpireTime(
+    expireTime: string | number | p.ITimestamp | PreciseDate,
+    callback: UpdateExpireTimeCallback
+  ): void;
+  updateExpireTime(
+    expireTime: string | number | p.ITimestamp | PreciseDate,
+    gaxOptions: CallOptions,
+    callback: UpdateExpireTimeCallback
+  ): void;
   updateExpireTime(
     expireTime: string | number | p.ITimestamp | PreciseDate,
     gaxOptionsOrCallback?: CallOptions | UpdateExpireTimeCallback,
@@ -483,9 +483,6 @@ class Backup {
     );
   }
 
-  delete(gaxOptions?: CallOptions): Promise<databaseAdmin.protobuf.IEmpty>;
-  delete(callback: DeleteCallback): void;
-  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   /**
    * Deletes a backup.
    *
@@ -505,6 +502,9 @@ class Backup {
    * await backup.delete();
    * ```
    */
+  delete(gaxOptions?: CallOptions): Promise<databaseAdmin.protobuf.IEmpty>;
+  delete(callback: DeleteCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteCallback): void;
   delete(
     gaxOptionsOrCallback?: CallOptions | DeleteCallback,
     cb?: DeleteCallback

--- a/src/database.ts
+++ b/src/database.ts
@@ -399,13 +399,6 @@ class Database extends common.GrpcServiceObject {
     return options;
   }
 
-  batchCreateSessions(
-    options: number | BatchCreateSessionsOptions
-  ): Promise<BatchCreateSessionsResponse>;
-  batchCreateSessions(
-    options: number | BatchCreateSessionsOptions,
-    callback: BatchCreateSessionsCallback
-  ): void;
   /**
    * @typedef {object} BatchCreateSessionsOptions
    * @property {number} count The number of sessions to create.
@@ -468,6 +461,13 @@ class Database extends common.GrpcServiceObject {
    * const [sessions, response] = await database.batchCreateSessions(count);
    * ```
    */
+  batchCreateSessions(
+    options: number | BatchCreateSessionsOptions
+  ): Promise<BatchCreateSessionsResponse>;
+  batchCreateSessions(
+    options: number | BatchCreateSessionsOptions,
+    callback: BatchCreateSessionsCallback
+  ): void;
   batchCreateSessions(
     options: number | BatchCreateSessionsOptions,
     callback?: BatchCreateSessionsCallback
@@ -548,8 +548,6 @@ class Database extends common.GrpcServiceObject {
     transaction.readTimestamp = identifier.timestamp as PreciseDate;
     return transaction;
   }
-  close(callback: SessionPoolCloseCallback): void;
-  close(): Promise<DatabaseCloseResponse>;
   /**
    * @callback CloseDatabaseCallback
    * @param {?Error} err Request error, if any.
@@ -587,6 +585,8 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  close(callback: SessionPoolCloseCallback): void;
+  close(): Promise<DatabaseCloseResponse>;
   close(
     callback?: SessionPoolCloseCallback
   ): void | Promise<DatabaseCloseResponse> {
@@ -595,14 +595,6 @@ class Database extends common.GrpcServiceObject {
     (this.parent as any).databases_.delete(key);
     this.pool_.close(callback!);
   }
-  createBatchTransaction(
-    options?: TimestampBounds
-  ): Promise<CreateBatchTransactionResponse>;
-  createBatchTransaction(callback: CreateBatchTransactionCallback): void;
-  createBatchTransaction(
-    options: TimestampBounds,
-    callback: CreateBatchTransactionCallback
-  ): void;
   /**
    * @typedef {array} CreateTransactionResponse
    * @property {BatchTransaction} 0 The {@link BatchTransaction}.
@@ -621,6 +613,14 @@ class Database extends common.GrpcServiceObject {
    * @param {CreateTransactionCallback} [callback] Callback function.
    * @returns {Promise<CreateTransactionResponse>}
    */
+  createBatchTransaction(
+    options?: TimestampBounds
+  ): Promise<CreateBatchTransactionResponse>;
+  createBatchTransaction(callback: CreateBatchTransactionCallback): void;
+  createBatchTransaction(
+    options: TimestampBounds,
+    callback: CreateBatchTransactionCallback
+  ): void;
   createBatchTransaction(
     optionsOrCallback?: TimestampBounds | CreateBatchTransactionCallback,
     cb?: CreateBatchTransactionCallback
@@ -650,12 +650,6 @@ class Database extends common.GrpcServiceObject {
       });
     });
   }
-  createSession(options: CreateSessionOptions): Promise<CreateSessionResponse>;
-  createSession(callback: CreateSessionCallback): void;
-  createSession(
-    options: CreateSessionOptions,
-    callback: CreateSessionCallback
-  ): void;
   /**
    * Create a new session.
    *
@@ -729,6 +723,12 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  createSession(options: CreateSessionOptions): Promise<CreateSessionResponse>;
+  createSession(callback: CreateSessionCallback): void;
+  createSession(
+    options: CreateSessionOptions,
+    callback: CreateSessionCallback
+  ): void;
   createSession(
     optionsOrCallback: CreateSessionOptions | CreateSessionCallback,
     cb?: CreateSessionCallback
@@ -767,16 +767,6 @@ class Database extends common.GrpcServiceObject {
       }
     );
   }
-  createTable(
-    schema: Schema,
-    gaxOptions?: CallOptions
-  ): Promise<CreateTableResponse>;
-  createTable(schema: Schema, callback: CreateTableCallback): void;
-  createTable(
-    schema: Schema,
-    gaxOptions: CallOptions,
-    callback: CreateTableCallback
-  ): void;
   /**
    * @typedef {array} CreateTableResponse
    * @property {Table} 0 The new {@link Table}.
@@ -851,6 +841,16 @@ class Database extends common.GrpcServiceObject {
    */
   createTable(
     schema: Schema,
+    gaxOptions?: CallOptions
+  ): Promise<CreateTableResponse>;
+  createTable(schema: Schema, callback: CreateTableCallback): void;
+  createTable(
+    schema: Schema,
+    gaxOptions: CallOptions,
+    callback: CreateTableCallback
+  ): void;
+  createTable(
+    schema: Schema,
     gaxOptionsOrCallback?: CallOptions | CreateTableCallback,
     cb?: CreateTableCallback
   ): void | Promise<CreateTableResponse> {
@@ -890,9 +890,6 @@ class Database extends common.GrpcServiceObject {
       }
     });
   }
-  delete(gaxOptions?: CallOptions): Promise<DatabaseDeleteResponse>;
-  delete(callback: DatabaseDeleteCallback): void;
-  delete(gaxOptions: CallOptions, callback: DatabaseDeleteCallback): void;
   /**
    * @typedef {array} DatabaseDeleteResponse
    * @property {object} 0 The full API response.
@@ -940,6 +937,9 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  delete(gaxOptions?: CallOptions): Promise<DatabaseDeleteResponse>;
+  delete(callback: DatabaseDeleteCallback): void;
+  delete(gaxOptions: CallOptions, callback: DatabaseDeleteCallback): void;
   delete(
     optionsOrCallback?: CallOptions | DatabaseDeleteCallback,
     cb?: DatabaseDeleteCallback
@@ -966,9 +966,6 @@ class Database extends common.GrpcServiceObject {
       );
     });
   }
-  exists(gaxOptions?: CallOptions): Promise<[boolean]>;
-  exists(callback: ExistsCallback): void;
-  exists(gaxOptions: CallOptions, callback: ExistsCallback): void;
   /**
    * @typedef {array} DatabaseExistsResponse
    * @property {boolean} 0 Whether the {@link Database} exists.
@@ -1006,6 +1003,9 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  exists(gaxOptions?: CallOptions): Promise<[boolean]>;
+  exists(callback: ExistsCallback): void;
+  exists(gaxOptions: CallOptions, callback: ExistsCallback): void;
   exists(
     gaxOptionsOrCallback?: CallOptions | ExistsCallback,
     cb?: ExistsCallback
@@ -1026,9 +1026,6 @@ class Database extends common.GrpcServiceObject {
       callback!(null, exists);
     });
   }
-  get(options?: GetDatabaseConfig): Promise<DatabaseResponse>;
-  get(callback: DatabaseCallback): void;
-  get(options: GetDatabaseConfig, callback: DatabaseCallback): void;
   /**
    * @typedef {array} GetDatabaseResponse
    * @property {Database} 0 The {@link Database}.
@@ -1078,6 +1075,9 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  get(options?: GetDatabaseConfig): Promise<DatabaseResponse>;
+  get(callback: DatabaseCallback): void;
+  get(options: GetDatabaseConfig, callback: DatabaseCallback): void;
   get(
     optionsOrCallback?: GetDatabaseConfig | DatabaseCallback,
     cb?: DatabaseCallback
@@ -1114,12 +1114,6 @@ class Database extends common.GrpcServiceObject {
       callback!(null, this, metadata as r.Response);
     });
   }
-  getMetadata(gaxOptions?: CallOptions): Promise<GetDatabaseMetadataResponse>;
-  getMetadata(callback: GetDatabaseMetadataCallback): void;
-  getMetadata(
-    gaxOptions: CallOptions,
-    callback: GetDatabaseMetadataCallback
-  ): void;
   /**
    * @typedef {array} GetDatabaseMetadataResponse
    * @property {object} 0 The {@link Database} metadata.
@@ -1169,6 +1163,12 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getMetadata(gaxOptions?: CallOptions): Promise<GetDatabaseMetadataResponse>;
+  getMetadata(callback: GetDatabaseMetadataCallback): void;
+  getMetadata(
+    gaxOptions: CallOptions,
+    callback: GetDatabaseMetadataCallback
+  ): void;
   getMetadata(
     gaxOptionsOrCallback?: CallOptions | GetDatabaseMetadataCallback,
     cb?: GetDatabaseMetadataCallback
@@ -1203,11 +1203,6 @@ class Database extends common.GrpcServiceObject {
     );
   }
 
-  getRestoreInfo(
-    options?: CallOptions
-  ): Promise<IRestoreInfoTranslatedEnum | undefined>;
-  getRestoreInfo(callback: GetRestoreInfoCallback): void;
-  getRestoreInfo(options: CallOptions, callback: GetRestoreInfoCallback): void;
   /**
    * {@link google.spanner.admin.database.v1#RestoreInfo} structure with restore
    * source type enum translated to string form.
@@ -1244,6 +1239,11 @@ class Database extends common.GrpcServiceObject {
    * console.log(`Database restored from ${restoreInfo.backupInfo.backup}`);
    * ```
    */
+  getRestoreInfo(
+    options?: CallOptions
+  ): Promise<IRestoreInfoTranslatedEnum | undefined>;
+  getRestoreInfo(callback: GetRestoreInfoCallback): void;
+  getRestoreInfo(options: CallOptions, callback: GetRestoreInfoCallback): void;
   async getRestoreInfo(
     optionsOrCallback?: CallOptions | GetRestoreInfoCallback
   ): Promise<IRestoreInfoTranslatedEnum | undefined> {
@@ -1254,14 +1254,6 @@ class Database extends common.GrpcServiceObject {
     return metadata.restoreInfo ? metadata.restoreInfo : undefined;
   }
 
-  getState(
-    options?: CallOptions
-  ): Promise<
-    | EnumKey<typeof databaseAdmin.spanner.admin.database.v1.Database.State>
-    | undefined
-  >;
-  getState(callback: GetStateCallback): void;
-  getState(options: CallOptions, callback: GetStateCallback): void;
   /**
    * @callback GetStateCallback
    * @param {?Error} err Request error, if any.
@@ -1295,6 +1287,14 @@ class Database extends common.GrpcServiceObject {
    * const isReady = (state === 'READY');
    * ```
    */
+  getState(
+    options?: CallOptions
+  ): Promise<
+    | EnumKey<typeof databaseAdmin.spanner.admin.database.v1.Database.State>
+    | undefined
+  >;
+  getState(callback: GetStateCallback): void;
+  getState(options: CallOptions, callback: GetStateCallback): void;
   async getState(
     optionsOrCallback?: CallOptions | GetStateCallback
   ): Promise<
@@ -1308,9 +1308,6 @@ class Database extends common.GrpcServiceObject {
     return metadata.state || undefined;
   }
 
-  getSchema(options?: CallOptions): Promise<GetSchemaResponse>;
-  getSchema(callback: GetSchemaCallback): void;
-  getSchema(options: CallOptions, callback: GetSchemaCallback): void;
   /**
    * @typedef {array} GetSchemaResponse
    * @property {string[]} 0 An array of database DDL statements.
@@ -1356,6 +1353,9 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getSchema(options?: CallOptions): Promise<GetSchemaResponse>;
+  getSchema(callback: GetSchemaCallback): void;
+  getSchema(options: CallOptions, callback: GetSchemaCallback): void;
   getSchema(
     optionsOrCallback?: CallOptions | GetSchemaCallback,
     cb?: GetSchemaCallback
@@ -1383,9 +1383,6 @@ class Database extends common.GrpcServiceObject {
       }
     );
   }
-  getSessions(options?: GetSessionsOptions): Promise<GetSessionsResponse>;
-  getSessions(callback: GetSessionsCallback): void;
-  getSessions(options: GetSessionsOptions, callback: GetSessionsCallback): void;
   /**
    * Options object for listing sessions.
    *
@@ -1471,6 +1468,9 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getSessions(options?: GetSessionsOptions): Promise<GetSessionsResponse>;
+  getSessions(callback: GetSessionsCallback): void;
+  getSessions(options: GetSessionsOptions, callback: GetSessionsCallback): void;
   getSessions(
     optionsOrCallback?: GetSessionsOptions | GetSessionsCallback,
     cb?: GetSessionsCallback
@@ -1604,9 +1604,6 @@ class Database extends common.GrpcServiceObject {
     });
   }
 
-  getSnapshot(options?: TimestampBounds): Promise<[Snapshot]>;
-  getSnapshot(callback: GetSnapshotCallback): void;
-  getSnapshot(options: TimestampBounds, callback: GetSnapshotCallback): void;
   /**
    * @typedef {array} GetSnapshotResponse
    * @property {Snapshot} 0 The snapshot object.
@@ -1666,6 +1663,9 @@ class Database extends common.GrpcServiceObject {
    * region_tag:spanner_read_only_transaction
    * Read-only transaction:
    */
+  getSnapshot(options?: TimestampBounds): Promise<[Snapshot]>;
+  getSnapshot(callback: GetSnapshotCallback): void;
+  getSnapshot(options: TimestampBounds, callback: GetSnapshotCallback): void;
   getSnapshot(
     optionsOrCallback?: TimestampBounds | GetSnapshotCallback,
     cb?: GetSnapshotCallback
@@ -1705,8 +1705,6 @@ class Database extends common.GrpcServiceObject {
       });
     });
   }
-  getTransaction(): Promise<[Transaction]>;
-  getTransaction(callback: GetTransactionCallback): void;
   /**
    * @typedef {array} GetTransactionResponse
    * @property {Transaction} 0 The transaction object.
@@ -1750,6 +1748,8 @@ class Database extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getTransaction(): Promise<[Transaction]>;
+  getTransaction(callback: GetTransactionCallback): void;
   getTransaction(
     callback?: GetTransactionCallback
   ): void | Promise<[Transaction]> {
@@ -1761,14 +1761,6 @@ class Database extends common.GrpcServiceObject {
     });
   }
 
-  getOperations(
-    options?: GetDatabaseOperationsOptions
-  ): Promise<GetDatabaseOperationsResponse>;
-  getOperations(callback: GetDatabaseOperationsCallback): void;
-  getOperations(
-    options: GetDatabaseOperationsOptions,
-    callback: GetDatabaseOperationsCallback
-  ): void;
   /**
    * Query object for listing database operations.
    *
@@ -1826,6 +1818,14 @@ class Database extends common.GrpcServiceObject {
    * } while (pageToken);
    * ```
    */
+  getOperations(
+    options?: GetDatabaseOperationsOptions
+  ): Promise<GetDatabaseOperationsResponse>;
+  getOperations(callback: GetDatabaseOperationsCallback): void;
+  getOperations(
+    options: GetDatabaseOperationsOptions,
+    callback: GetDatabaseOperationsCallback
+  ): void;
   async getOperations(
     optionsOrCallback?:
       | GetDatabaseOperationsOptions
@@ -1848,11 +1848,6 @@ class Database extends common.GrpcServiceObject {
     return this.instance.getDatabaseOperations(dbSpecificQuery);
   }
 
-  makePooledRequest_(config: RequestConfig): Promise<Session>;
-  makePooledRequest_(
-    config: RequestConfig,
-    callback: PoolRequestCallback
-  ): void;
   /**
    * Make an API request, first assuring an active session is used.
    *
@@ -1861,6 +1856,11 @@ class Database extends common.GrpcServiceObject {
    * @param {object} config Request config
    * @param {function} callback Callback function
    */
+  makePooledRequest_(config: RequestConfig): Promise<Session>;
+  makePooledRequest_(
+    config: RequestConfig,
+    callback: PoolRequestCallback
+  ): void;
   makePooledRequest_(
     config: RequestConfig,
     callback?: PoolRequestCallback
@@ -1929,17 +1929,6 @@ class Database extends common.GrpcServiceObject {
     return waitForSessionStream;
   }
 
-  restore(backupPath: string): Promise<RestoreDatabaseResponse>;
-  restore(
-    backupPath: string,
-    options?: RestoreOptions | CallOptions
-  ): Promise<RestoreDatabaseResponse>;
-  restore(backupPath: string, callback: RestoreDatabaseCallback): void;
-  restore(
-    backupPath: string,
-    options: RestoreOptions | CallOptions,
-    callback: RestoreDatabaseCallback
-  ): void;
   /**
    * @typedef {object} RestoreOptions
    * @property {google.spanner.admin.database.v1.IRestoreDatabaseEncryptionConfig}
@@ -2004,6 +1993,17 @@ class Database extends common.GrpcServiceObject {
    * await restoreWithKeyOperation.promise();
    * ```
    */
+  restore(backupPath: string): Promise<RestoreDatabaseResponse>;
+  restore(
+    backupPath: string,
+    options?: RestoreOptions | CallOptions
+  ): Promise<RestoreDatabaseResponse>;
+  restore(backupPath: string, callback: RestoreDatabaseCallback): void;
+  restore(
+    backupPath: string,
+    options: RestoreOptions | CallOptions,
+    callback: RestoreDatabaseCallback
+  ): void;
   restore(
     backupName: string,
     optionsOrCallback?: RestoreOptions | CallOptions | RestoreDatabaseCallback,
@@ -2052,17 +2052,6 @@ class Database extends common.GrpcServiceObject {
     );
   }
 
-  run(query: string | ExecuteSqlRequest): Promise<RunResponse>;
-  run(
-    query: string | ExecuteSqlRequest,
-    options?: TimestampBounds
-  ): Promise<RunResponse>;
-  run(query: string | ExecuteSqlRequest, callback: RunCallback): void;
-  run(
-    query: string | ExecuteSqlRequest,
-    options: TimestampBounds,
-    callback: RunCallback
-  ): void;
   /**
    * Transaction options.
    *
@@ -2216,6 +2205,17 @@ class Database extends common.GrpcServiceObject {
    * region_tag:spanner_query_data_with_index
    * Querying data with an index:
    */
+  run(query: string | ExecuteSqlRequest): Promise<RunResponse>;
+  run(
+    query: string | ExecuteSqlRequest,
+    options?: TimestampBounds
+  ): Promise<RunResponse>;
+  run(query: string | ExecuteSqlRequest, callback: RunCallback): void;
+  run(
+    query: string | ExecuteSqlRequest,
+    options: TimestampBounds,
+    callback: RunCallback
+  ): void;
   run(
     query: string | ExecuteSqlRequest,
     optionsOrCallback?: TimestampBounds | RunCallback,
@@ -2248,11 +2248,6 @@ class Database extends common.GrpcServiceObject {
         callback!(null, rows, stats, metadata);
       });
   }
-  runPartitionedUpdate(query: string | ExecuteSqlRequest): Promise<[number]>;
-  runPartitionedUpdate(
-    query: string | ExecuteSqlRequest,
-    callback?: RunUpdateCallback
-  ): void;
   /**
    * Partitioned DML transactions are used to execute DML statements with a
    * different execution strategy that provides different, and often better,
@@ -2267,6 +2262,11 @@ class Database extends common.GrpcServiceObject {
    * @param {RunUpdateCallback} [callback] Callback function.
    * @returns {Promise<RunUpdateResponse>}
    */
+  runPartitionedUpdate(query: string | ExecuteSqlRequest): Promise<[number]>;
+  runPartitionedUpdate(
+    query: string | ExecuteSqlRequest,
+    callback?: RunUpdateCallback
+  ): void;
   runPartitionedUpdate(
     query: string | ExecuteSqlRequest,
     callback?: RunUpdateCallback
@@ -2491,11 +2491,6 @@ class Database extends common.GrpcServiceObject {
     return proxyStream as PartialResultStream;
   }
 
-  runTransaction(runFn: RunTransactionCallback): void;
-  runTransaction(
-    options: RunTransactionOptions,
-    runFn: RunTransactionCallback
-  ): void;
   /**
    * @typedef {object} RunTransactionOptions
    * @property {number} [timeout] The maximum amount of time (in ms) that a
@@ -2585,6 +2580,11 @@ class Database extends common.GrpcServiceObject {
    * region_tag:spanner_read_write_transaction
    * Read-write transaction:
    */
+  runTransaction(runFn: RunTransactionCallback): void;
+  runTransaction(
+    options: RunTransactionOptions,
+    runFn: RunTransactionCallback
+  ): void;
   runTransaction(
     optionsOrRunFn: RunTransactionOptions | RunTransactionCallback,
     fn?: RunTransactionCallback
@@ -2780,16 +2780,6 @@ class Database extends common.GrpcServiceObject {
     }
     return new Table(this, name);
   }
-  updateSchema(
-    statements: Schema,
-    gaxOptions?: CallOptions
-  ): Promise<UpdateSchemaResponse>;
-  updateSchema(statements: Schema, callback: UpdateSchemaCallback): void;
-  updateSchema(
-    statements: Schema,
-    gaxOptions: CallOptions,
-    callback: UpdateSchemaCallback
-  ): void;
   /**
    * Update the schema of the database by creating/altering/dropping tables,
    * columns, indexes, etc.
@@ -2868,6 +2858,16 @@ class Database extends common.GrpcServiceObject {
    * region_tag:spanner_create_storing_index
    * Creating a storing index:
    */
+  updateSchema(
+    statements: Schema,
+    gaxOptions?: CallOptions
+  ): Promise<UpdateSchemaResponse>;
+  updateSchema(statements: Schema, callback: UpdateSchemaCallback): void;
+  updateSchema(
+    statements: Schema,
+    gaxOptions: CallOptions,
+    callback: UpdateSchemaCallback
+  ): void;
   updateSchema(
     statements: Schema,
     optionsOrCallback?: CallOptions | UpdateSchemaCallback,

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,15 +295,6 @@ class Spanner extends GrpcService {
     });
   }
 
-  createInstance(
-    name: string,
-    config: CreateInstanceRequest
-  ): Promise<CreateInstanceResponse>;
-  createInstance(
-    name: string,
-    config: CreateInstanceRequest,
-    callback: CreateInstanceCallback
-  ): void;
   /**
    * Config for the new instance.
    *
@@ -395,6 +386,15 @@ class Spanner extends GrpcService {
    */
   createInstance(
     name: string,
+    config: CreateInstanceRequest
+  ): Promise<CreateInstanceResponse>;
+  createInstance(
+    name: string,
+    config: CreateInstanceRequest,
+    callback: CreateInstanceCallback
+  ): void;
+  createInstance(
+    name: string,
     config: CreateInstanceRequest,
     callback?: CreateInstanceCallback
   ): void | Promise<CreateInstanceResponse> {
@@ -458,12 +458,6 @@ class Spanner extends GrpcService {
     );
   }
 
-  getInstances(options?: GetInstancesOptions): Promise<GetInstancesResponse>;
-  getInstances(callback: GetInstancesCallback): void;
-  getInstances(
-    query: GetInstancesOptions,
-    callback: GetInstancesCallback
-  ): void;
   /**
    * Query object for listing instances.
    *
@@ -548,6 +542,12 @@ class Spanner extends GrpcService {
    * });
    * ```
    */
+  getInstances(options?: GetInstancesOptions): Promise<GetInstancesResponse>;
+  getInstances(callback: GetInstancesCallback): void;
+  getInstances(
+    query: GetInstancesOptions,
+    callback: GetInstancesCallback
+  ): void;
   getInstances(
     optionsOrCallback?: GetInstancesOptions | GetInstancesCallback,
     cb?: GetInstancesCallback
@@ -678,14 +678,6 @@ class Spanner extends GrpcService {
     });
   }
 
-  getInstanceConfigs(
-    query?: GetInstanceConfigsOptions
-  ): Promise<GetInstanceConfigsResponse>;
-  getInstanceConfigs(callback: GetInstanceConfigsCallback): void;
-  getInstanceConfigs(
-    query: GetInstanceConfigsOptions,
-    callback: GetInstanceConfigsCallback
-  ): void;
   /**
    * Lists the supported instance configurations for a given project.
    *
@@ -770,6 +762,14 @@ class Spanner extends GrpcService {
    * });
    * ```
    */
+  getInstanceConfigs(
+    query?: GetInstanceConfigsOptions
+  ): Promise<GetInstanceConfigsResponse>;
+  getInstanceConfigs(callback: GetInstanceConfigsCallback): void;
+  getInstanceConfigs(
+    query: GetInstanceConfigsOptions,
+    callback: GetInstanceConfigsCallback
+  ): void;
   getInstanceConfigs(
     optionsOrCallback?: GetInstanceConfigsOptions | GetInstanceConfigsCallback,
     cb?: GetInstanceConfigsCallback
@@ -888,17 +888,6 @@ class Spanner extends GrpcService {
     });
   }
 
-  getInstanceConfig(name: string): Promise<GetInstanceConfigResponse>;
-  getInstanceConfig(
-    name: string,
-    options: GetInstanceConfigOptions
-  ): Promise<GetInstanceConfigResponse>;
-  getInstanceConfig(name: string, callback: GetInstanceConfigCallback): void;
-  getInstanceConfig(
-    name: string,
-    options: GetInstanceConfigOptions,
-    callback: GetInstanceConfigCallback
-  ): void;
   /**
    * Gets the instance configuration with the specified name.
    */
@@ -953,6 +942,17 @@ class Spanner extends GrpcService {
    * });
    * ```
    */
+  getInstanceConfig(name: string): Promise<GetInstanceConfigResponse>;
+  getInstanceConfig(
+    name: string,
+    options: GetInstanceConfigOptions
+  ): Promise<GetInstanceConfigResponse>;
+  getInstanceConfig(name: string, callback: GetInstanceConfigCallback): void;
+  getInstanceConfig(
+    name: string,
+    options: GetInstanceConfigOptions,
+    callback: GetInstanceConfigCallback
+  ): void;
   getInstanceConfig(
     name: string,
     optionsOrCallback?: GetInstanceConfigOptions | GetInstanceConfigCallback,

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -255,9 +255,6 @@ class Instance extends common.GrpcServiceObject {
     return new Backup(this, backupId);
   }
 
-  getBackups(options?: GetBackupsOptions): Promise<GetBackupsResponse>;
-  getBackups(callback: GetBackupsCallback): void;
-  getBackups(options: GetBackupsOptions, callback: GetBackupsCallback): void;
   /**
    * Query object for listing backups.
    *
@@ -323,6 +320,9 @@ class Instance extends common.GrpcServiceObject {
    * } while (pageToken);
    * ```
    */
+  getBackups(options?: GetBackupsOptions): Promise<GetBackupsResponse>;
+  getBackups(callback: GetBackupsCallback): void;
+  getBackups(options: GetBackupsOptions, callback: GetBackupsCallback): void;
   getBackups(
     optionsOrCallback?: GetBackupsOptions | GetBackupsCallback,
     cb?: GetBackupsCallback
@@ -454,14 +454,6 @@ class Instance extends common.GrpcServiceObject {
     });
   }
 
-  getBackupOperations(
-    options?: GetBackupOperationsOptions
-  ): Promise<GetBackupOperationsResponse>;
-  getBackupOperations(callback: GetBackupOperationsCallback): void;
-  getBackupOperations(
-    options: GetBackupOperationsOptions,
-    callback: GetBackupOperationsCallback
-  ): void;
   /**
    * Query object for listing backup operations.
    *
@@ -489,6 +481,14 @@ class Instance extends common.GrpcServiceObject {
    * @param {object} nextQuery A query object to receive more results.
    * @param {object} apiResponse The full API response.
    */
+  getBackupOperations(
+    options?: GetBackupOperationsOptions
+  ): Promise<GetBackupOperationsResponse>;
+  getBackupOperations(callback: GetBackupOperationsCallback): void;
+  getBackupOperations(
+    options: GetBackupOperationsOptions,
+    callback: GetBackupOperationsCallback
+  ): void;
 
   /**
    * List pending and completed backup operations for all databases in the instance.
@@ -581,14 +581,6 @@ class Instance extends common.GrpcServiceObject {
     );
   }
 
-  getDatabaseOperations(
-    options?: GetDatabaseOperationsOptions
-  ): Promise<GetDatabaseOperationsResponse>;
-  getDatabaseOperations(callback: GetDatabaseOperationsCallback): void;
-  getDatabaseOperations(
-    options: GetDatabaseOperationsOptions,
-    callback: GetDatabaseOperationsCallback
-  ): void;
   /**
    * Query object for listing database operations.
    *
@@ -616,6 +608,14 @@ class Instance extends common.GrpcServiceObject {
    * @param {object} nextQuery A query object to receive more results.
    * @param {object} apiResponse The full API response.
    */
+  getDatabaseOperations(
+    options?: GetDatabaseOperationsOptions
+  ): Promise<GetDatabaseOperationsResponse>;
+  getDatabaseOperations(callback: GetDatabaseOperationsCallback): void;
+  getDatabaseOperations(
+    options: GetDatabaseOperationsOptions,
+    callback: GetDatabaseOperationsCallback
+  ): void;
 
   /**
    * List pending and completed operations for all databases in the instance.
@@ -709,16 +709,6 @@ class Instance extends common.GrpcServiceObject {
     );
   }
 
-  createDatabase(
-    name: string,
-    options?: CreateDatabaseOptions
-  ): Promise<CreateDatabaseResponse>;
-  createDatabase(name: string, callback: CreateDatabaseCallback): void;
-  createDatabase(
-    name: string,
-    options: CreateDatabaseOptions,
-    callback: CreateDatabaseCallback
-  ): void;
   /**
    * Config for the new database.
    *
@@ -805,6 +795,16 @@ class Instance extends common.GrpcServiceObject {
    * region_tag:spanner_create_database
    * Full example:
    */
+  createDatabase(
+    name: string,
+    options?: CreateDatabaseOptions
+  ): Promise<CreateDatabaseResponse>;
+  createDatabase(name: string, callback: CreateDatabaseCallback): void;
+  createDatabase(
+    name: string,
+    options: CreateDatabaseOptions,
+    callback: CreateDatabaseCallback
+  ): void;
   createDatabase(
     name: string,
     optionsOrCallback?: CreateDatabaseOptions | CreateDatabaseCallback,
@@ -908,9 +908,6 @@ class Instance extends common.GrpcServiceObject {
     return this.databases_.get(key!)!;
   }
 
-  delete(gaxOptions?: CallOptions): Promise<DeleteInstanceResponse>;
-  delete(callback: DeleteInstanceCallback): void;
-  delete(gaxOptions: CallOptions, callback: DeleteInstanceCallback): void;
   /**
    * @typedef {array} DeleteInstanceResponse
    * @property {object} 0 The full API response.
@@ -957,6 +954,9 @@ class Instance extends common.GrpcServiceObject {
    * });
    * ```
    */
+  delete(gaxOptions?: CallOptions): Promise<DeleteInstanceResponse>;
+  delete(callback: DeleteInstanceCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteInstanceCallback): void;
   delete(
     optionsOrCallback?: CallOptions | DeleteInstanceCallback,
     cb?: DeleteInstanceCallback
@@ -995,9 +995,6 @@ class Instance extends common.GrpcServiceObject {
       });
   }
 
-  exists(gaxOptions?: CallOptions): Promise<ExistsInstanceResponse>;
-  exists(callback: ExistsInstanceCallback): void;
-  exists(gaxOptions: CallOptions, callback: ExistsInstanceCallback): void;
   /**
    * @typedef {array} InstanceExistsResponse
    * @property {boolean} 0 Whether the {@link Instance} exists.
@@ -1034,6 +1031,9 @@ class Instance extends common.GrpcServiceObject {
    * });
    * ```
    */
+  exists(gaxOptions?: CallOptions): Promise<ExistsInstanceResponse>;
+  exists(callback: ExistsInstanceCallback): void;
+  exists(gaxOptions: CallOptions, callback: ExistsInstanceCallback): void;
   exists(
     optionsOrCallback?: CallOptions | ExistsInstanceCallback,
     cb?: ExistsInstanceCallback
@@ -1056,9 +1056,6 @@ class Instance extends common.GrpcServiceObject {
     });
   }
 
-  get(options?: GetInstanceConfig): Promise<GetInstanceResponse>;
-  get(callback: GetInstanceCallback): void;
-  get(options: GetInstanceConfig, callback: GetInstanceCallback): void;
   /**
    * @typedef {array} GetInstanceResponse
    * @property {Instance} 0 The {@link Instance}.
@@ -1107,6 +1104,9 @@ class Instance extends common.GrpcServiceObject {
    * });
    * ```
    */
+  get(options?: GetInstanceConfig): Promise<GetInstanceResponse>;
+  get(callback: GetInstanceCallback): void;
+  get(options: GetInstanceConfig, callback: GetInstanceCallback): void;
   get(
     optionsOrCallback?: GetInstanceConfig | GetInstanceCallback,
     cb?: GetInstanceCallback
@@ -1160,12 +1160,6 @@ class Instance extends common.GrpcServiceObject {
     });
   }
 
-  getDatabases(options?: GetDatabasesOptions): Promise<GetDatabasesResponse>;
-  getDatabases(callback: GetDatabasesCallback): void;
-  getDatabases(
-    options: GetDatabasesOptions,
-    callback: GetDatabasesCallback
-  ): void;
   /**
    * Query object for listing databases.
    *
@@ -1236,6 +1230,12 @@ class Instance extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getDatabases(options?: GetDatabasesOptions): Promise<GetDatabasesResponse>;
+  getDatabases(callback: GetDatabasesCallback): void;
+  getDatabases(
+    options: GetDatabasesOptions,
+    callback: GetDatabasesCallback
+  ): void;
   getDatabases(
     optionsOrCallback?: GetDatabasesOptions | GetDatabasesCallback,
     cb?: GetDatabasesCallback
@@ -1370,14 +1370,6 @@ class Instance extends common.GrpcServiceObject {
     });
   }
 
-  getMetadata(
-    options?: GetInstanceMetadataOptions
-  ): Promise<GetInstanceMetadataResponse>;
-  getMetadata(callback: GetInstanceMetadataCallback): void;
-  getMetadata(
-    options: GetInstanceMetadataOptions,
-    callback: GetInstanceMetadataCallback
-  ): void;
   /**
    * @typedef {array} GetInstanceMetadataResponse
    * @property {object} 0 The {@link Instance} metadata.
@@ -1440,6 +1432,14 @@ class Instance extends common.GrpcServiceObject {
    * ```
    */
   getMetadata(
+    options?: GetInstanceMetadataOptions
+  ): Promise<GetInstanceMetadataResponse>;
+  getMetadata(callback: GetInstanceMetadataCallback): void;
+  getMetadata(
+    options: GetInstanceMetadataOptions,
+    callback: GetInstanceMetadataCallback
+  ): void;
+  getMetadata(
     optionsOrCallback?:
       | GetInstanceMetadataOptions
       | GetInstanceMetadataCallback,
@@ -1474,16 +1474,6 @@ class Instance extends common.GrpcServiceObject {
     );
   }
 
-  setMetadata(
-    metadata: IInstance,
-    gaxOptions?: CallOptions
-  ): Promise<SetInstanceMetadataResponse>;
-  setMetadata(metadata: IInstance, callback: SetInstanceMetadataCallback): void;
-  setMetadata(
-    metadata: IInstance,
-    gaxOptions: CallOptions,
-    callback: SetInstanceMetadataCallback
-  ): void;
   /**
    * Update the metadata for this instance. Note that this method follows PATCH
    * semantics, so previously-configured settings will persist.
@@ -1532,6 +1522,16 @@ class Instance extends common.GrpcServiceObject {
    * });
    * ```
    */
+  setMetadata(
+    metadata: IInstance,
+    gaxOptions?: CallOptions
+  ): Promise<SetInstanceMetadataResponse>;
+  setMetadata(metadata: IInstance, callback: SetInstanceMetadataCallback): void;
+  setMetadata(
+    metadata: IInstance,
+    gaxOptions: CallOptions,
+    callback: SetInstanceMetadataCallback
+  ): void;
   setMetadata(
     metadata: IInstance,
     optionsOrCallback?: CallOptions | SetInstanceMetadataCallback,

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -74,34 +74,34 @@ export interface SessionPoolInterface extends EventEmitter {
    * @name SessionPoolInterface#close
    * @param {SessionPoolCloseCallback} callback The callback function.
    */
-  close(callback: SessionPoolCloseCallback): void;
   /**
    * Will be called by the Database object, should be used to start creating
    * sessions/etc.
    *
    * @name SessionPoolInterface#open
    */
-  open(): void;
   /**
    * When called returns a read-only session.
    *
    * @name SessionPoolInterface#getReadSession
    * @param {GetReadSessionCallback} callback The callback function.
    */
-  getReadSession(callback: GetReadSessionCallback): void;
   /**
    * When called returns a read-write session with prepared transaction.
    *
    * @name SessionPoolInterface#getWriteSession
    * @param {GetWriteSessionCallback} callback The callback function.
    */
-  getWriteSession(callback: GetWriteSessionCallback): void;
   /**
    * To be called when releasing a session back into the pool.
    *
    * @name SessionPoolInterface#release
    * @param {Session} session The session to be released.
    */
+  close(callback: SessionPoolCloseCallback): void;
+  open(): void;
+  getReadSession(callback: GetReadSessionCallback): void;
+  getWriteSession(callback: GetWriteSessionCallback): void;
   release(session: Session): void;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -253,9 +253,6 @@ export class Session extends common.GrpcServiceObject {
       this.formattedName_ = Session.formatName_(database.formattedName_, name);
     }
   }
-  delete(gaxOptions?: CallOptions): Promise<DeleteSessionResponse>;
-  delete(callback: DeleteSessionCallback): void;
-  delete(gaxOptions: CallOptions, callback: DeleteSessionCallback): void;
   /**
    * Delete a session.
    *
@@ -288,6 +285,9 @@ export class Session extends common.GrpcServiceObject {
    * });
    * ```
    */
+  delete(gaxOptions?: CallOptions): Promise<DeleteSessionResponse>;
+  delete(callback: DeleteSessionCallback): void;
+  delete(gaxOptions: CallOptions, callback: DeleteSessionCallback): void;
   delete(
     optionsOrCallback?: CallOptions | DeleteSessionCallback,
     cb?: DeleteSessionCallback
@@ -311,12 +311,6 @@ export class Session extends common.GrpcServiceObject {
       callback!
     );
   }
-  getMetadata(gaxOptions?: CallOptions): Promise<GetSessionMetadataResponse>;
-  getMetadata(callback: GetSessionMetadataCallback): void;
-  getMetadata(
-    gaxOptions: CallOptions,
-    callback: GetSessionMetadataCallback
-  ): void;
   /**
    * @typedef {array} GetSessionMetadataResponse
    * @property {object} 0 The session's metadata.
@@ -355,6 +349,12 @@ export class Session extends common.GrpcServiceObject {
    * });
    * ```
    */
+  getMetadata(gaxOptions?: CallOptions): Promise<GetSessionMetadataResponse>;
+  getMetadata(callback: GetSessionMetadataCallback): void;
+  getMetadata(
+    gaxOptions: CallOptions,
+    callback: GetSessionMetadataCallback
+  ): void;
   getMetadata(
     optionsOrCallback?: CallOptions | GetSessionMetadataCallback,
     cb?: GetSessionMetadataCallback
@@ -383,9 +383,6 @@ export class Session extends common.GrpcServiceObject {
       }
     );
   }
-  keepAlive(gaxOptions?: CallOptions): Promise<KeepAliveResponse>;
-  keepAlive(callback: KeepAliveCallback): void;
-  keepAlive(gaxOptions: CallOptions, callback: KeepAliveCallback): void;
   /**
    * Ping the session with `SELECT 1` to prevent it from expiring.
    *
@@ -404,6 +401,9 @@ export class Session extends common.GrpcServiceObject {
    * });
    * ```
    */
+  keepAlive(gaxOptions?: CallOptions): Promise<KeepAliveResponse>;
+  keepAlive(callback: KeepAliveCallback): void;
+  keepAlive(gaxOptions: CallOptions, callback: KeepAliveCallback): void;
   keepAlive(
     optionsOrCallback?: CallOptions | KeepAliveCallback,
     cb?: KeepAliveCallback

--- a/src/table.ts
+++ b/src/table.ts
@@ -104,16 +104,6 @@ class Table {
      */
     this.name = name;
   }
-  create(
-    schema: Schema,
-    gaxOptions?: CallOptions
-  ): Promise<CreateTableResponse>;
-  create(schema: Schema, callback: CreateTableCallback): void;
-  create(
-    schema: Schema,
-    gaxOptions: CallOptions,
-    callback: CreateTableCallback
-  ): void;
   /**
    * Create a table.
    *
@@ -168,6 +158,16 @@ class Table {
    *   });
    * ```
    */
+  create(
+    schema: Schema,
+    gaxOptions?: CallOptions
+  ): Promise<CreateTableResponse>;
+  create(schema: Schema, callback: CreateTableCallback): void;
+  create(
+    schema: Schema,
+    gaxOptions: CallOptions,
+    callback: CreateTableCallback
+  ): void;
   create(
     schema: Schema,
     gaxOptionsOrCallback?: CallOptions | CreateTableCallback,
@@ -269,9 +269,6 @@ class Table {
 
     return proxyStream as PartialResultStream;
   }
-  delete(gaxOptions?: CallOptions): Promise<DropTableResponse>;
-  delete(callback: DropTableCallback): void;
-  delete(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
    * @typedef {array} DropTableResponse
    * @property {google.longrunning.Operation} 0 An {@link Operation} object that can be used to check
@@ -333,6 +330,9 @@ class Table {
    *   });
    * ```
    */
+  delete(gaxOptions?: CallOptions): Promise<DropTableResponse>;
+  delete(callback: DropTableCallback): void;
+  delete(gaxOptions: CallOptions, callback: DropTableCallback): void;
   delete(
     gaxOptionsOrCallback?: CallOptions | DropTableCallback,
     cb?: DropTableCallback
@@ -348,16 +348,6 @@ class Table {
       callback!
     );
   }
-  deleteRows(
-    keys: Key[],
-    options?: DeleteRowsOptions | CallOptions
-  ): Promise<DeleteRowsResponse>;
-  deleteRows(keys: Key[], callback: DeleteRowsCallback): void;
-  deleteRows(
-    keys: Key[],
-    options: DeleteRowsOptions | CallOptions,
-    callback: DeleteRowsCallback
-  ): void;
   /**
    * @typedef {array} DeleteRowsResponse
    * @property {CommitResponse} 0 The commit response.
@@ -429,6 +419,16 @@ class Table {
    */
   deleteRows(
     keys: Key[],
+    options?: DeleteRowsOptions | CallOptions
+  ): Promise<DeleteRowsResponse>;
+  deleteRows(keys: Key[], callback: DeleteRowsCallback): void;
+  deleteRows(
+    keys: Key[],
+    options: DeleteRowsOptions | CallOptions,
+    callback: DeleteRowsCallback
+  ): void;
+  deleteRows(
+    keys: Key[],
     optionsOrCallback?: DeleteRowsOptions | CallOptions | DeleteRowsCallback,
     cb?: DeleteRowsCallback
   ): Promise<DeleteRowsResponse> | void {
@@ -439,9 +439,6 @@ class Table {
 
     return this._mutate('deleteRows', keys, options, callback!);
   }
-  drop(gaxOptions?: CallOptions): Promise<DropTableResponse>;
-  drop(callback: DropTableCallback): void;
-  drop(gaxOptions: CallOptions, callback: DropTableCallback): void;
   /**
    * Drop the table.
    *
@@ -488,6 +485,9 @@ class Table {
    *   });
    * ```
    */
+  drop(gaxOptions?: CallOptions): Promise<DropTableResponse>;
+  drop(callback: DropTableCallback): void;
+  drop(gaxOptions: CallOptions, callback: DropTableCallback): void;
   drop(
     gaxOptionsOrCallback?: CallOptions | DropTableCallback,
     cb?: DropTableCallback
@@ -499,16 +499,6 @@ class Table {
 
     return this.delete(gaxOptions, callback!);
   }
-  insert(
-    rows: object | object[],
-    options?: InsertRowsOptions | CallOptions
-  ): Promise<InsertRowsResponse>;
-  insert(rows: object | object[], callback: InsertRowsCallback): void;
-  insert(
-    rows: object | object[],
-    options: InsertRowsOptions | CallOptions,
-    callback: InsertRowsCallback
-  ): void;
   /**
    * @typedef {array} InsertRowsResponse
    * @property {CommitResponse} 0 The commit response.
@@ -591,6 +581,16 @@ class Table {
    */
   insert(
     rows: object | object[],
+    options?: InsertRowsOptions | CallOptions
+  ): Promise<InsertRowsResponse>;
+  insert(rows: object | object[], callback: InsertRowsCallback): void;
+  insert(
+    rows: object | object[],
+    options: InsertRowsOptions | CallOptions,
+    callback: InsertRowsCallback
+  ): void;
+  insert(
+    rows: object | object[],
     optionsOrCallback?: InsertRowsOptions | CallOptions | InsertRowsCallback,
     cb?: InsertRowsCallback
   ): Promise<InsertRowsResponse> | void {
@@ -601,13 +601,6 @@ class Table {
 
     this._mutate('insert', rows, options, callback!);
   }
-  read(request: ReadRequest, options?: TimestampBounds): Promise<ReadResponse>;
-  read(request: ReadRequest, callback: ReadCallback): void;
-  read(
-    request: ReadRequest,
-    options: TimestampBounds,
-    callback: ReadCallback
-  ): void;
   /**
    * Configuration object, describing what to read from the table.
    */
@@ -745,6 +738,13 @@ class Table {
    * region_tag:spanner_read_data_with_storing_index
    * Reading data using a storing index:
    */
+  read(request: ReadRequest, options?: TimestampBounds): Promise<ReadResponse>;
+  read(request: ReadRequest, callback: ReadCallback): void;
+  read(
+    request: ReadRequest,
+    options: TimestampBounds,
+    callback: ReadCallback
+  ): void;
   read(
     request: ReadRequest,
     optionsOrCallback?: TimestampBounds | ReadCallback,
@@ -764,16 +764,6 @@ class Table {
       .on('data', (row: Row) => rows.push(row))
       .on('end', () => callback!(null, rows));
   }
-  replace(
-    rows: object | object[],
-    options?: ReplaceRowsOptions | CallOptions
-  ): Promise<ReplaceRowsResponse>;
-  replace(rows: object | object[], callback: ReplaceRowsCallback): void;
-  replace(
-    rows: object | object[],
-    options: ReplaceRowsOptions | CallOptions,
-    callback: ReplaceRowsCallback
-  ): void;
   /**
    * @typedef {array} ReplaceRowsResponse
    * @property {CommitResponse} 0 The commit response.
@@ -839,6 +829,16 @@ class Table {
    */
   replace(
     rows: object | object[],
+    options?: ReplaceRowsOptions | CallOptions
+  ): Promise<ReplaceRowsResponse>;
+  replace(rows: object | object[], callback: ReplaceRowsCallback): void;
+  replace(
+    rows: object | object[],
+    options: ReplaceRowsOptions | CallOptions,
+    callback: ReplaceRowsCallback
+  ): void;
+  replace(
+    rows: object | object[],
     optionsOrCallback?: ReplaceRowsOptions | CallOptions | ReplaceRowsCallback,
     cb?: ReplaceRowsCallback
   ): Promise<ReplaceRowsResponse> | void {
@@ -849,16 +849,6 @@ class Table {
 
     this._mutate('replace', rows, options, callback!);
   }
-  update(
-    rows: object | object[],
-    options?: UpdateRowsOptions | CallOptions
-  ): Promise<UpdateRowsResponse>;
-  update(rows: object | object[], callback: UpdateRowsCallback): void;
-  update(
-    rows: object | object[],
-    options: UpdateRowsOptions | CallOptions,
-    callback: UpdateRowsCallback
-  ): void;
   /**
    * @typedef {array} UpdateRowsResponse
    * @property {CommitResponse} 0 The commit response.
@@ -928,6 +918,16 @@ class Table {
    */
   update(
     rows: object | object[],
+    options?: UpdateRowsOptions | CallOptions
+  ): Promise<UpdateRowsResponse>;
+  update(rows: object | object[], callback: UpdateRowsCallback): void;
+  update(
+    rows: object | object[],
+    options: UpdateRowsOptions | CallOptions,
+    callback: UpdateRowsCallback
+  ): void;
+  update(
+    rows: object | object[],
     optionsOrCallback?: UpdateRowsOptions | CallOptions | UpdateRowsCallback,
     cb?: UpdateRowsCallback
   ): Promise<UpdateRowsResponse> | void {
@@ -938,16 +938,6 @@ class Table {
 
     this._mutate('update', rows, options, callback!);
   }
-  upsert(
-    rows: object | object[],
-    options?: UpsertRowsOptions | CallOptions
-  ): Promise<UpsertRowsResponse>;
-  upsert(rows: object | object[], callback: UpsertRowsCallback): void;
-  upsert(
-    rows: object | object[],
-    options: UpsertRowsOptions | CallOptions,
-    callback: UpsertRowsCallback
-  ): void;
   /**
    * @typedef {array} UpsertRowsResponse
    * @property {CommitResponse} 0 The commit response.
@@ -1012,6 +1002,16 @@ class Table {
    *   });
    * ```
    */
+  upsert(
+    rows: object | object[],
+    options?: UpsertRowsOptions | CallOptions
+  ): Promise<UpsertRowsResponse>;
+  upsert(rows: object | object[], callback: UpsertRowsCallback): void;
+  upsert(
+    rows: object | object[],
+    options: UpsertRowsOptions | CallOptions,
+    callback: UpsertRowsCallback
+  ): void;
   upsert(
     rows: object | object[],
     optionsOrCallback?: UpsertRowsOptions | CallOptions | UpsertRowsCallback,

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -291,9 +291,6 @@ export class Snapshot extends EventEmitter {
     };
   }
 
-  begin(gaxOptions?: CallOptions): Promise<BeginResponse>;
-  begin(callback: BeginTransactionCallback): void;
-  begin(gaxOptions: CallOptions, callback: BeginTransactionCallback): void;
   /**
    * @typedef {object} TransactionResponse
    * @property {string|Buffer} id The transaction ID.
@@ -338,6 +335,9 @@ export class Snapshot extends EventEmitter {
    *   });
    * ```
    */
+  begin(gaxOptions?: CallOptions): Promise<BeginResponse>;
+  begin(callback: BeginTransactionCallback): void;
+  begin(gaxOptions: CallOptions, callback: BeginTransactionCallback): void;
   begin(
     gaxOptionsOrCallback?: CallOptions | BeginTransactionCallback,
     cb?: BeginTransactionCallback
@@ -673,9 +673,6 @@ export class Snapshot extends EventEmitter {
     process.nextTick(() => this.emit('end'));
   }
 
-  read(table: string, request: ReadRequest): Promise<ReadResponse>;
-  read(table: string, callback: ReadCallback): void;
-  read(table: string, request: ReadRequest, callback: ReadCallback): void;
   /**
    * @typedef {array} ReadResponse
    * @property {array[]} 0 Rows are returned as an array of object arrays. Each
@@ -793,6 +790,9 @@ export class Snapshot extends EventEmitter {
    * });
    * ```
    */
+  read(table: string, request: ReadRequest): Promise<ReadResponse>;
+  read(table: string, callback: ReadCallback): void;
+  read(table: string, request: ReadRequest, callback: ReadCallback): void;
   read(
     table: string,
     requestOrCallback: ReadRequest | ReadCallback,
@@ -817,8 +817,6 @@ export class Snapshot extends EventEmitter {
       .on('end', () => callback!(null, rows));
   }
 
-  run(query: string | ExecuteSqlRequest): Promise<RunResponse>;
-  run(query: string | ExecuteSqlRequest, callback: RunCallback): void;
   /**
    * Execute a SQL statement on this database inside of a transaction.
    *
@@ -896,6 +894,8 @@ export class Snapshot extends EventEmitter {
    * });
    * ```
    */
+  run(query: string | ExecuteSqlRequest): Promise<RunResponse>;
+  run(query: string | ExecuteSqlRequest, callback: RunCallback): void;
   run(
     query: string | ExecuteSqlRequest,
     callback?: RunCallback
@@ -1245,11 +1245,6 @@ promisifyAll(Snapshot, {
  * @class
  */
 export class Dml extends Snapshot {
-  runUpdate(query: string | ExecuteSqlRequest): Promise<RunUpdateResponse>;
-  runUpdate(
-    query: string | ExecuteSqlRequest,
-    callback: RunUpdateCallback
-  ): void;
   /**
    * @typedef {array} RunUpdateResponse
    * @property {number} 0 Affected row count.
@@ -1274,6 +1269,11 @@ export class Dml extends Snapshot {
    * @param {RunUpdateCallback} [callback] Callback function.
    * @returns {Promise<RunUpdateResponse>}
    */
+  runUpdate(query: string | ExecuteSqlRequest): Promise<RunUpdateResponse>;
+  runUpdate(
+    query: string | ExecuteSqlRequest,
+    callback: RunUpdateCallback
+  ): void;
   runUpdate(
     query: string | ExecuteSqlRequest,
     callback?: RunUpdateCallback
@@ -1411,19 +1411,6 @@ export class Transaction extends Dml {
     this.requestOptions = requestOptions;
   }
 
-  batchUpdate(
-    queries: Array<string | Statement>,
-    options?: BatchUpdateOptions | CallOptions
-  ): Promise<BatchUpdateResponse>;
-  batchUpdate(
-    queries: Array<string | Statement>,
-    callback: BatchUpdateCallback
-  ): void;
-  batchUpdate(
-    queries: Array<string | Statement>,
-    options: BatchUpdateOptions | CallOptions,
-    callback: BatchUpdateCallback
-  ): void;
   /**
    * @typedef {error} BatchUpdateError
    * @property {number} code gRPC status code.
@@ -1493,6 +1480,19 @@ export class Transaction extends Dml {
    * const [rowCounts, apiResponse] = await transaction.batchUpdate(queries);
    * ```
    */
+  batchUpdate(
+    queries: Array<string | Statement>,
+    options?: BatchUpdateOptions | CallOptions
+  ): Promise<BatchUpdateResponse>;
+  batchUpdate(
+    queries: Array<string | Statement>,
+    callback: BatchUpdateCallback
+  ): void;
+  batchUpdate(
+    queries: Array<string | Statement>,
+    options: BatchUpdateOptions | CallOptions,
+    callback: BatchUpdateCallback
+  ): void;
   batchUpdate(
     queries: Array<string | Statement>,
     optionsOrCallback?: BatchUpdateOptions | CallOptions | BatchUpdateCallback,
@@ -1603,9 +1603,6 @@ export class Transaction extends Dml {
     return undefined;
   }
 
-  commit(options?: CommitOptions | CallOptions): Promise<CommitResponse>;
-  commit(callback: CommitCallback): void;
-  commit(options: CommitOptions | CallOptions, callback: CommitCallback): void;
   /**
    * @typedef {object} CommitOptions
    * @property {google.spanner.v1.IRequestOptions} requestOptions The request options to include
@@ -1668,6 +1665,9 @@ export class Transaction extends Dml {
    * });
    * ```
    */
+  commit(options?: CommitOptions | CallOptions): Promise<CommitResponse>;
+  commit(callback: CommitCallback): void;
+  commit(options: CommitOptions | CallOptions, callback: CommitCallback): void;
   commit(
     optionsOrCallback?: CommitOptions | CallOptions | CommitCallback,
     cb?: CommitCallback
@@ -1972,12 +1972,6 @@ export class Transaction extends Dml {
     this._mutate('replace', table, rows);
   }
 
-  rollback(gaxOptions?: CallOptions): Promise<void>;
-  rollback(callback: spannerClient.spanner.v1.Spanner.RollbackCallback): void;
-  rollback(
-    gaxOptions: CallOptions,
-    callback: spannerClient.spanner.v1.Spanner.RollbackCallback
-  ): void;
   /**
    * Roll back a transaction, releasing any locks it holds. It is a good idea to
    * call this for any transaction that includes one or more queries that you
@@ -2009,6 +2003,12 @@ export class Transaction extends Dml {
    * });
    * ```
    */
+  rollback(gaxOptions?: CallOptions): Promise<void>;
+  rollback(callback: spannerClient.spanner.v1.Spanner.RollbackCallback): void;
+  rollback(
+    gaxOptions: CallOptions,
+    callback: spannerClient.spanner.v1.Spanner.RollbackCallback
+  ): void;
   rollback(
     gaxOptionsOrCallback?:
       | CallOptions
@@ -2218,11 +2218,6 @@ export class PartitionedDml extends Dml {
     this._options = {partitionedDml: options};
   }
 
-  runUpdate(query: string | ExecuteSqlRequest): Promise<RunUpdateResponse>;
-  runUpdate(
-    query: string | ExecuteSqlRequest,
-    callback: RunUpdateCallback
-  ): void;
   /**
    * Execute a DML statement and get the affected row count. Unlike
    * {@link Transaction#runUpdate} after using this method you should
@@ -2248,6 +2243,11 @@ export class PartitionedDml extends Dml {
    * });
    * ```
    */
+  runUpdate(query: string | ExecuteSqlRequest): Promise<RunUpdateResponse>;
+  runUpdate(
+    query: string | ExecuteSqlRequest,
+    callback: RunUpdateCallback
+  ): void;
   runUpdate(
     query: string | ExecuteSqlRequest,
     callback?: RunUpdateCallback


### PR DESCRIPTION
As we move our ref docs to cloud.google.com, we rely on TSDoc rather JSDoc.

TSDoc expects comments before the first overloaded function, we
currently have those on the last function. Those comments don't make
it into the d.ts files. We need to move comments to the first
overloaded function rather than the last one.

Internally b/190631834

Script used: https://github.com/fhinkel/cloud-rad-script/blob/main/moveComments.js