### PR TITLE
chore: Revert "feat: Adding new fields for Serverless analytics #1816"

### DIFF
--- a/protos/google/spanner/v1/spanner.proto
+++ b/protos/google/spanner/v1/spanner.proto
@@ -643,13 +643,6 @@ message ExecuteSqlRequest {
 
   // Common options for this request.
   RequestOptions request_options = 11;
-
-  // If this is for a partitioned read and this field is set to `true`, the
-  // request will be executed via Spanner independent compute resources.
-  //
-  // If the field is set to `true` but the request does not set
-  // `partition_token`, the API will return an `INVALID_ARGUMENT` error.
-  bool data_boost_enabled = 15;
 }
 
 // The request for [ExecuteBatchDml][google.spanner.v1.Spanner.ExecuteBatchDml].
@@ -956,13 +949,6 @@ message ReadRequest {
 
   // Common options for this request.
   RequestOptions request_options = 11;
-
-  // If this is for a partitioned query and this field is set to `true`, the
-  // request will be executed via Spanner independent compute resources.
-  //
-  // If the field is set to `true` but the request does not set
-  // `partition_token`, the API will return an `INVALID_ARGUMENT` error.
-  bool data_boost_enabled = 16;
 }
 
 // The request for [BeginTransaction][google.spanner.v1.Spanner.BeginTransaction].

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -17400,9 +17400,6 @@ export namespace google {
 
                 /** ExecuteSqlRequest requestOptions */
                 requestOptions?: (google.spanner.v1.IRequestOptions|null);
-
-                /** ExecuteSqlRequest dataBoostEnabled */
-                dataBoostEnabled?: (boolean|null);
             }
 
             /** Represents an ExecuteSqlRequest. */
@@ -17446,9 +17443,6 @@ export namespace google {
 
                 /** ExecuteSqlRequest requestOptions. */
                 public requestOptions?: (google.spanner.v1.IRequestOptions|null);
-
-                /** ExecuteSqlRequest dataBoostEnabled. */
-                public dataBoostEnabled: boolean;
 
                 /**
                  * Creates a new ExecuteSqlRequest instance using the specified properties.
@@ -18572,9 +18566,6 @@ export namespace google {
 
                 /** ReadRequest requestOptions */
                 requestOptions?: (google.spanner.v1.IRequestOptions|null);
-
-                /** ReadRequest dataBoostEnabled */
-                dataBoostEnabled?: (boolean|null);
             }
 
             /** Represents a ReadRequest. */
@@ -18615,9 +18606,6 @@ export namespace google {
 
                 /** ReadRequest requestOptions. */
                 public requestOptions?: (google.spanner.v1.IRequestOptions|null);
-
-                /** ReadRequest dataBoostEnabled. */
-                public dataBoostEnabled: boolean;
 
                 /**
                  * Creates a new ReadRequest instance using the specified properties.

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -42925,7 +42925,6 @@
                      * @property {number|Long|null} [seqno] ExecuteSqlRequest seqno
                      * @property {google.spanner.v1.ExecuteSqlRequest.IQueryOptions|null} [queryOptions] ExecuteSqlRequest queryOptions
                      * @property {google.spanner.v1.IRequestOptions|null} [requestOptions] ExecuteSqlRequest requestOptions
-                     * @property {boolean|null} [dataBoostEnabled] ExecuteSqlRequest dataBoostEnabled
                      */
     
                     /**
@@ -43033,14 +43032,6 @@
                     ExecuteSqlRequest.prototype.requestOptions = null;
     
                     /**
-                     * ExecuteSqlRequest dataBoostEnabled.
-                     * @member {boolean} dataBoostEnabled
-                     * @memberof google.spanner.v1.ExecuteSqlRequest
-                     * @instance
-                     */
-                    ExecuteSqlRequest.prototype.dataBoostEnabled = false;
-    
-                    /**
                      * Creates a new ExecuteSqlRequest instance using the specified properties.
                      * @function create
                      * @memberof google.spanner.v1.ExecuteSqlRequest
@@ -43089,8 +43080,6 @@
                             $root.google.spanner.v1.ExecuteSqlRequest.QueryOptions.encode(message.queryOptions, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
                         if (message.requestOptions != null && Object.hasOwnProperty.call(message, "requestOptions"))
                             $root.google.spanner.v1.RequestOptions.encode(message.requestOptions, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
-                        if (message.dataBoostEnabled != null && Object.hasOwnProperty.call(message, "dataBoostEnabled"))
-                            writer.uint32(/* id 15, wireType 0 =*/120).bool(message.dataBoostEnabled);
                         return writer;
                     };
     
