### PR TITLE
Revert "feat: Set LAR as False (#1883)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,8 @@ export type GetInstanceConfigOperationsCallback = PagedCallback<
 
 /**
  * Session pool configuration options.
- * @property {boolean} [routeToLeaderEnabled=False] If set to true leader aware routing will be enabled.
- * Enabling leader aware routing would route all requests in RW/PDML transactions to leader region.
+ * @property {boolean} [routeToLeaderEnabled=True] If set to false leader aware routing will be disabled.
+ * Disabling leader aware routing would route all requests in RW/PDML transactions to any region.
  */
 export interface SpannerOptions extends GrpcClientOptions {
   apiEndpoint?: string;
@@ -216,7 +216,7 @@ class Spanner extends GrpcService {
   projectIdReplaced_: boolean;
   projectFormattedName_: string;
   resourceHeader_: {[k: string]: string};
-  routeToLeaderEnabled = false;
+  routeToLeaderEnabled = true;
 
   /**
    * Placeholder used to auto populate a column with the commit timestamp.
@@ -318,8 +318,8 @@ class Spanner extends GrpcService {
     } as {} as GrpcServiceConfig;
     super(config, options);
 
-    if (options.routeToLeaderEnabled === true) {
-      this.routeToLeaderEnabled = true;
+    if (options.routeToLeaderEnabled === false) {
+      this.routeToLeaderEnabled = false;
     }
 
     this.options = options;

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -1491,14 +1491,14 @@ describe('Spanner with mock server', () => {
     });
 
     describe('LeaderAwareRouting', () => {
-      let spannerWithLAREnabled: Spanner;
-      let instanceWithLAREnabled: Instance;
+      let spannerWithLARDisabled: Spanner;
+      let instanceWithLARDisabled: Instance;
 
-      function newTestDatabaseWithLAREnabled(
+      function newTestDatabaseWithLARDisabled(
         options?: SessionPoolOptions,
         queryOptions?: IQueryOptions
       ): Database {
-        return instanceWithLAREnabled.database(
+        return instanceWithLARDisabled.database(
           `database-${dbCounter++}`,
           options,
           queryOptions
@@ -1506,18 +1506,18 @@ describe('Spanner with mock server', () => {
       }
 
       before(() => {
-        spannerWithLAREnabled = new Spanner({
+        spannerWithLARDisabled = new Spanner({
           servicePath: 'localhost',
           port,
           sslCreds: grpc.credentials.createInsecure(),
-          routeToLeaderEnabled: true,
+          routeToLeaderEnabled: false,
         });
         // Gets a reference to a Cloud Spanner instance and database
-        instanceWithLAREnabled = spannerWithLAREnabled.instance('instance');
+        instanceWithLARDisabled = spannerWithLARDisabled.instance('instance');
       });
 
       it('should execute with leader aware routing enabled in a read/write transaction', async () => {
-        const database = newTestDatabaseWithLAREnabled();
+        const database = newTestDatabase();
         await database.runTransactionAsync(async tx => {
           await tx!.runUpdate({
             sql: insertSql,
@@ -1539,7 +1539,7 @@ describe('Spanner with mock server', () => {
       });
 
       it('should execute with leader aware routing disabled in a read/write transaction', async () => {
-        const database = newTestDatabase();
+        const database = newTestDatabaseWithLARDisabled();
         await database.runTransactionAsync(async tx => {
           await tx!.runUpdate({
             sql: insertSql,


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Enable leader aware routing by default. This update contains performance optimisations that will reduce the latency of read/write transactions that originate from a region other than the default leader region.
END_COMMIT_OVERRIDE