### PR TITLE
fix: (observability) make async/await correctly work by setting initial AsyncHooksManager

### DIFF
--- a/observability-test/spanner.ts
+++ b/observability-test/spanner.ts
@@ -617,8 +617,9 @@ describe('ObservabilityOptions injection and propagation', async () => {
   });
 });
 
-describe('Bug fixes', () => {
+describe('Regression tests for fixed bugs', () => {
   it('async/await correctly parents trace spans', async () => {
+    // See https://github.com/googleapis/nodejs-spanner/issues/2146.
     const traceExporter = new InMemorySpanExporter();
     const provider = new NodeTracerProvider({
       sampler: new AlwaysOnSampler(),

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -100,14 +100,16 @@ const {
 } = require('@opentelemetry/context-async-hooks');
 
 /*
- * This function ensures that async/await functions correctly by
+ * This function ensures that async/await works correctly by
  * checking if context.active() returns an invalid/unset context
- * and if so, sets a global AsyncHooksContextManager.
+ * and if so, sets a global AsyncHooksContextManager otherwise
+ * spans resulting from async/await invocations won't be correctly
+ * associated in their respective hierarchies.
  */
 function ensureInitialContextManagerSet() {
   if (context.active() === ROOT_CONTEXT) {
     // If no active context was set previously, trace context propagation cannot
-    // work correctly with async/await for OpenTelemetry and they acknowledge
+    // function correctly with async/await for OpenTelemetry and they acknowledge
     // this fact per https://opentelemetry.io/docs/languages/js/context/#active-context
     // but we shouldn't make our customers have to invasively edit their code
     // nor should they be burdened about these facts, their code should JUST work.


### PR DESCRIPTION
OpenTelemetry cannot work correctly for async/await if there isn't a set AsyncHooksManager, but we should not burden our customers with this type of specialist knowledge, their code should just work and this change performs such a check. Later on we shall file a feature request with the OpenTelemetry-JS API group to give us a hook to detect if we've got a live asyncHooksManager instead of this mandatory comparison to ROOT_CONTEXT each time.

Fixes #2146