@@ -43188,10 +43177,6 @@
                                     message.requestOptions = $root.google.spanner.v1.RequestOptions.decode(reader, reader.uint32());
                                     break;
                                 }
-                            case 15: {
-                                    message.dataBoostEnabled = reader.bool();
-                                    break;
-                                }
                             default:
                                 reader.skipType(tag & 7);
                                 break;
@@ -43281,9 +43266,6 @@
                             if (error)
                                 return "requestOptions." + error;
                         }
-                        if (message.dataBoostEnabled != null && message.hasOwnProperty("dataBoostEnabled"))
-                            if (typeof message.dataBoostEnabled !== "boolean")
-                                return "dataBoostEnabled: boolean expected";
                         return null;
                     };
     
@@ -43372,8 +43354,6 @@
                                 throw TypeError(".google.spanner.v1.ExecuteSqlRequest.requestOptions: object expected");
                             message.requestOptions = $root.google.spanner.v1.RequestOptions.fromObject(object.requestOptions);
                         }
-                        if (object.dataBoostEnabled != null)
-                            message.dataBoostEnabled = Boolean(object.dataBoostEnabled);
                         return message;
                     };
     
@@ -43419,7 +43399,6 @@
                                 object.seqno = options.longs === String ? "0" : 0;
                             object.queryOptions = null;
                             object.requestOptions = null;
-                            object.dataBoostEnabled = false;
                         }
                         if (message.session != null && message.hasOwnProperty("session"))
                             object.session = message.session;
@@ -43450,8 +43429,6 @@
                             object.queryOptions = $root.google.spanner.v1.ExecuteSqlRequest.QueryOptions.toObject(message.queryOptions, options);
                         if (message.requestOptions != null && message.hasOwnProperty("requestOptions"))
                             object.requestOptions = $root.google.spanner.v1.RequestOptions.toObject(message.requestOptions, options);
-                        if (message.dataBoostEnabled != null && message.hasOwnProperty("dataBoostEnabled"))
-                            object.dataBoostEnabled = message.dataBoostEnabled;
                         return object;
                     };
     
@@ -46107,7 +46084,6 @@
                      * @property {Uint8Array|null} [resumeToken] ReadRequest resumeToken
                      * @property {Uint8Array|null} [partitionToken] ReadRequest partitionToken
                      * @property {google.spanner.v1.IRequestOptions|null} [requestOptions] ReadRequest requestOptions
-                     * @property {boolean|null} [dataBoostEnabled] ReadRequest dataBoostEnabled
                      */
     
                     /**
@@ -46207,14 +46183,6 @@
                     ReadRequest.prototype.requestOptions = null;
     
                     /**
-                     * ReadRequest dataBoostEnabled.
-                     * @member {boolean} dataBoostEnabled
-                     * @memberof google.spanner.v1.ReadRequest
-                     * @instance
-                     */
-                    ReadRequest.prototype.dataBoostEnabled = false;
-    
-                    /**
                      * Creates a new ReadRequest instance using the specified properties.
                      * @function create
                      * @memberof google.spanner.v1.ReadRequest
@@ -46259,8 +46227,6 @@
                             writer.uint32(/* id 10, wireType 2 =*/82).bytes(message.partitionToken);
                         if (message.requestOptions != null && Object.hasOwnProperty.call(message, "requestOptions"))
                             $root.google.spanner.v1.RequestOptions.encode(message.requestOptions, writer.uint32(/* id 11, wireType 2 =*/90).fork()).ldelim();
-                        if (message.dataBoostEnabled != null && Object.hasOwnProperty.call(message, "dataBoostEnabled"))
-                            writer.uint32(/* id 16, wireType 0 =*/128).bool(message.dataBoostEnabled);
                         return writer;
                     };
     
@@ -46335,10 +46301,6 @@
                                 }
                             case 11: {
                                     message.requestOptions = $root.google.spanner.v1.RequestOptions.decode(reader, reader.uint32());
-                                    break;
-                                }
-                            case 16: {
-                                    message.dataBoostEnabled = reader.bool();
                                     break;
                                 }
                             default:
@@ -46416,9 +46378,6 @@
                             if (error)
                                 return "requestOptions." + error;
                         }
-                        if (message.dataBoostEnabled != null && message.hasOwnProperty("dataBoostEnabled"))
-                            if (typeof message.dataBoostEnabled !== "boolean")
-                                return "dataBoostEnabled: boolean expected";
                         return null;
                     };
     
