### PR TITLE
fix(codec): use index to determine array struct member value

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -411,7 +411,7 @@ function decode(value: Value, type: spannerClient.spanner.v1.Type): Value {
     case 'STRUCT':
       fields = type.structType!.fields!.map(({name, type}, index) => {
         const value = decode(
-          decoded[name!] || decoded[index],
+          (!Array.isArray(decoded) && decoded[name!]) || decoded[index],
           type as spannerClient.spanner.v1.Type
         );
         return {name, value};

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -631,15 +631,22 @@ describe('codec', () => {
       assert(decoded[0] instanceof codec.Int);
     });
 
-    it('should decode STRUCT and inner members', () => {
+    it('should decode object STRUCT value and inner members', () => {
       const value = {
-        fieldName: '1',
+        keys: 1,
+        fieldName: '2',
       };
 
       const decoded = codec.decode(value, {
         code: google.spanner.v1.TypeCode.STRUCT,
         structType: {
           fields: [
+            {
+              name: 'keys',
+              type: {
+                code: google.spanner.v1.TypeCode.JSON,
+              },
+            },
             {
               name: 'fieldName',
               type: {
@@ -650,10 +657,54 @@ describe('codec', () => {
         },
       });
 
-      const expectedStruct = new codec.Struct({
-        name: 'fieldName',
-        value: new codec.Int(value.fieldName),
+      const expectedStruct = new codec.Struct(
+        {
+          name: 'keys',
+          value: value.keys,
+        },
+        {
+          name: 'fieldName',
+          value: new codec.Int(value.fieldName),
+        }
+      );
+
+      assert(decoded instanceof codec.Struct);
+      assert.deepStrictEqual(decoded, expectedStruct);
+    });
+
+    it('should decode array STRUCT value and inner members', () => {
+      const value = ['1', '2'];
+
+      const decoded = codec.decode(value, {
+        code: google.spanner.v1.TypeCode.STRUCT,
+        structType: {
+          fields: [
+            {
+              name: 'keys',
+              type: {
+                code: google.spanner.v1.TypeCode.JSON,
+              },
+            },
+            {
+              name: 'fieldName',
+              type: {
+                code: google.spanner.v1.TypeCode.INT64,
+              },
+            },
+          ],
+        },
       });
+
+      const expectedStruct = new codec.Struct(
+        {
+          name: 'keys',
+          value: JSON.parse(value[0]),
+        },
+        {
+          name: 'fieldName',
+          value: new codec.Int(value[1]),
+        }
+      );
 
       assert(decoded instanceof codec.Struct);
       assert.deepStrictEqual(decoded, expectedStruct);


### PR DESCRIPTION
Where the STRUCT value is an array, always determine inner member value using field index.

Error case is reproduced by the new `should decode array STRUCT value and inner members` test case in _test/codec.ts_.

Fixes #1774.

---

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-spanner/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] ~Appropriate docs were updated (if necessary)~
