### PR TITLE
observability: ensure that each span has otel.scope.name,version

### DIFF
--- a/observability-test/observability.ts
+++ b/observability-test/observability.ts
@@ -25,8 +25,8 @@ const {SpanStatusCode, TracerProvider} = require('@opentelemetry/api');
 // eslint-disable-next-line n/no-extraneous-require
 const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
 const {
-  LIB_FQNAME,
-  LIB_VERSION,
+  TRACER_NAME,
+  TRACER_VERSION,
   SPAN_NAMESPACE_PREFIX,
   getActiveOrNoopSpan,
   setSpanError,
@@ -135,13 +135,13 @@ describe('startTrace', () => {
     startTrace('aSpan', opts, span => {
       assert.equal(
         span.attributes[ATTR_OTEL_SCOPE_NAME],
-        LIB_FQNAME,
+        TRACER_NAME,
         'Missing OTEL_SCOPE_NAME attribute'
       );
 
       assert.equal(
         span.attributes[ATTR_OTEL_SCOPE_VERSION],
-        LIB_VERSION,
+        TRACER_VERSION,
         'Missing OTEL_SCOPE_VERSION attribute'
       );
 

--- a/observability-test/observability.ts
+++ b/observability-test/observability.ts
@@ -25,6 +25,8 @@ const {SpanStatusCode, TracerProvider} = require('@opentelemetry/api');
 // eslint-disable-next-line n/no-extraneous-require
 const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
 const {
+  LIB_FQNAME,
+  LIB_VERSION,
   SPAN_NAMESPACE_PREFIX,
   getActiveOrNoopSpan,
   setSpanError,
@@ -32,6 +34,8 @@ const {
   startTrace,
 } = require('../src/instrument');
 const {
+  ATTR_OTEL_SCOPE_NAME,
+  ATTR_OTEL_SCOPE_VERSION,
   SEMATTRS_DB_NAME,
   SEMATTRS_DB_SQL_TABLE,
   SEMATTRS_DB_STATEMENT,
@@ -129,6 +133,18 @@ describe('startTrace', () => {
   it('with semantic attributes', () => {
     const opts = {tableName: 'table', dbName: 'db'};
     startTrace('aSpan', opts, span => {
+      assert.equal(
+        span.attributes[ATTR_OTEL_SCOPE_NAME],
+        LIB_FQNAME,
+        'Missing OTEL_SCOPE_NAME attribute'
+      );
+
+      assert.equal(
+        span.attributes[ATTR_OTEL_SCOPE_VERSION],
+        LIB_VERSION,
+        'Missing OTEL_SCOPE_VERSION attribute'
+      );
+
       assert.equal(
         span.attributes[SEMATTRS_DB_SYSTEM],
         'spanner',

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -52,12 +52,10 @@ interface observabilityOptions {
 
 export type {observabilityOptions as ObservabilityOptions};
 
-const LIB_FQNAME = 'cloud.google.com/nodejs/spanner';
-const LIB_VERSION = '7.14.0'; // Manually hard coded, TODO: remove
-const TRACER_NAME = LIB_FQNAME;
-const TRACER_VERSION = LIB_VERSION;
+const TRACER_NAME = 'cloud.google.com/nodejs/spanner';
+const TRACER_VERSION = '7.14.0'; // Manually hard coded, TODO: remove
 
-export {LIB_FQNAME, LIB_VERSION}; // Only exported for testing.
+export {TRACER_NAME, TRACER_VERSION}; // Only exported for testing.
 
 /**
  * getTracer fetches the tracer from the provided tracerProvider.
@@ -108,8 +106,8 @@ export function startTrace<T>(
     {kind: SpanKind.CLIENT},
     span => {
       span.setAttribute(SEMATTRS_DB_SYSTEM, 'spanner');
-      span.setAttribute(ATTR_OTEL_SCOPE_NAME, LIB_FQNAME);
-      span.setAttribute(ATTR_OTEL_SCOPE_VERSION, LIB_VERSION);
+      span.setAttribute(ATTR_OTEL_SCOPE_NAME, TRACER_NAME);
+      span.setAttribute(ATTR_OTEL_SCOPE_VERSION, TRACER_VERSION);
 
       if (config.tableName) {
         span.setAttribute(SEMATTRS_DB_SQL_TABLE, config.tableName);

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+  ATTR_OTEL_SCOPE_NAME,
+  ATTR_OTEL_SCOPE_VERSION,
   SEMATTRS_DB_NAME,
   SEMATTRS_DB_STATEMENT,
   SEMATTRS_DB_SYSTEM,
@@ -50,8 +52,12 @@ interface observabilityOptions {
 
 export type {observabilityOptions as ObservabilityOptions};
 
-const TRACER_NAME = 'cloud.google.com/nodejs/spanner';
-const TRACER_VERSION = '7.14.0'; // Manually hard coded, TODO: remove
+const LIB_FQNAME = 'cloud.google.com/nodejs/spanner';
+const LIB_VERSION = '7.14.0'; // Manually hard coded, TODO: remove
+const TRACER_NAME = LIB_FQNAME;
+const TRACER_VERSION = LIB_VERSION;
+
+export {LIB_FQNAME, LIB_VERSION}; // Only exported for testing.
 
 /**
  * getTracer fetches the tracer from the provided tracerProvider.
@@ -102,6 +108,8 @@ export function startTrace<T>(
     {kind: SpanKind.CLIENT},
     span => {
       span.setAttribute(SEMATTRS_DB_SYSTEM, 'spanner');
+      span.setAttribute(ATTR_OTEL_SCOPE_NAME, LIB_FQNAME);
+      span.setAttribute(ATTR_OTEL_SCOPE_VERSION, LIB_VERSION);
 
       if (config.tableName) {
         span.setAttribute(SEMATTRS_DB_SQL_TABLE, config.tableName);


### PR DESCRIPTION
This change ensures that each span created by the code in this library is annotated with:
* otel.scope.name = "cloud.google.com/nodejs/spanner"
* otel.scope.version = <LIBRARY_VERSION>

Updates #2079