### PR TITLE
feat(spanner): add maxCommitDelay support

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -69,6 +69,7 @@ export interface RequestOptions {
 export interface CommitOptions {
   requestOptions?: Pick<IRequestOptions, 'priority'>;
   returnCommitStats?: boolean;
+  maxCommitDelay?: spannerClient.protobuf.IDuration;
   gaxOptions?: CallOptions;
 }
 
@@ -1798,6 +1799,9 @@ export class Transaction extends Dml {
    *     with the commit request.
    * @property {boolean} returnCommitStats Include statistics related to the
    *     transaction in the {@link CommitResponse}.
+   * @property {spannerClient.proto.IDuration} maxCommitDelay Maximum amount
+   *     of delay the commit is willing to incur in order to improve
+   *     throughput. Value should be between 0ms and 500ms.
    * @property {object} [gaxOptions] The request configuration options,
    *     See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions}
    *     for more details.
@@ -1887,6 +1891,12 @@ export class Transaction extends Dml {
       (options as CommitOptions).returnCommitStats
     ) {
       reqOpts.returnCommitStats = (options as CommitOptions).returnCommitStats;
+    }
+    if (
+      'maxCommitDelay' in options &&
+      (options as CommitOptions).maxCommitDelay
+    ) {
+      reqOpts.maxCommitDelay = (options as CommitOptions).maxCommitDelay;
     }
     reqOpts.requestOptions = Object.assign(
       requestOptions || {},

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -1634,10 +1634,13 @@ describe('Transaction', () => {
 
       it('should accept commit options', done => {
         const maxCommitDelay = new google.protobuf.Duration({
-          seconds: 0,  // 0 seconds
-          nanos: 100000000 // 100,000,000 nanoseconds = 100 milliseconds
+          seconds: 0, // 0 seconds
+          nanos: 100000000, // 100,000,000 nanoseconds = 100 milliseconds
         });
-        const options = {returnCommitStats: true, maxCommitDelay: maxCommitDelay};
+        const options = {
+          returnCommitStats: true,
+          maxCommitDelay: maxCommitDelay,
+        };
         transaction.request = config => {
           assert.strictEqual(config.reqOpts.returnCommitStats, true);
           done();

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -1633,7 +1633,11 @@ describe('Transaction', () => {
       });
 
       it('should accept commit options', done => {
-        const options = {returnCommitStats: true};
+        const maxCommitDelay = new google.protobuf.Duration({
+          seconds: 0,  // 0 seconds
+          nanos: 100000000 // 100,000,000 nanoseconds = 100 milliseconds
+        });
+        const options = {returnCommitStats: true, maxCommitDelay: maxCommitDelay};
         transaction.request = config => {
           assert.strictEqual(config.reqOpts.returnCommitStats, true);
           done();


### PR DESCRIPTION
maxCommitDelays allows the user to specify the maximum delay a commit request is willing to incur in order to improve throughput. This PR adds support for the feature in the commit API.