### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "requires_billing": true,
   "codeowner_team": "@googleapis/api-spanner-nodejs",
   "api_shortname": "spanner",
-  "library_type": ""
+  "library_type": "GAPIC_COMBO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,11 +4,13 @@
   "product_documentation": "https://cloud.google.com/spanner/docs/",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/spanner/latest",
   "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/nodejs-spanner",
   "distribution_name": "@google-cloud/spanner",
   "api_id": "spanner.googleapis.com",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/api-spanner-nodejs"
+  "codeowner_team": "@googleapis/api-spanner-nodejs",
+  "api_shortname": "spanner",
+  "library_type": ""
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Cloud Spanner: Node.js Client](https://github.com/googleapis/nodejs-spanner)
 
-[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/spanner.svg)](https://www.npmjs.org/package/@google-cloud/spanner)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-spanner/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-spanner)
 
@@ -169,12 +169,6 @@ _Legacy Node.js versions are supported as a best effort:_
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-
-This library is considered to be **General Availability (GA)**. This means it
-is stable; the code surface will not change in backwards-incompatible ways
-unless absolutely necessary (e.g. because of critical security issues) or with
-an extensive deprecation period. Issues and requests against **GA** libraries
-are addressed with the highest priority.
 
 
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be **stable**. The code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **stable** libraries
+are addressed with the highest priority.
+
 
 
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 