### PR TITLE
fix: fixing npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "events-intercept": "^2.0.0",
     "extend": "^3.0.2",
     "google-auth-library": "^7.0.0",
-    "google-gax": "^2.3.0",
+    "google-gax": "^2.30.5",
     "grpc-gcp": "^0.4.0",
     "is": "^3.2.1",
     "lodash.snakecase": "^4.1.1",


### PR DESCRIPTION
resolves the error:
src/v1/spanner_client.ts:196:9 - error TS2554: Expected 1 arguments, but got 2.
196         opts.fallback === 'rest'
            ~~~~~~~~~~~~~~~~~~~~~~~~
src/v1/spanner_client.ts:200:9 - error TS2554: Expected 1 arguments, but got 2.

200         opts.fallback === 'rest'
            ~~~~~~~~~~~~~~~~~~~~~~~~