### PR TITLE
test: emit empty metadata before emitting unspecified error

### DIFF
--- a/system-test/fixtures/sample/package.json
+++ b/system-test/fixtures/sample/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.0.0",
-    "typescript": "^3.0.0",
+    "typescript": "^4.0.0",
     "gts": "^3.0.0"
   }
 }

--- a/test/mockserver/mockspanner.ts
+++ b/test/mockserver/mockspanner.ts
@@ -616,6 +616,7 @@ export class MockSpanner {
               call.write(MockSpanner.toPartialResultSet(res.updateCount));
               break;
             case StatementResultType.ERROR:
+              call.sendMetadata(new Metadata());
               call.emit('error', res.error);
               break;
             default:
@@ -633,6 +634,7 @@ export class MockSpanner {
         call.end();
       })
       .catch(err => {
+        call.sendMetadata(new Metadata());
         call.emit('error', err);
         call.end();
       });


### PR DESCRIPTION
Since gRPC upgrade to `@grpc/grpc-js` v1.8.x, the server can emit errors without sending a metadata. It breaks some retrying logic in `retry-request`. This is unlikely to happen in production; for the test, let's make our stub gRPC server emit `metadata` event (with an empty `Metadata` instance) before emitting an error.

BEGIN_COMMIT_OVERRIDE
fix: tests emit empty metadata before emitting unspecified error
END_COMMIT_OVERRIDE