@@ -46481,8 +46440,6 @@
                                 throw TypeError(".google.spanner.v1.ReadRequest.requestOptions: object expected");
                             message.requestOptions = $root.google.spanner.v1.RequestOptions.fromObject(object.requestOptions);
                         }
-                        if (object.dataBoostEnabled != null)
-                            message.dataBoostEnabled = Boolean(object.dataBoostEnabled);
                         return message;
                     };
     
@@ -46527,7 +46484,6 @@
                                     object.partitionToken = $util.newBuffer(object.partitionToken);
                             }
                             object.requestOptions = null;
-                            object.dataBoostEnabled = false;
                         }
                         if (message.session != null && message.hasOwnProperty("session"))
                             object.session = message.session;
@@ -46555,8 +46511,6 @@
                             object.partitionToken = options.bytes === String ? $util.base64.encode(message.partitionToken, 0, message.partitionToken.length) : options.bytes === Array ? Array.prototype.slice.call(message.partitionToken) : message.partitionToken;
                         if (message.requestOptions != null && message.hasOwnProperty("requestOptions"))
                             object.requestOptions = $root.google.spanner.v1.RequestOptions.toObject(message.requestOptions, options);
-                        if (message.dataBoostEnabled != null && message.hasOwnProperty("dataBoostEnabled"))
-                            object.dataBoostEnabled = message.dataBoostEnabled;
                         return object;
                     };
     

--- a/protos/protos.json
+++ b/protos/protos.json
@@ -4604,10 +4604,6 @@
                     "requestOptions": {
                       "type": "RequestOptions",
                       "id": 11
-                    },
-                    "dataBoostEnabled": {
-                      "type": "bool",
-                      "id": 15
                     }
                   },
                   "nested": {
@@ -4872,10 +4868,6 @@
                     "requestOptions": {
                       "type": "RequestOptions",
                       "id": 11
-                    },
-                    "dataBoostEnabled": {
-                      "type": "bool",
-                      "id": 16
                     }
                   }
                 },

--- a/src/v1/spanner_client.ts
+++ b/src/v1/spanner_client.ts
@@ -824,12 +824,6 @@ export class SpannerClient {
    *   Query optimizer configuration to use for the given query.
    * @param {google.spanner.v1.RequestOptions} request.requestOptions
    *   Common options for this request.
-   * @param {boolean} request.dataBoostEnabled
-   *   If this is for a partitioned read and this field is set to `true`, the
-   *   request will be executed via Spanner independent compute resources.
-   *
-   *   If the field is set to `true` but the request does not set
-   *   `partition_token`, the API will return an `INVALID_ARGUMENT` error.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -1081,12 +1075,6 @@ export class SpannerClient {
    *   PartitionReadRequest message used to create this partition_token.
    * @param {google.spanner.v1.RequestOptions} request.requestOptions
    *   Common options for this request.
-   * @param {boolean} request.dataBoostEnabled
-   *   If this is for a partitioned query and this field is set to `true`, the
-   *   request will be executed via Spanner independent compute resources.
-   *
-   *   If the field is set to `true` but the request does not set
-   *   `partition_token`, the API will return an `INVALID_ARGUMENT` error.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -1782,12 +1770,6 @@ export class SpannerClient {
    *   Query optimizer configuration to use for the given query.
    * @param {google.spanner.v1.RequestOptions} request.requestOptions
    *   Common options for this request.
-   * @param {boolean} request.dataBoostEnabled
-   *   If this is for a partitioned read and this field is set to `true`, the
-   *   request will be executed via Spanner independent compute resources.
-   *
-   *   If the field is set to `true` but the request does not set
-   *   `partition_token`, the API will return an `INVALID_ARGUMENT` error.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}
@@ -1866,12 +1848,6 @@ export class SpannerClient {
    *   PartitionReadRequest message used to create this partition_token.
    * @param {google.spanner.v1.RequestOptions} request.requestOptions
    *   Common options for this request.
-   * @param {boolean} request.dataBoostEnabled
-   *   If this is for a partitioned query and this field is set to `true`, the
-   *   request will be executed via Spanner independent compute resources.
-   *
-   *   If the field is set to `true` but the request does not set
-   *   `partition_token`, the API will return an `INVALID_ARGUMENT` error.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Stream}


### PR DESCRIPTION
This reverts commit 2a6ca6f09215752f9451d625ac02837e9d70b66a.

This would be a breaking change, but the new field hasn't been included in any release yet. A follow-up PR will be generated with a change to correctly add the field.
