### PR TITLE
chore: add owlbot configuration for executor

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -25,6 +25,8 @@ deep-copy-regex:
     dest: /owl-bot-staging/$1/$2
   - source: /google/spanner/(admin/instance/v.*)/.*-nodejs/(.*)
     dest: /owl-bot-staging/$1/$2
+  - source: /google/spanner/(executor/v.*)/.*-nodejs/(.*)
+    dest: /owl-bot-staging/$1/$2
 
 begin-after-commit-hash: 46f25fb1121747b994ff5818963fda84b5e6bfd3
 

--- a/owlbot.py
+++ b/owlbot.py
@@ -53,6 +53,12 @@ if staging.is_dir():
         _tracked_paths.add(library)
         s.copy([library], excludes=excludes)
 
+    # Copy the spanner/executor library.
+    for version in ['v1']:
+        library = staging / 'executor' / version
+        _tracked_paths.add(library)
+        s.copy([library], excludes=excludes)
+
     # The staging directory should never be merged into the main branch.
     shutil.rmtree(staging)
 


### PR DESCRIPTION
This PR adds owlbot configurations for pulling executor relevant code. This is needed for executor framework support in NodeJS.