### PR TITLE
observability: dynamically retrieve TRACER_VERSION from published package.json

### DIFF
--- a/observability-test/observability.ts
+++ b/observability-test/observability.ts
@@ -122,6 +122,11 @@ describe('startTrace', () => {
     );
   });
 
+  it('sanity check: TRACER_NAME, TRACER_VERSION', () => {
+    assert.equal(!TRACER_NAME, false, 'TRACER_NAME must be set');
+    assert.equal(!TRACER_VERSION, false, 'TRACER_VERSION must be set');
+  });
+
   it('with semantic attributes', () => {
     const opts = {tableName: 'table', dbName: 'db'};
     startTrace('aSpan', opts, span => {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -53,7 +53,7 @@ interface observabilityOptions {
 export type {observabilityOptions as ObservabilityOptions};
 
 const TRACER_NAME = 'cloud.google.com/nodejs/spanner';
-const TRACER_VERSION = '7.14.0'; // Manually hard coded, TODO: remove
+const TRACER_VERSION = require('../../package.json').version;
 
 export {TRACER_NAME, TRACER_VERSION}; // Only exported for testing.
 


### PR DESCRIPTION
This change dynamically retrieves the published version of this module from the package.json.version variable.

Updates #2079