### PR TITLE
refactor: return GoogleError instead of Error in handwritten library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "events-intercept": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^7.0.0",
-    "google-gax": "^2.17.1",
+    "google-gax": "^2.29.3",
     "grpc-gcp": "^0.3.2",
     "is": "^3.2.1",
     "lodash.snakecase": "^4.1.1",

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -20,6 +20,7 @@ import {Big} from 'big.js';
 import * as is from 'is';
 import {common as p} from 'protobufjs';
 import {google as spannerClient} from '../protos/protos';
+import {GoogleError} from 'google-gax';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Value = any;
@@ -150,7 +151,7 @@ export class Int extends WrappedNumber {
   valueOf(): number {
     const num = Number(this.value);
     if (num > Number.MAX_SAFE_INTEGER) {
-      throw new Error(`Integer ${this.value} is out of bounds.`);
+      throw new GoogleError(`Integer ${this.value} is out of bounds.`);
     }
     return num;
   }

--- a/src/database.ts
+++ b/src/database.ts
@@ -28,7 +28,12 @@ import * as extend from 'extend';
 import * as r from 'teeny-request';
 import * as streamEvents from 'stream-events';
 import * as through from 'through2';
-import {CallOptions, grpc, Operation as GaxOperation} from 'google-gax';
+import {
+  CallOptions,
+  GoogleError,
+  grpc,
+  Operation as GaxOperation,
+} from 'google-gax';
 import {Backup} from './backup';
 import {BatchTransaction, TransactionIdentifier} from './batch-transaction';
 import {
@@ -2758,7 +2763,7 @@ class Database extends common.GrpcServiceObject {
   /**
    * Get a reference to a Table object.
    *
-   * @throws {Error} If a name is not provided.
+   * @throws {GoogleError} If a name is not provided.
    *
    * @param {string} name The name of the table.
    * @return {Table} A Table object.
@@ -2776,7 +2781,7 @@ class Database extends common.GrpcServiceObject {
    */
   table(name: string) {
     if (!name) {
-      throw new Error('A name is required to access a Table object.');
+      throw new GoogleError('A name is required to access a Table object.');
     }
     return new Table(this, name);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {
   CreateInstanceCallback,
   CreateInstanceResponse,
 } from './instance';
-import {grpc, GrpcClientOptions, CallOptions} from 'google-gax';
+import {grpc, GrpcClientOptions, CallOptions, GoogleError} from 'google-gax';
 import {google as instanceAdmin} from '../protos/protos';
 import {
   PagedOptions,
@@ -198,7 +198,7 @@ class Spanner extends GrpcService {
         endpointWithPort.startsWith('http:') ||
         endpointWithPort.startsWith('https:')
       ) {
-        throw new Error(
+        throw new GoogleError(
           'SPANNER_EMULATOR_HOST must not start with a protocol specification (http/https)'
         );
       }
@@ -207,7 +207,7 @@ class Spanner extends GrpcService {
         const portName = endpointWithPort.substring(index + 1);
         const port = +portName;
         if (!port || port < 1 || port > 65535) {
-          throw new Error(`Invalid port number: ${portName}`);
+          throw new GoogleError(`Invalid port number: ${portName}`);
         }
         return {
           endpoint: endpointWithPort.substring(0, index),
@@ -338,8 +338,8 @@ class Spanner extends GrpcService {
    * @see {@link v1.InstanceAdminClient#createInstance}
    * @see [CreateInstace API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.instance.v1#google.spanner.admin.instance.v1.InstanceAdmin.CreateInstance)
    *
-   * @throws {Error} If a name is not provided.
-   * @throws {Error} If a configuration object is not provided.
+   * @throws {GoogleError} If a name is not provided.
+   * @throws {GoogleError} If a configuration object is not provided.
    *
    * @param {string} name The name of the instance to be created.
    * @param {CreateInstanceRequest} config Configuration object.
@@ -399,10 +399,10 @@ class Spanner extends GrpcService {
     callback?: CreateInstanceCallback
   ): void | Promise<CreateInstanceResponse> {
     if (!name) {
-      throw new Error('A name is required to create an instance.');
+      throw new GoogleError('A name is required to create an instance.');
     }
     if (!config) {
-      throw new Error(
+      throw new GoogleError(
         ['A configuration object is required to create an instance.'].join('')
       );
     }
@@ -423,7 +423,7 @@ class Spanner extends GrpcService {
     };
 
     if (reqOpts.instance.nodeCount && reqOpts.instance.processingUnits) {
-      throw new Error(
+      throw new GoogleError(
         ['Only one of nodeCount or processingUnits can be specified.'].join('')
       );
     }
@@ -990,7 +990,7 @@ class Spanner extends GrpcService {
   /**
    * Get a reference to an Instance object.
    *
-   * @throws {Error} If a name is not provided.
+   * @throws {GoogleError} If a name is not provided.
    *
    * @param {string} name The name of the instance.
    * @returns {Instance} An Instance object.
@@ -1004,7 +1004,7 @@ class Spanner extends GrpcService {
    */
   instance(name: string): Instance {
     if (!name) {
-      throw new Error('A name is required to access an Instance object.');
+      throw new GoogleError('A name is required to access an Instance object.');
     }
     const key = name.split('/').pop()!;
     if (!this.instances_.has(key)) {

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -35,7 +35,12 @@ import {
 } from './common';
 import {Duplex} from 'stream';
 import {SessionPoolOptions, SessionPool} from './session-pool';
-import {grpc, Operation as GaxOperation, CallOptions} from 'google-gax';
+import {
+  grpc,
+  Operation as GaxOperation,
+  CallOptions,
+  GoogleError,
+} from 'google-gax';
 import {Backup} from './backup';
 import {google as instanceAdmin} from '../protos/protos';
 import {google as databaseAdmin} from '../protos/protos';
@@ -234,7 +239,7 @@ class Instance extends common.GrpcServiceObject {
   /**
    * Get a reference to a Backup object.
    *
-   * @throws {Error} If any parameter is not provided.
+   * @throws {GoogleError} If any parameter is not provided.
    *
    * @param {string} backupId The name of the backup.
    * @return {Backup} A Backup object.
@@ -249,7 +254,7 @@ class Instance extends common.GrpcServiceObject {
    */
   backup(backupId: string): Backup {
     if (!backupId) {
-      throw new Error('A backup ID is required to create a Backup.');
+      throw new GoogleError('A backup ID is required to create a Backup.');
     }
 
     return new Backup(this, backupId);
@@ -739,7 +744,7 @@ class Instance extends common.GrpcServiceObject {
    * @see {@link v1.DatabaseAdminClient#createDatabase}
    * @see [CreateDatabase API Documentation](https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.admin.database.v1#google.spanner.admin.database.v1.DatabaseAdmin.CreateDatabase)
    *
-   * @throws {Error} If a name is not provided.
+   * @throws {GoogleError} If a name is not provided.
    *
    * @param {name} name The name of the database to create.
    * @param {CreateDatabaseRequest} [options] Configuration object.
@@ -811,7 +816,7 @@ class Instance extends common.GrpcServiceObject {
     cb?: CreateDatabaseCallback
   ): void | Promise<CreateDatabaseResponse> {
     if (!name) {
-      throw new Error('A name is required to create a database.');
+      throw new GoogleError('A name is required to create a database.');
     }
     const callback =
       typeof optionsOrCallback === 'function' ? optionsOrCallback : cb!;
@@ -860,7 +865,7 @@ class Instance extends common.GrpcServiceObject {
   /**
    * Get a reference to a Database object.
    *
-   * @throws {Error} If a name is not provided.
+   * @throws {GoogleError} If a name is not provided.
    *
    * @param {string} name The name of the instance.
    * @param {SessionPoolOptions|SessionPoolCtor} [poolOptions] Session pool
@@ -886,7 +891,7 @@ class Instance extends common.GrpcServiceObject {
     queryOptions?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions
   ): Database {
     if (!name) {
-      throw new Error('A name is required to access a Database object.');
+      throw new GoogleError('A name is required to access a Database object.');
     }
     // Only add an additional key for SessionPoolOptions and QueryOptions if an
     // options object with at least one value was passed in.

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -18,7 +18,7 @@ import {DateStruct, PreciseDate} from '@google-cloud/precise-date';
 import {promisifyAll} from '@google-cloud/promisify';
 import arrify = require('arrify');
 import {EventEmitter} from 'events';
-import {grpc, CallOptions, ServiceError, Status} from 'google-gax';
+import {grpc, CallOptions, ServiceError, Status, GoogleError} from 'google-gax';
 import * as is from 'is';
 import {common as p} from 'protobufjs';
 import {Readable, PassThrough} from 'stream';
@@ -2151,7 +2151,7 @@ export class Transaction extends Dml {
       const missingColumns = columns.filter(column => !keys.includes(column));
 
       if (missingColumns.length > 0) {
-        throw new Error(
+        throw new GoogleError(
           [
             `Row at index ${index} does not contain the correct number of columns.`,
             `Missing columns: ${JSON.stringify(missingColumns)}`,


### PR DESCRIPTION
- Replacing Error by [GoogleError](https://github.com/googleapis/gax-nodejs/blob/main/src/googleError.ts) for making the error consistent across all GAPIC libraries.