### PR TITLE
feat: (observability) trace Database.batchCreateSessions + SessionPool.createSessions

### DIFF
--- a/observability-test/database.ts
+++ b/observability-test/database.ts
@@ -518,7 +518,7 @@ describe('Database', () => {
 
       getSessionStub.callsFake(callback => callback(fakeError, null));
 
-      database.getSnapshot((err, snapshot) => {
+      database.getSnapshot(err => {
         assert.strictEqual(err, fakeError);
         traceExporter.forceFlush();
         const spans = traceExporter.getFinishedSpans();
@@ -1136,7 +1136,6 @@ describe('Database', () => {
     });
 
     it('with error on null mutation should catch thrown error', done => {
-      const fakeError = new Error('err');
       try {
         database.writeAtLeastOnce(null, (err, res) => {});
       } catch (err) {

--- a/observability-test/session-pool.ts
+++ b/observability-test/session-pool.ts
@@ -32,7 +32,6 @@ const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
 import {Database} from '../src/database';
 import {Session} from '../src/session';
 import * as sp from '../src/session-pool';
-import {Transaction} from '../src/transaction';
 
 let pQueueOverride: typeof PQueue | null = null;
 

--- a/observability-test/session-pool.ts
+++ b/observability-test/session-pool.ts
@@ -1,0 +1,201 @@
+/*!
+ * Copyright 2024 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {before, beforeEach, afterEach, describe, it} from 'mocha';
+import * as events from 'events';
+import * as extend from 'extend';
+import PQueue from 'p-queue';
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import stackTrace = require('stack-trace');
+import timeSpan = require('time-span');
+const {
+  AlwaysOnSampler,
+  NodeTracerProvider,
+  InMemorySpanExporter,
+} = require('@opentelemetry/sdk-trace-node');
+// eslint-disable-next-line n/no-extraneous-require
+const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
+
+import {Database} from '../src/database';
+import {Session} from '../src/session';
+import * as sp from '../src/session-pool';
+import {Transaction} from '../src/transaction';
+
+let pQueueOverride: typeof PQueue | null = null;
+
+function FakePQueue(options) {
+  return new (pQueueOverride || PQueue)(options);
+}
+
+FakePQueue.default = FakePQueue;
+
+class FakeTransaction {
+  options;
+  constructor(options?) {
+    this.options = options;
+  }
+  async begin(): Promise<void> {}
+}
+
+const fakeStackTrace = extend({}, stackTrace);
+
+function noop() {}
+
+describe('SessionPool', () => {
+  let sessionPool: sp.SessionPool;
+  // tslint:disable-next-line variable-name
+  let SessionPool: typeof sp.SessionPool;
+
+  function noop() {}
+  const DATABASE = {
+    batchCreateSessions: noop,
+    databaseRole: 'parent_role',
+  } as unknown as Database;
+
+  const sandbox = sinon.createSandbox();
+  const shouldNotBeCalled = sandbox.stub().throws('Should not be called.');
+
+  const createSession = (name = 'id', props?): Session => {
+    props = props || {};
+
+    return Object.assign(new Session(DATABASE, name), props, {
+      create: sandbox.stub().resolves(),
+      delete: sandbox.stub().resolves(),
+      keepAlive: sandbox.stub().resolves(),
+      transaction: sandbox.stub().returns(new FakeTransaction()),
+    });
+  };
+
+  before(() => {
+    SessionPool = proxyquire('../src/session-pool.js', {
+      'p-queue': FakePQueue,
+      'stack-trace': fakeStackTrace,
+    }).SessionPool;
+  });
+
+  afterEach(() => {
+    pQueueOverride = null;
+    sandbox.restore();
+  });
+
+  const traceExporter = new InMemorySpanExporter();
+  const sampler = new AlwaysOnSampler();
+  const provider = new NodeTracerProvider({
+    sampler: sampler,
+    exporter: traceExporter,
+  });
+  provider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
+
+  beforeEach(() => {
+    DATABASE.session = createSession;
+    DATABASE._observabilityOptions = {
+      tracerProvider: provider,
+    };
+    sessionPool = new SessionPool(DATABASE);
+    sessionPool._observabilityOptions = DATABASE._observabilityOptions;
+    traceExporter.reset();
+  });
+
+  describe('_createSessions', () => {
+    const OPTIONS = 3;
+    it('on exception from Database.batchCreateSessions', async () => {
+      const ourException = new Error('this fails intentionally');
+      const stub = sandbox
+        .stub(DATABASE, 'batchCreateSessions')
+        .throws(ourException);
+      const releaseStub = sandbox.stub(sessionPool, 'release');
+
+      assert.rejects(async () => {
+        await sessionPool._createSessions(OPTIONS);
+      }, ourException);
+
+      traceExporter.forceFlush();
+      const spans = traceExporter.getFinishedSpans();
+
+      const actualSpanNames: string[] = [];
+      const actualEventNames: string[] = [];
+      spans.forEach(span => {
+        actualSpanNames.push(span.name);
+        span.events.forEach(event => {
+          actualEventNames.push(event.name);
+        });
+      });
+
+      const expectedSpanNames = ['CloudSpanner.SessionPool.createSessions'];
+      assert.deepStrictEqual(
+        actualSpanNames,
+        expectedSpanNames,
+        `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+      );
+
+      const expectedEventNames = [
+        'Requesting 3 sessions',
+        'Creating 3 sessions',
+        'Requested for 3 sessions returned 0',
+        'exception',
+      ];
+      assert.deepStrictEqual(
+        actualEventNames,
+        expectedEventNames,
+        `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
+      );
+    });
+
+    it('without error', async () => {
+      const RESPONSE = [[{}, {}, {}]];
+
+      const stub = sandbox
+        .stub(DATABASE, 'batchCreateSessions')
+        .resolves(RESPONSE);
+      const releaseStub = sandbox.stub(sessionPool, 'release');
+
+      await sessionPool._createSessions(OPTIONS);
+      assert.strictEqual(sessionPool.size, 3);
+
+      traceExporter.forceFlush();
+      const spans = traceExporter.getFinishedSpans();
+
+      const actualSpanNames: string[] = [];
+      const actualEventNames: string[] = [];
+      spans.forEach(span => {
+        actualSpanNames.push(span.name);
+        span.events.forEach(event => {
+          actualEventNames.push(event.name);
+        });
+      });
+
+      const expectedSpanNames = ['CloudSpanner.SessionPool.createSessions'];
+      assert.deepStrictEqual(
+        actualSpanNames,
+        expectedSpanNames,
+        `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+      );
+
+      const expectedEventNames = [
+        'Requesting 3 sessions',
+        'Creating 3 sessions',
+        'Requested for 3 sessions returned 3',
+      ];
+      assert.deepStrictEqual(
+        actualEventNames,
+        expectedEventNames,
+        `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
+      );
+    });
+  });
+});

--- a/observability-test/session-pool.ts
+++ b/observability-test/session-pool.ts
@@ -28,6 +28,8 @@ const {
 } = require('@opentelemetry/sdk-trace-node');
 // eslint-disable-next-line n/no-extraneous-require
 const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
+// eslint-disable-next-line n/no-extraneous-require
+const {SpanStatusCode} = require('@opentelemetry/api');
 
 import {Database} from '../src/database';
 import {Session} from '../src/session';
@@ -149,6 +151,18 @@ describe('SessionPool', () => {
         expectedEventNames,
         `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
       );
+
+      const firstSpan = spans[0];
+      assert.strictEqual(
+        SpanStatusCode.ERROR,
+        firstSpan.status.code,
+        'Unexpected an span status code'
+      );
+      assert.strictEqual(
+        ourException.message,
+        firstSpan.status.message,
+        'Unexpected span status message'
+      );
     });
 
     it('without error', async () => {
@@ -190,6 +204,18 @@ describe('SessionPool', () => {
         actualEventNames,
         expectedEventNames,
         `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
+      );
+
+      const firstSpan = spans[0];
+      assert.strictEqual(
+        SpanStatusCode.UNSET,
+        firstSpan.status.code,
+        'Unexpected an span status code'
+      );
+      assert.strictEqual(
+        undefined,
+        firstSpan.status.message,
+        'Unexpected span status message'
       );
     });
   });

--- a/observability-test/session-pool.ts
+++ b/observability-test/session-pool.ts
@@ -16,13 +16,11 @@
 
 import * as assert from 'assert';
 import {before, beforeEach, afterEach, describe, it} from 'mocha';
-import * as events from 'events';
 import * as extend from 'extend';
 import PQueue from 'p-queue';
 import * as proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 import stackTrace = require('stack-trace');
-import timeSpan = require('time-span');
 const {
   AlwaysOnSampler,
   NodeTracerProvider,
@@ -53,8 +51,6 @@ class FakeTransaction {
 }
 
 const fakeStackTrace = extend({}, stackTrace);
-
-function noop() {}
 
 describe('SessionPool', () => {
   let sessionPool: sp.SessionPool;

--- a/observability-test/spanner.ts
+++ b/observability-test/spanner.ts
@@ -113,65 +113,54 @@ async function setup(
 }
 
 describe('EndToEnd', () => {
+  let server: grpc.Server;
+  let spanner: Spanner;
+  let database: Database;
+  let spannerMock: mock.MockSpanner;
+  let traceExporter: typeof InMemorySpanExporter;
+
+  const contextManager = new AsyncHooksContextManager();
+  setGlobalContextManager(contextManager);
+
+  afterEach(() => {
+    disableContextAndManager(contextManager);
+  });
+
+  beforeEach(async () => {
+    traceExporter = new InMemorySpanExporter();
+    const sampler = new AlwaysOnSampler();
+    const provider = new NodeTracerProvider({
+      sampler: sampler,
+      exporter: traceExporter,
+    });
+    provider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
+
+    const setupResult = await setup({
+      tracerProvider: provider,
+      enableExtendedTracing: false,
+    });
+
+    spanner = setupResult.spanner;
+    server = setupResult.server;
+    spannerMock = setupResult.spannerMock;
+
+    const instance = spanner.instance('instance');
+    database = instance.database('database');
+  });
+
+  afterEach(() => {
+    traceExporter.reset();
+    spannerMock.resetRequests();
+    spanner.close();
+    server.tryShutdown(() => {});
+  });
+
   describe('Database', () => {
-    let server: grpc.Server;
-    let spanner: Spanner;
-    let database: Database;
-    let spannerMock: mock.MockSpanner;
-    let traceExporter: typeof InMemorySpanExporter;
-
-    const contextManager = new AsyncHooksContextManager();
-    setGlobalContextManager(contextManager);
-
-    afterEach(() => {
-      disableContextAndManager(contextManager);
-    });
-
-    beforeEach(async () => {
-      traceExporter = new InMemorySpanExporter();
-      const sampler = new AlwaysOnSampler();
-      const provider = new NodeTracerProvider({
-        sampler: sampler,
-        exporter: traceExporter,
-      });
-      const setupResult = await setup({
-        tracerProvider: provider,
-        enableExtendedTracing: false,
-      });
-      spanner = setupResult.spanner;
-      server = setupResult.server;
-      spannerMock = setupResult.spannerMock;
-
-      const selectSql = 'SELECT 1';
-      const updateSql = 'UPDATE FOO SET BAR=1 WHERE BAZ=2';
-      spannerMock.putStatementResult(
-        selectSql,
-        mock.StatementResult.resultSet(createSelect1ResultSet())
-      );
-      spannerMock.putStatementResult(
-        updateSql,
-        mock.StatementResult.updateCount(1)
-      );
-
-      provider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
-
-      const instance = spanner.instance('instance');
-      database = instance.database('database');
-    });
-
-    afterEach(() => {
-      traceExporter.reset();
-      spannerMock.resetRequests();
-      spanner.close();
-      server.tryShutdown(() => {});
-    });
-
     it('getSessions', async () => {
       const [rows] = await database.getSessions();
 
       traceExporter.forceFlush();
       const spans = traceExporter.getFinishedSpans();
-      assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
 
       const actualSpanNames: string[] = [];
       const actualEventNames: string[] = [];
@@ -217,6 +206,8 @@ describe('EndToEnd', () => {
           });
 
           const expectedSpanNames = [
+            'CloudSpanner.Database.batchCreateSessions',
+            'CloudSpanner.SessionPool.createSessions',
             'CloudSpanner.Snapshot.begin',
             'CloudSpanner.Database.getSnapshot',
             'CloudSpanner.Snapshot.runStream',
@@ -228,7 +219,16 @@ describe('EndToEnd', () => {
             `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
           );
 
-          const expectedEventNames = ['Begin Transaction'];
+          const expectedEventNames = [
+            'Requesting 25 sessions',
+            'Creating 25 sessions',
+            'Requested for 25 sessions returned 25',
+            'Begin Transaction',
+            'Transaction Creation Done',
+            'Acquiring session',
+            'Waiting for a session to become available',
+            'Acquired session',
+          ];
           assert.deepStrictEqual(
             actualEventNames,
             expectedEventNames,
@@ -247,7 +247,6 @@ describe('EndToEnd', () => {
 
         traceExporter.forceFlush();
         const spans = traceExporter.getFinishedSpans();
-        assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
 
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
@@ -258,14 +257,26 @@ describe('EndToEnd', () => {
           });
         });
 
-        const expectedSpanNames = ['CloudSpanner.Database.getTransaction'];
+        const expectedSpanNames = [
+          'CloudSpanner.Database.batchCreateSessions',
+          'CloudSpanner.SessionPool.createSessions',
+          'CloudSpanner.Database.getTransaction',
+        ];
         assert.deepStrictEqual(
           actualSpanNames,
           expectedSpanNames,
           `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
         );
 
-        const expectedEventNames = ['Using Session'];
+        const expectedEventNames = [
+          'Requesting 25 sessions',
+          'Creating 25 sessions',
+          'Requested for 25 sessions returned 25',
+          'Acquiring session',
+          'Waiting for a session to become available',
+          'Acquired session',
+          'Using Session',
+        ];
         assert.deepStrictEqual(
           actualEventNames,
           expectedEventNames,
@@ -295,6 +306,8 @@ describe('EndToEnd', () => {
           });
 
           const expectedSpanNames = [
+            'CloudSpanner.Database.batchCreateSessions',
+            'CloudSpanner.SessionPool.createSessions',
             'CloudSpanner.Snapshot.runStream',
             'CloudSpanner.Database.runStream',
           ];
@@ -304,7 +317,15 @@ describe('EndToEnd', () => {
             `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
           );
 
-          const expectedEventNames = ['Using Session'];
+          const expectedEventNames = [
+            'Requesting 25 sessions',
+            'Creating 25 sessions',
+            'Requested for 25 sessions returned 25',
+            'Acquiring session',
+            'Waiting for a session to become available',
+            'Acquired session',
+            'Using Session',
+          ];
           assert.deepStrictEqual(
             actualEventNames,
             expectedEventNames,
@@ -336,6 +357,8 @@ describe('EndToEnd', () => {
       });
 
       const expectedSpanNames = [
+        'CloudSpanner.Database.batchCreateSessions',
+        'CloudSpanner.SessionPool.createSessions',
         'CloudSpanner.Snapshot.runStream',
         'CloudSpanner.Database.runStream',
         'CloudSpanner.Database.run',
@@ -366,7 +389,15 @@ describe('EndToEnd', () => {
         'Expected that RunStream has a defined spanId'
       );
 
-      const expectedEventNames = ['Using Session'];
+      const expectedEventNames = [
+        'Requesting 25 sessions',
+        'Creating 25 sessions',
+        'Requested for 25 sessions returned 25',
+        'Acquiring session',
+        'Waiting for a session to become available',
+        'Acquired session',
+        'Using Session',
+      ];
       assert.deepStrictEqual(
         actualEventNames,
         expectedEventNames,
@@ -393,6 +424,8 @@ describe('EndToEnd', () => {
           });
 
           const expectedSpanNames = [
+            'CloudSpanner.Database.batchCreateSessions',
+            'CloudSpanner.SessionPool.createSessions',
             'CloudSpanner.Database.runTransaction',
             'CloudSpanner.Snapshot.runStream',
             'CloudSpanner.Snapshot.run',
@@ -403,7 +436,15 @@ describe('EndToEnd', () => {
             `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
           );
 
-          const expectedEventNames = [];
+          const expectedEventNames = [
+            'Requesting 25 sessions',
+            'Creating 25 sessions',
+            'Requested for 25 sessions returned 25',
+            'Acquiring session',
+            'Waiting for a session to become available',
+            'Acquired session',
+            'Transaction Creation Done',
+          ];
           assert.deepStrictEqual(
             actualEventNames,
             expectedEventNames,
@@ -434,6 +475,8 @@ describe('EndToEnd', () => {
         });
 
         const expectedSpanNames = [
+          'CloudSpanner.Database.batchCreateSessions',
+          'CloudSpanner.SessionPool.createSessions',
           'CloudSpanner.Transaction.commit',
           'CloudSpanner.Database.writeAtLeastOnce',
         ];
@@ -444,9 +487,58 @@ describe('EndToEnd', () => {
         );
 
         const expectedEventNames = [
+          'Requesting 25 sessions',
+          'Creating 25 sessions',
+          'Requested for 25 sessions returned 25',
           'Starting Commit',
           'Commit Done',
+          'Acquiring session',
+          'Waiting for a session to become available',
+          'Acquired session',
           'Using Session',
+        ];
+        assert.deepStrictEqual(
+          actualEventNames,
+          expectedEventNames,
+          `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
+        );
+
+        done();
+      });
+    });
+
+    it('batchCreateSessions', done => {
+      const blankMutations = new MutationSet();
+      database.batchCreateSessions(5, (err, sessions) => {
+        assert.ifError(err);
+
+        traceExporter.forceFlush();
+        const spans = traceExporter.getFinishedSpans();
+
+        const actualEventNames: string[] = [];
+        const actualSpanNames: string[] = [];
+        spans.forEach(span => {
+          actualSpanNames.push(span.name);
+          span.events.forEach(event => {
+            actualEventNames.push(event.name);
+          });
+        });
+
+        const expectedSpanNames = [
+          'CloudSpanner.Database.batchCreateSessions',
+          'CloudSpanner.SessionPool.createSessions',
+          'CloudSpanner.Database.batchCreateSessions',
+        ];
+        assert.deepStrictEqual(
+          actualSpanNames,
+          expectedSpanNames,
+          `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+        );
+
+        const expectedEventNames = [
+          'Requesting 25 sessions',
+          'Creating 25 sessions',
+          'Requested for 25 sessions returned 25',
         ];
         assert.deepStrictEqual(
           actualEventNames,
@@ -461,46 +553,32 @@ describe('EndToEnd', () => {
 });
 
 describe('ObservabilityOptions injection and propagation', async () => {
-  const globalTraceExporter = new InMemorySpanExporter();
-  const globalTracerProvider = new NodeTracerProvider({
-    sampler: new AlwaysOnSampler(),
-    exporter: globalTraceExporter,
-  });
-  globalTracerProvider.addSpanProcessor(
-    new SimpleSpanProcessor(globalTraceExporter)
-  );
-  globalTracerProvider.register();
+  it('Passed into Spanner, Instance and Database', async () => {
+    const traceExporter = new InMemorySpanExporter();
+    const tracerProvider = new NodeTracerProvider({
+      sampler: new AlwaysOnSampler(),
+      exporter: traceExporter,
+    });
+    tracerProvider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
 
-  const injectedTraceExporter = new InMemorySpanExporter();
-  const injectedTracerProvider = new NodeTracerProvider({
-    sampler: new AlwaysOnSampler(),
-    exporter: injectedTraceExporter,
-  });
-  injectedTracerProvider.addSpanProcessor(
-    new SimpleSpanProcessor(injectedTraceExporter)
-  );
+    const observabilityOptions: typeof ObservabilityOptions = {
+      tracerProvider: tracerProvider,
+      enableExtendedTracing: true,
+    };
 
-  const observabilityOptions: typeof ObservabilityOptions = {
-    tracerProvider: injectedTracerProvider,
-    enableExtendedTracing: true,
-  };
+    const setupResult = await setup(observabilityOptions);
+    const spanner = setupResult.spanner;
+    const server = setupResult.server;
+    const spannerMock = setupResult.spannerMock;
 
-  const setupResult = await setup(observabilityOptions);
-  const spanner = setupResult.spanner;
-  const server = setupResult.server;
-  const spannerMock = setupResult.spannerMock;
+    after(async () => {
+      traceExporter.reset();
+      await tracerProvider.shutdown();
+      spannerMock.resetRequests();
+      spanner.close();
+      server.tryShutdown(() => {});
+    });
 
-  after(async () => {
-    globalTraceExporter.reset();
-    injectedTraceExporter.reset();
-    await globalTracerProvider.shutdown();
-    await injectedTracerProvider.shutdown();
-    spannerMock.resetRequests();
-    spanner.close();
-    server.tryShutdown(() => {});
-  });
-
-  it('Passed into Spanner, Instance and Database', done => {
     // Ensure that the same observability configuration is set on the Spanner client.
     assert.deepStrictEqual(spanner._observabilityOptions, observabilityOptions);
 
@@ -534,23 +612,42 @@ describe('ObservabilityOptions injection and propagation', async () => {
       databaseByConstructor._observabilityOptions,
       observabilityOptions
     );
-
-    done();
   });
 
-  afterEach(async () => {
-    await injectedTracerProvider.forceFlush();
-    injectedTraceExporter.reset();
-  });
+  describe('Transaction', async () => {
+    const traceExporter = new InMemorySpanExporter();
+    const tracerProvider = new NodeTracerProvider({
+      sampler: new AlwaysOnSampler(),
+      exporter: traceExporter,
+    });
+    tracerProvider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
 
-  let database: Database;
-  beforeEach(() => {
-    const instance = spanner.instance('instance');
-    database = instance.database('db');
-  });
+    const observabilityOptions: typeof ObservabilityOptions = {
+      tracerProvider: tracerProvider,
+      enableExtendedTracing: true,
+    };
+    const setupResult = await setup(observabilityOptions);
+    const spanner = setupResult.spanner;
+    const server = setupResult.server;
+    const spannerMock = setupResult.spannerMock;
 
-  describe('Transaction', () => {
-    const traceExporter = injectedTraceExporter;
+    after(async () => {
+      traceExporter.reset();
+      await tracerProvider.shutdown();
+      spannerMock.resetRequests();
+      spanner.close();
+      server.tryShutdown(() => {});
+    });
+
+    let database: Database;
+    beforeEach(() => {
+      const instance = spanner.instance('instance');
+      database = instance.database('database');
+    });
+
+    afterEach(() => {
+      spannerMock.resetRequests();
+    });
 
     it('run', done => {
       database.getTransaction((err, tx) => {
@@ -571,6 +668,8 @@ describe('ObservabilityOptions injection and propagation', async () => {
           });
 
           const expectedSpanNames = [
+            'CloudSpanner.Database.batchCreateSessions',
+            'CloudSpanner.SessionPool.createSessions',
             'CloudSpanner.Database.getTransaction',
             'CloudSpanner.Snapshot.runStream',
             'CloudSpanner.Snapshot.run',
@@ -680,6 +779,10 @@ describe('ObservabilityOptions injection and propagation', async () => {
             });
 
             const expectedSpanNames = [
+              'CloudSpanner.Snapshot.begin',
+              'CloudSpanner.Snapshot.runStream',
+              'CloudSpanner.Snapshot.run',
+              'CloudSpanner.Dml.runUpdate',
               'CloudSpanner.Database.getTransaction',
               'CloudSpanner.Snapshot.runStream',
             ];
@@ -689,7 +792,14 @@ describe('ObservabilityOptions injection and propagation', async () => {
               `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
             );
 
-            const expectedEventNames = ['Using Session'];
+            const expectedEventNames = [
+              'Begin Transaction',
+              'Transaction Creation Done',
+              'Acquiring session',
+              'Cache hit: has usable session',
+              'Acquired session',
+              'Using Session',
+            ];
             assert.deepStrictEqual(
               actualEventNames,
               expectedEventNames,
@@ -758,7 +868,43 @@ describe('ObservabilityOptions injection and propagation', async () => {
     });
   });
 
-  it('Propagates spans to the injected not global TracerProvider', done => {
+  it('Propagates spans to the injected not global TracerProvider', async () => {
+    const globalTraceExporter = new InMemorySpanExporter();
+    const globalTracerProvider = new NodeTracerProvider({
+      sampler: new AlwaysOnSampler(),
+      exporter: globalTraceExporter,
+    });
+    globalTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(globalTraceExporter)
+    );
+    globalTracerProvider.register();
+
+    const injectedTraceExporter = new InMemorySpanExporter();
+    const injectedTracerProvider = new NodeTracerProvider({
+      sampler: new AlwaysOnSampler(),
+      exporter: injectedTraceExporter,
+    });
+    injectedTracerProvider.addSpanProcessor(
+      new SimpleSpanProcessor(injectedTraceExporter)
+    );
+
+    const observabilityOptions: typeof ObservabilityOptions = {
+      tracerProvider: injectedTracerProvider,
+      enableExtendedTracing: true,
+    };
+    const setupResult = await setup(observabilityOptions);
+    const spanner = setupResult.spanner;
+    const server = setupResult.server;
+    const spannerMock = setupResult.spannerMock;
+
+    after(async () => {
+      injectedTraceExporter.reset();
+      await injectedTracerProvider.shutdown();
+      spannerMock.resetRequests();
+      spanner.close();
+      server.tryShutdown(() => {});
+    });
+
     const instance = spanner.instance('instance');
     const database = instance.database('database');
 
@@ -794,6 +940,8 @@ describe('ObservabilityOptions injection and propagation', async () => {
       });
 
       const expectedSpanNames = [
+        'CloudSpanner.Database.batchCreateSessions',
+        'CloudSpanner.SessionPool.createSessions',
         'CloudSpanner.Snapshot.runStream',
         'CloudSpanner.Database.runStream',
         'CloudSpanner.Database.run',
@@ -805,6 +953,9 @@ describe('ObservabilityOptions injection and propagation', async () => {
       );
 
       const expectedEventNames = [
+        'Requesting 25 sessions',
+        'Creating 25 sessions',
+        'Requested for 25 sessions returned 25',
         'Acquiring session',
         'Waiting for a session to become available',
         'Acquired session',
@@ -815,8 +966,161 @@ describe('ObservabilityOptions injection and propagation', async () => {
         expectedEventNames,
         `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
       );
-
-      done();
     });
+  });
+});
+
+describe('Regression tests for fixed bugs', () => {
+  it('async/await correctly parents trace spans', async () => {
+    // See https://github.com/googleapis/nodejs-spanner/issues/2146.
+    const traceExporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider({
+      sampler: new AlwaysOnSampler(),
+      exporter: traceExporter,
+    });
+    provider.addSpanProcessor(new SimpleSpanProcessor(traceExporter));
+
+    const observabilityOptions: typeof ObservabilityOptions = {
+      tracerProvider: provider,
+      enableExtendedTracing: true,
+    };
+    const setupResult = await setup(observabilityOptions);
+    const spanner = setupResult.spanner;
+    const server = setupResult.server;
+    const spannerMock = setupResult.spannerMock;
+
+    after(async () => {
+      provider.shutdown();
+      spannerMock.resetRequests();
+      spanner.close();
+      server.tryShutdown(() => {});
+    });
+
+    async function main() {
+      const instance = spanner.instance('testing');
+      instance._observabilityOptions = observabilityOptions;
+      const database = instance.database('db-1');
+
+      const query = {
+        sql: selectSql,
+      };
+
+      const [rows] = await database.run(query);
+
+      rows.forEach(row => {
+        const json = row.toJSON();
+      });
+
+      provider.forceFlush();
+    }
+
+    await main();
+
+    traceExporter.forceFlush();
+    const spans = traceExporter.getFinishedSpans();
+
+    const actualSpanNames: string[] = [];
+    const actualEventNames: string[] = [];
+    spans.forEach(span => {
+      actualSpanNames.push(span.name);
+      span.events.forEach(event => {
+        actualEventNames.push(event.name);
+      });
+    });
+
+    const expectedSpanNames = [
+      'CloudSpanner.Database.batchCreateSessions',
+      'CloudSpanner.SessionPool.createSessions',
+      'CloudSpanner.Snapshot.runStream',
+      'CloudSpanner.Database.runStream',
+      'CloudSpanner.Database.run',
+    ];
+    assert.deepStrictEqual(
+      actualSpanNames,
+      expectedSpanNames,
+      `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+    );
+
+    // We need to ensure a strict relationship between the spans.
+    // runSpan -------------------|
+    //     |-runStream ----------|
+    const runStreamSpan = spans[spans.length - 2];
+    const runSpan = spans[spans.length - 1];
+    assert.ok(
+      runSpan.spanContext().traceId,
+      'Expected that runSpan has a defined traceId'
+    );
+    assert.ok(
+      runStreamSpan.spanContext().traceId,
+      'Expected that runStreamSpan has a defined traceId'
+    );
+    assert.deepStrictEqual(
+      runStreamSpan.parentSpanId,
+      runSpan.spanContext().spanId,
+      `Expected that runSpan(spanId=${runSpan.spanContext().spanId}) is the parent to runStreamSpan(parentSpanId=${runStreamSpan.parentSpanId})`
+    );
+    assert.deepStrictEqual(
+      runSpan.spanContext().traceId,
+      runStreamSpan.spanContext().traceId,
+      'Expected that both spans share a traceId'
+    );
+    assert.ok(
+      runStreamSpan.spanContext().spanId,
+      'Expected that runStreamSpan has a defined spanId'
+    );
+    assert.ok(
+      runSpan.spanContext().spanId,
+      'Expected that runSpan has a defined spanId'
+    );
+
+    const databaseBatchCreateSessionsSpan = spans[0];
+    assert.strictEqual(
+      databaseBatchCreateSessionsSpan.name,
+      'CloudSpanner.Database.batchCreateSessions'
+    );
+    const sessionPoolCreateSessionsSpan = spans[1];
+    assert.strictEqual(
+      sessionPoolCreateSessionsSpan.name,
+      'CloudSpanner.SessionPool.createSessions'
+    );
+    assert.ok(
+      sessionPoolCreateSessionsSpan.spanContext().traceId,
+      'Expecting a defined sessionPoolCreateSessions traceId'
+    );
+    assert.deepStrictEqual(
+      sessionPoolCreateSessionsSpan.spanContext().traceId,
+      databaseBatchCreateSessionsSpan.spanContext().traceId,
+      'Expected the same traceId'
+    );
+    assert.deepStrictEqual(
+      databaseBatchCreateSessionsSpan.parentSpanId,
+      sessionPoolCreateSessionsSpan.spanContext().spanId,
+      'Expected that sessionPool.createSessions is the parent to db.batchCreassionSessions'
+    );
+
+    // Assert that despite all being exported, SessionPool.createSessions
+    // is not in the same trace as runStream, createSessions is invoked at
+    // Spanner Client instantiation, thus before database.run is invoked.
+    assert.notEqual(
+      sessionPoolCreateSessionsSpan.spanContext().traceId,
+      runSpan.spanContext().traceId,
+      'Did not expect the same traceId'
+    );
+
+    // Finally check for the collective expected event names.
+    const expectedEventNames = [
+      'Requesting 25 sessions',
+      'Creating 25 sessions',
+      'Requested for 25 sessions returned 25',
+      'Acquiring session',
+      'Waiting for a session to become available',
+      'Acquired session',
+      'Using Session',
+    ];
+    assert.deepStrictEqual(
+      actualEventNames,
+      expectedEventNames,
+      `Unexpected events:\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
+    );
   });
 });

--- a/observability-test/transaction.ts
+++ b/observability-test/transaction.ts
@@ -178,7 +178,10 @@ describe('Transaction', () => {
             `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
           );
 
-          const expectedEventNames = ['Begin Transaction'];
+          const expectedEventNames = [
+            'Begin Transaction',
+            'Transaction Creation Done',
+          ];
           assert.deepStrictEqual(
             actualEventNames,
             expectedEventNames,

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@google-cloud/promisify": "^4.0.0",
     "@grpc/proto-loader": "^0.7.0",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.25.1",
     "@types/big.js": "^6.0.0",
     "@types/stack-trace": "0.0.33",
@@ -85,7 +86,6 @@
     "through2": "^4.0.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^1.25.1",
     "@opentelemetry/sdk-trace-base": "^1.26.0",
     "@opentelemetry/sdk-trace-node": "^1.26.0",
     "@types/concat-stream": "^2.0.0",

--- a/src/database.ts
+++ b/src/database.ts
@@ -464,6 +464,7 @@ class Database extends common.GrpcServiceObject {
       [CLOUD_RESOURCE_HEADER]: this.formattedName_,
     };
     this.request = instance.request;
+    this._observabilityOptions = instance._observabilityOptions;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.requestStream = instance.requestStream as any;
     this.pool_.on('error', this.emit.bind(this, 'error'));
@@ -472,7 +473,6 @@ class Database extends common.GrpcServiceObject {
       Object.assign({}, queryOptions),
       Database.getEnvironmentQueryOptions()
     );
-    this._observabilityOptions = instance._observabilityOptions;
   }
   /**
    * @typedef {array} SetDatabaseMetadataResponse

--- a/src/database.ts
+++ b/src/database.ts
@@ -682,8 +682,8 @@ class Database extends common.GrpcServiceObject {
       addLeaderAwareRoutingHeader(headers);
     }
 
-    const q = {opts: this._observabilityOptions};
-    startTrace('Database.batchCreateSessions', q, span => {
+    const traceConfig = {opts: this._observabilityOptions};
+    startTrace('Database.batchCreateSessions', traceConfig, span => {
       this.request<google.spanner.v1.IBatchCreateSessionsResponse>(
         {
           client: 'SpannerClient',

--- a/src/instance.ts
+++ b/src/instance.ts
@@ -1363,6 +1363,7 @@ class Instance extends common.GrpcServiceObject {
           databases = rowDatabases.map(database => {
             const databaseInstance = self.database(database.name!, {min: 0});
             databaseInstance.metadata = database;
+            databaseInstance._observabilityOptions = this._observabilityOptions;
             return databaseInstance;
           });
         }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -111,9 +111,6 @@ function ensureInitialContextManagerSet() {
     // If no active context was set previously, trace context propagation cannot
     // function correctly with async/await for OpenTelemetry
     // See {@link https://opentelemetry.io/docs/languages/js/context/#active-context}
-    // but we shouldn't make our customers have to invasively edit their code
-    // nor should they be burdened about these facts, their code should JUST work.
-    // Please see https://github.com/googleapis/nodejs-spanner/issues/2146
     context.disable(); // Disable any prior contextManager.
     const contextManager = new AsyncHooksContextManager();
     contextManager.enable();

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -109,12 +109,12 @@ const {
 function ensureInitialContextManagerSet() {
   if (context.active() === ROOT_CONTEXT) {
     // If no active context was set previously, trace context propagation cannot
-    // function correctly with async/await for OpenTelemetry and they acknowledge
-    // this fact per https://opentelemetry.io/docs/languages/js/context/#active-context
+    // function correctly with async/await for OpenTelemetry
+    // See {@link https://opentelemetry.io/docs/languages/js/context/#active-context}
     // but we shouldn't make our customers have to invasively edit their code
     // nor should they be burdened about these facts, their code should JUST work.
     // Please see https://github.com/googleapis/nodejs-spanner/issues/2146
-    context.disable(); // Firstly disable any prior contextManager.
+    context.disable(); // Disable any prior contextManager.
     const contextManager = new AsyncHooksContextManager();
     contextManager.enable();
     context.setGlobalContextManager(contextManager);

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -789,6 +789,7 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
             `Requested for ${nRequested} sessions returned ${nReturned}`
           );
           setSpanErrorAndException(span, e as Error);
+          span.end();
           throw e;
         }
 

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -762,8 +762,8 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
       this.database._observabilityOptions = this._observabilityOptions;
     }
 
-    const q = {opts: this._observabilityOptions};
-    return startTrace('SessionPool.createSessions', q, async span => {
+    const traceConfig = {opts: this._observabilityOptions};
+    return startTrace('SessionPool.createSessions', traceConfig, async span => {
       span.addEvent(`Requesting ${amount} sessions`);
 
       // while we can request as many sessions be created as we want, the backend

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -491,9 +491,7 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
     });
 
     this._traces = new Map();
-    if (!this._observabilityOptions) {
-      this._observabilityOptions = database._observabilityOptions;
-    }
+    this._observabilityOptions = database._observabilityOptions;
   }
 
   /**
@@ -757,10 +755,6 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
 
     let nReturned = 0;
     const nRequested: number = amount;
-
-    if (!this.database._observabilityOptions) {
-      this.database._observabilityOptions = this._observabilityOptions;
-    }
 
     const traceConfig = {opts: this._observabilityOptions};
     return startTrace('SessionPool.createSessions', traceConfig, async span => {

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -24,7 +24,12 @@ import {Transaction} from './transaction';
 import {NormalCallback} from './common';
 import {GoogleError, grpc, ServiceError} from 'google-gax';
 import trace = require('stack-trace');
-import {getActiveOrNoopSpan} from './instrument';
+import {
+  ObservabilityOptions,
+  getActiveOrNoopSpan,
+  setSpanErrorAndException,
+  startTrace,
+} from './instrument';
 
 /**
  * @callback SessionPoolCloseCallback
@@ -353,6 +358,7 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
   _pingHandle!: NodeJS.Timer;
   _requests: PQueue;
   _traces: Map<string, trace.StackFrame[]>;
+  _observabilityOptions?: ObservabilityOptions;
 
   /**
    * Formats stack trace objects into Node-like stack trace.
@@ -485,6 +491,9 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
     });
 
     this._traces = new Map();
+    if (!this._observabilityOptions) {
+      this._observabilityOptions = database._observabilityOptions;
+    }
   }
 
   /**
@@ -738,9 +747,6 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
    * @emits SessionPool#createError
    */
   async _createSessions(amount: number): Promise<void> {
-    const span = getActiveOrNoopSpan();
-    span.addEvent(`Requesting ${amount} sessions`);
-
     const labels = this.options.labels!;
     const databaseRole = this.options.databaseRole!;
 
@@ -752,41 +758,54 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
     let nReturned = 0;
     const nRequested: number = amount;
 
-    // while we can request as many sessions be created as we want, the backend
-    // will return at most 100 at a time, hence the need for a while loop.
-    while (amount > 0) {
-      let sessions: Session[] | null = null;
-
-      span.addEvent(`Creating ${amount} sessions`);
-
-      try {
-        [sessions] = await this.database.batchCreateSessions({
-          count: amount,
-          labels: labels,
-          databaseRole: databaseRole,
-        });
-
-        amount -= sessions.length;
-        nReturned += sessions.length;
-      } catch (e) {
-        this._pending -= amount;
-        this.emit('createError', e);
-        span.addEvent(
-          `Requested for ${nRequested} sessions returned ${nReturned}`
-        );
-        throw e;
-      }
-
-      sessions.forEach((session: Session) => {
-        setImmediate(() => {
-          this._inventory.borrowed.add(session);
-          this._pending -= 1;
-          this.release(session);
-        });
-      });
+    if (!this.database._observabilityOptions) {
+      this.database._observabilityOptions = this._observabilityOptions;
     }
 
-    span.addEvent(`Requested for ${nRequested} sessions returned ${nReturned}`);
+    const q = {opts: this._observabilityOptions};
+    return startTrace('SessionPool.createSessions', q, async span => {
+      span.addEvent(`Requesting ${amount} sessions`);
+
+      // while we can request as many sessions be created as we want, the backend
+      // will return at most 100 at a time, hence the need for a while loop.
+      while (amount > 0) {
+        let sessions: Session[] | null = null;
+
+        span.addEvent(`Creating ${amount} sessions`);
+
+        try {
+          [sessions] = await this.database.batchCreateSessions({
+            count: amount,
+            labels: labels,
+            databaseRole: databaseRole,
+          });
+
+          amount -= sessions.length;
+          nReturned += sessions.length;
+        } catch (e) {
+          this._pending -= amount;
+          this.emit('createError', e);
+          span.addEvent(
+            `Requested for ${nRequested} sessions returned ${nReturned}`
+          );
+          setSpanErrorAndException(span, e as Error);
+          throw e;
+        }
+
+        sessions.forEach((session: Session) => {
+          setImmediate(() => {
+            this._inventory.borrowed.add(session);
+            this._pending -= 1;
+            this.release(session);
+          });
+        });
+      }
+
+      span.addEvent(
+        `Requested for ${nRequested} sessions returned ${nReturned}`
+      );
+      span.end();
+    });
   }
 
   /**

--- a/src/table.ts
+++ b/src/table.ts
@@ -1082,6 +1082,7 @@ class Table {
   ): void {
     const traceConfig: traceConfig = {
       opts: this._observabilityOptions,
+      tableName: this.name,
     };
 
     startTrace('Table.' + method, traceConfig, span => {

--- a/test/spanner.ts
+++ b/test/spanner.ts
@@ -4999,7 +4999,7 @@ describe('Spanner with mock server', () => {
   // and tests the database/instance suffix is an iteration of
   // each afresh invocation of newTestDatabase, which has been
   // causing test flakes.
-  it('Check for span annotations', () => {
+  it('Check for span annotations', done => {
     const exporter = new InMemorySpanExporter();
     const provider = new NodeTracerProvider({
       sampler: new AlwaysOnSampler(),
@@ -5013,45 +5013,68 @@ describe('Spanner with mock server', () => {
     });
 
     const opts: typeof ObservabilityOptions = {tracerProvider: provider};
-    startTrace('aSpan', {opts: opts}, span => {
+    startTrace('aSpan', {opts: opts}, async span => {
+      instance._observabilityOptions = opts;
       const database = newTestDatabase();
       database._observabilityOptions = opts;
 
-      async function runIt() {
-        const query = {
-          sql: 'SELECT 1',
-        };
+      const query = {
+        sql: 'SELECT 1',
+      };
 
-        const [rows] = await database.run(query);
-        assert.strictEqual(rows.length, 1);
-      }
-
-      runIt();
+      const [rows] = await database.run(query);
+      assert.strictEqual(rows.length, 1);
 
       span.end();
 
+      exporter.forceFlush();
       const spans = exporter.getFinishedSpans();
-      assert.strictEqual(spans.length, 1, 'Exactly 1 span');
-      const span0 = spans[0];
-      const events = span0.events;
 
-      // Sort the events by earliest time of occurence.
-      events.sort((evtA, evtB) => {
-        return evtA.time < evtB.time;
+      // Sort the spans by startTime.
+      spans.sort((spanA, spanB) => {
+        spanA.startTime < spanB.startTime;
       });
 
-      const gotEventNames: string[] = [];
-      events.forEach(event => {
-        gotEventNames.push(event.name);
+      const actualSpanNames: string[] = [];
+      const actualEventNames: string[] = [];
+      spans.forEach(span => {
+        actualSpanNames.push(span.name);
+        span.events.forEach(event => {
+          actualEventNames.push(event.name);
+        });
       });
 
-      const wantEventNames = ['Requesting 25 sessions', 'Creating 25 sessions'];
+      const expectedSpanNames = [
+        'CloudSpanner.Database.batchCreateSessions',
+        'CloudSpanner.SessionPool.createSessions',
+        'CloudSpanner.Snapshot.runStream',
+        'CloudSpanner.Database.runStream',
+        'CloudSpanner.Database.run',
+        'CloudSpanner.aSpan',
+      ];
+      assert.deepStrictEqual(
+        actualSpanNames,
+        expectedSpanNames,
+        `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+      );
+
+      const expectedEventNames = [
+        'Requesting 25 sessions',
+        'Creating 25 sessions',
+        'Requested for 25 sessions returned 25',
+        'Acquiring session',
+        'Waiting for a session to become available',
+        'Acquired session',
+        'Using Session',
+      ];
 
       assert.deepEqual(
-        gotEventNames,
-        wantEventNames,
-        `Mismatched events\n\tGot:  ${gotEventNames}\n\tWant: ${wantEventNames}`
+        actualEventNames,
+        expectedEventNames,
+        `Mismatched events\n\tGot:  ${actualEventNames}\n\tWant: ${expectedEventNames}`
       );
+
+      done();
     });
   });
 });


### PR DESCRIPTION
This change adds tracing for Database.batchCreateSessions
as well as SessionPool.createSessions which was raised
as a big need.
This change is a premise to finishing up tracing Transaction.

While here, also folded in the async/await fix to avoid day+ long
code review lag and then 3+ hours just to run tests per PR:
OpenTelemetry cannot work correctly for async/await if there isn't
a set AsyncHooksManager, but we should not burden our customers with
this type of specialist knowledge, their code should just work and
this change performs such a check. Later on we shall file a feature
request with the OpenTelemetry-JS API group to give us a hook to detect
if we've got a live asyncHooksManager instead of this mandatory
comparison to ROOT_CONTEXT each time.

Fixes #2146
Updates #2079
Spun out of PR #2122
Supersedes PR #2147
