### PR TITLE
docs: remove unused references to generated samples

### DIFF
--- a/src/v1/database_admin_client.ts
+++ b/src/v1/database_admin_client.ts
@@ -526,8 +526,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.get_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_GetDatabase_async
    */
   getDatabase(
     request?: protos.google.spanner.admin.database.v1.IGetDatabaseRequest,
@@ -621,8 +619,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.drop_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_DropDatabase_async
    */
   dropDatabase(
     request?: protos.google.spanner.admin.database.v1.IDropDatabaseRequest,
@@ -716,8 +712,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.get_database_ddl.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_GetDatabaseDdl_async
    */
   getDatabaseDdl(
     request?: protos.google.spanner.admin.database.v1.IGetDatabaseDdlRequest,
@@ -831,8 +825,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.set_iam_policy.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_SetIamPolicy_async
    */
   setIamPolicy(
     request?: protos.google.iam.v1.ISetIamPolicyRequest,
@@ -925,8 +917,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.get_iam_policy.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_GetIamPolicy_async
    */
   getIamPolicy(
     request?: protos.google.iam.v1.IGetIamPolicyRequest,
@@ -1023,8 +1013,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.test_iam_permissions.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_TestIamPermissions_async
    */
   testIamPermissions(
     request?: protos.google.iam.v1.ITestIamPermissionsRequest,
@@ -1108,8 +1096,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.get_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_GetBackup_async
    */
   getBackup(
     request?: protos.google.spanner.admin.database.v1.IGetBackupRequest,
@@ -1208,8 +1194,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.update_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_UpdateBackup_async
    */
   updateBackup(
     request?: protos.google.spanner.admin.database.v1.IUpdateBackupRequest,
@@ -1301,8 +1285,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.delete_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_DeleteBackup_async
    */
   deleteBackup(
     request?: protos.google.spanner.admin.database.v1.IDeleteBackupRequest,
@@ -1420,8 +1402,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.create_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CreateDatabase_async
    */
   createDatabase(
     request?: protos.google.spanner.admin.database.v1.ICreateDatabaseRequest,
@@ -1516,8 +1496,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.create_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CreateDatabase_async
    */
   async checkCreateDatabaseProgress(
     name: string
@@ -1586,8 +1564,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.update_database_ddl.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_UpdateDatabaseDdl_async
    */
   updateDatabaseDdl(
     request?: protos.google.spanner.admin.database.v1.IUpdateDatabaseDdlRequest,
@@ -1682,8 +1658,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.update_database_ddl.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_UpdateDatabaseDdl_async
    */
   async checkUpdateDatabaseDdlProgress(
     name: string
@@ -1752,8 +1726,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.create_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CreateBackup_async
    */
   createBackup(
     request?: protos.google.spanner.admin.database.v1.ICreateBackupRequest,
@@ -1848,8 +1820,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.create_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CreateBackup_async
    */
   async checkCreateBackupProgress(
     name: string
@@ -1925,8 +1895,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.copy_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CopyBackup_async
    */
   copyBackup(
     request?: protos.google.spanner.admin.database.v1.ICopyBackupRequest,
@@ -2021,8 +1989,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.copy_backup.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_CopyBackup_async
    */
   async checkCopyBackupProgress(
     name: string
@@ -2098,8 +2064,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.restore_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_RestoreDatabase_async
    */
   restoreDatabase(
     request?: protos.google.spanner.admin.database.v1.IRestoreDatabaseRequest,
@@ -2194,8 +2158,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.restore_database.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_RestoreDatabase_async
    */
   async checkRestoreDatabaseProgress(
     name: string
@@ -2397,8 +2359,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.list_databases.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_ListDatabases_async
    */
   listDatabasesAsync(
     request?: protos.google.spanner.admin.database.v1.IListDatabasesRequest,
@@ -2711,8 +2671,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.list_backups.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_ListBackups_async
    */
   listBackupsAsync(
     request?: protos.google.spanner.admin.database.v1.IListBackupsRequest,
@@ -3055,8 +3013,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.list_database_operations.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_ListDatabaseOperations_async
    */
   listDatabaseOperationsAsync(
     request?: protos.google.spanner.admin.database.v1.IListDatabaseOperationsRequest,
@@ -3469,8 +3425,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.list_backup_operations.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_ListBackupOperations_async
    */
   listBackupOperationsAsync(
     request?: protos.google.spanner.admin.database.v1.IListBackupOperationsRequest,
@@ -3673,8 +3627,6 @@ export class DatabaseAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/database_admin.list_database_roles.js</caption>
-   * region_tag:spanner_v1_generated_DatabaseAdmin_ListDatabaseRoles_async
    */
   listDatabaseRolesAsync(
     request?: protos.google.spanner.admin.database.v1.IListDatabaseRolesRequest,

--- a/src/v1/instance_admin_client.ts
+++ b/src/v1/instance_admin_client.ts
@@ -493,8 +493,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.get_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_GetInstanceConfig_async
    */
   getInstanceConfig(
     request?: protos.google.spanner.admin.instance.v1.IGetInstanceConfigRequest,
@@ -610,8 +608,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.delete_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_DeleteInstanceConfig_async
    */
   deleteInstanceConfig(
     request?: protos.google.spanner.admin.instance.v1.IDeleteInstanceConfigRequest,
@@ -713,8 +709,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.get_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_GetInstance_async
    */
   getInstance(
     request?: protos.google.spanner.admin.instance.v1.IGetInstanceRequest,
@@ -815,8 +809,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.delete_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_DeleteInstance_async
    */
   deleteInstance(
     request?: protos.google.spanner.admin.instance.v1.IDeleteInstanceRequest,
@@ -928,8 +920,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.set_iam_policy.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_SetIamPolicy_async
    */
   setIamPolicy(
     request?: protos.google.iam.v1.ISetIamPolicyRequest,
@@ -1019,8 +1009,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.get_iam_policy.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_GetIamPolicy_async
    */
   getIamPolicy(
     request?: protos.google.iam.v1.IGetIamPolicyRequest,
@@ -1113,8 +1101,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#regular-methods)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.test_iam_permissions.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_TestIamPermissions_async
    */
   testIamPermissions(
     request?: protos.google.iam.v1.ITestIamPermissionsRequest,
@@ -1254,8 +1240,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.create_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_CreateInstanceConfig_async
    */
   createInstanceConfig(
     request?: protos.google.spanner.admin.instance.v1.ICreateInstanceConfigRequest,
@@ -1350,8 +1334,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.create_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_CreateInstanceConfig_async
    */
   async checkCreateInstanceConfigProgress(
     name: string
@@ -1450,8 +1432,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.update_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_UpdateInstanceConfig_async
    */
   updateInstanceConfig(
     request?: protos.google.spanner.admin.instance.v1.IUpdateInstanceConfigRequest,
@@ -1546,8 +1526,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.update_instance_config.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_UpdateInstanceConfig_async
    */
   async checkUpdateInstanceConfigProgress(
     name: string
@@ -1629,8 +1607,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.create_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_CreateInstance_async
    */
   createInstance(
     request?: protos.google.spanner.admin.instance.v1.ICreateInstanceRequest,
@@ -1725,8 +1701,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.create_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_CreateInstance_async
    */
   async checkCreateInstanceProgress(
     name: string
@@ -1815,8 +1789,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.update_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_UpdateInstance_async
    */
   updateInstance(
     request?: protos.google.spanner.admin.instance.v1.IUpdateInstanceRequest,
@@ -1911,8 +1883,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#long-running-operations)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.update_instance.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_UpdateInstance_async
    */
   async checkUpdateInstanceProgress(
     name: string
@@ -2120,8 +2090,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.list_instance_configs.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_ListInstanceConfigs_async
    */
   listInstanceConfigsAsync(
     request?: protos.google.spanner.admin.instance.v1.IListInstanceConfigsRequest,
@@ -2473,8 +2441,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.list_instance_config_operations.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_ListInstanceConfigOperations_async
    */
   listInstanceConfigOperationsAsync(
     request?: protos.google.spanner.admin.instance.v1.IListInstanceConfigOperationsRequest,
@@ -2737,8 +2703,6 @@ export class InstanceAdminClient {
    *   Please see the
    *   [documentation](https://github.com/googleapis/gax-nodejs/blob/master/client-libraries.md#auto-pagination)
    *   for more details and examples.
-   * @example <caption>include:samples/generated/v1/instance_admin.list_instances.js</caption>
-   * region_tag:spanner_v1_generated_InstanceAdmin_ListInstances_async
    */
   listInstancesAsync(
     request?: protos.google.spanner.admin.instance.v1.IListInstancesRequest,


### PR DESCRIPTION
The Spanner team is not using auto-generated samples, so references to them should be removed.


#1517 