### PR TITLE
feat: (observability) propagate database name for every span generated to aid in quick debugging

### DIFF
--- a/observability-test/database.ts
+++ b/observability-test/database.ts
@@ -39,6 +39,7 @@ import {Instance, Spanner} from '../src';
 import * as pfy from '@google-cloud/promisify';
 import {grpc} from 'google-gax';
 import {MockError} from '../test/mockserver/mockspanner';
+const {generateWithAllSpansHaveDBName} = require('./helper');
 
 const fakePfy = extend({}, pfy, {
   promisifyAll(klass, options) {
@@ -235,16 +236,20 @@ describe('Database', () => {
     DatabaseCached = Object.assign({}, Database);
   });
 
+  const withAllSpansHaveDBName = generateWithAllSpansHaveDBName(
+    INSTANCE.formattedName_ + '/databases/' + NAME
+  );
+
   beforeEach(() => {
     fakeCodec.encode = util.noop;
     extend(Database, DatabaseCached);
-    database = new Database(INSTANCE, NAME, POOL_OPTIONS);
-    database.parent = INSTANCE;
-    database.databaseRole = 'parent_role';
-    database._observabilityOptions = {
+    INSTANCE._observabilityOptions = {
       tracerProvider: provider,
       enableExtendedTracing: false,
     };
+    database = new Database(INSTANCE, NAME, POOL_OPTIONS);
+    database.parent = INSTANCE;
+    database.databaseRole = 'parent_role';
     const gaxOpts = {};
     const options: {
       a: string;
@@ -284,6 +289,8 @@ describe('Database', () => {
       traceExporter.forceFlush();
       const spans = traceExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+
+      withAllSpansHaveDBName(spans);
 
       const actualSpanNames: string[] = [];
       const actualEventNames: string[] = [];
@@ -333,6 +340,7 @@ describe('Database', () => {
       traceExporter.forceFlush();
       const spans = traceExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+      withAllSpansHaveDBName(spans);
 
       const actualSpanNames: string[] = [];
       const actualEventNames: string[] = [];
@@ -523,6 +531,7 @@ describe('Database', () => {
         traceExporter.forceFlush();
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
 
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
@@ -604,6 +613,7 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 2, 'Exactly 2 spans expected');
+        withAllSpansHaveDBName(spans);
 
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
@@ -706,6 +716,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
         spans.forEach(span => {
@@ -771,6 +783,7 @@ describe('Database', () => {
         assert.strictEqual(resp, RESPONSE);
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
 
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
@@ -836,6 +849,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
         spans.forEach(span => {
@@ -911,6 +926,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
         spans.forEach(span => {
@@ -958,6 +975,8 @@ describe('Database', () => {
         assert.strictEqual(transaction, fakeTransaction);
 
         const spans = traceExporter.getFinishedSpans();
+        withAllSpansHaveDBName(spans);
+
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
@@ -1037,6 +1056,7 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
 
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
@@ -1091,6 +1111,7 @@ describe('Database', () => {
 
           const spans = traceExporter.getFinishedSpans();
           assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+          withAllSpansHaveDBName(spans);
 
           const actualEventNames: string[] = [];
           const actualSpanNames: string[] = [];
@@ -1148,6 +1169,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
         spans.forEach(span => {
@@ -1222,6 +1245,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
         spans.forEach(span => {
@@ -1273,6 +1298,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualSpanNames: string[] = [];
         const actualEventNames: string[] = [];
         spans.forEach(span => {
@@ -1376,6 +1403,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
         spans.forEach(span => {
@@ -1427,6 +1456,8 @@ describe('Database', () => {
 
         const spans = traceExporter.getFinishedSpans();
         assert.strictEqual(spans.length, 1, 'Exactly 1 span expected');
+        withAllSpansHaveDBName(spans);
+
         const actualEventNames: string[] = [];
         const actualSpanNames: string[] = [];
         spans.forEach(span => {
@@ -1491,6 +1522,8 @@ describe('Database', () => {
 
           const spans = traceExporter.getFinishedSpans();
           assert.strictEqual(spans.length, 2, 'Exactly 1 span expected');
+          withAllSpansHaveDBName(spans);
+
           const actualSpanNames: string[] = [];
           const actualEventNames: string[] = [];
           spans.forEach(span => {

--- a/observability-test/helper.ts
+++ b/observability-test/helper.ts
@@ -15,6 +15,9 @@
  */
 
 import {ContextManager, context} from '@opentelemetry/api';
+import * as assert from 'assert';
+const {ReadableSpan} = require('@opentelemetry/sdk-trace-base');
+import {SEMATTRS_DB_NAME} from '@opentelemetry/semantic-conventions';
 
 /**
  * This utility exists as a test helper because mocha has builtin "context"
@@ -31,4 +34,16 @@ export function setGlobalContextManager(manager: ContextManager) {
 export function disableContextAndManager(manager: ContextManager) {
   manager.disable();
   context.disable();
+}
+
+export function generateWithAllSpansHaveDBName(dbName: String): Function {
+  return function (spans: (typeof ReadableSpan)[]) {
+    spans.forEach(span => {
+      assert.deepStrictEqual(
+        span.attributes[SEMATTRS_DB_NAME],
+        dbName,
+        `Span ${span.name} has mismatched DB_NAME`
+      );
+    });
+  };
 }

--- a/observability-test/table.ts
+++ b/observability-test/table.ts
@@ -31,6 +31,7 @@ import {SpanStatusCode} from '@opentelemetry/api';
 
 // eslint-disable-next-line n/no-extraneous-require
 const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
+const {generateWithAllSpansHaveDBName} = require('./helper');
 
 const fakePfy = extend({}, pfy, {
   promisifyAll(klass, options) {
@@ -67,6 +68,7 @@ describe('Table', () => {
   let transaction: FakeTransaction;
 
   const DATABASE = {
+    formattedName_: 'formatted-db-name',
     runTransaction: (opts, callback) => callback(null, transaction),
     getSnapshot: (options, callback) => callback(null, transaction),
   };
@@ -99,6 +101,10 @@ describe('Table', () => {
     sandbox.restore();
     traceExporter.reset();
   });
+
+  const withAllSpansHaveDBName = generateWithAllSpansHaveDBName(
+    DATABASE.formattedName_
+  );
 
   function getExportedSpans(minCount: number) {
     traceExporter.forceFlush();
@@ -215,7 +221,10 @@ describe('Table', () => {
       assert.ifError(err);
       assert.strictEqual(stub.callCount, 1);
 
-      const actualSpanNames = spanNames(getExportedSpans(1));
+      const gotSpans = getExportedSpans(1);
+      withAllSpansHaveDBName(gotSpans);
+
+      const actualSpanNames = spanNames(gotSpans);
       const expectedSpanNames = ['CloudSpanner.Table.upsert'];
 
       assert.deepStrictEqual(
@@ -238,6 +247,8 @@ describe('Table', () => {
       assert.strictEqual(err, fakeError);
 
       const gotSpans = getExportedSpans(1);
+      withAllSpansHaveDBName(gotSpans);
+
       const gotSpanStatus = gotSpans[0].status;
       const wantSpanStatus = {
         code: SpanStatusCode.ERROR,
@@ -270,7 +281,10 @@ describe('Table', () => {
       assert.ifError(err);
       assert.strictEqual(stub.callCount, 1);
 
-      const actualSpanNames = spanNames(getExportedSpans(1));
+      const gotSpans = getExportedSpans(1);
+      withAllSpansHaveDBName(gotSpans);
+
+      const actualSpanNames = spanNames(gotSpans);
       const expectedSpanNames = ['CloudSpanner.Table.replace'];
       assert.deepStrictEqual(
         actualSpanNames,
@@ -301,6 +315,8 @@ describe('Table', () => {
         wantSpanStatus,
         `mismatch in span status:\n\tGot:  ${JSON.stringify(gotSpanStatus)}\n\tWant: ${JSON.stringify(wantSpanStatus)}`
       );
+
+      withAllSpansHaveDBName(gotSpans);
 
       const actualSpanNames = spanNames(gotSpans);
       const expectedSpanNames = ['CloudSpanner.Table.replace'];

--- a/observability-test/transaction.ts
+++ b/observability-test/transaction.ts
@@ -32,6 +32,7 @@ const {
   ReadableSpan,
   SimpleSpanProcessor,
 } = require('@opentelemetry/sdk-trace-base');
+const {generateWithAllSpansHaveDBName} = require('./helper');
 
 describe('Transaction', () => {
   const sandbox = sinon.createSandbox();
@@ -53,6 +54,10 @@ describe('Transaction', () => {
     formattedName_: 'formatted-database-name',
     parent: INSTANCE,
   };
+
+  const withAllSpansHaveDBName = generateWithAllSpansHaveDBName(
+    DATABASE.formattedName_
+  );
 
   const SESSION = {
     parent: DATABASE,
@@ -723,6 +728,7 @@ describe('Transaction', () => {
 
         // Ensure that the final span that got retries did not error.
         const spans = exportResults.spans;
+
         const firstSpan = spans[0];
         assert.strictEqual(
           SpanStatusCode.ERROR,
@@ -734,6 +740,8 @@ describe('Transaction', () => {
           firstSpan.status.message,
           'Unexpected span status message'
         );
+
+        withAllSpansHaveDBName(spans);
       });
     });
   });

--- a/src/batch-transaction.ts
+++ b/src/batch-transaction.ts
@@ -140,6 +140,7 @@ class BatchTransaction extends Snapshot {
     const traceConfig: traceConfig = {
       sql: query,
       opts: this._observabilityOptions,
+      dbName: this.getDBName(),
     };
     return startTrace(
       'BatchTransaction.createQueryPartitions',
@@ -170,6 +171,11 @@ class BatchTransaction extends Snapshot {
       }
     );
   }
+
+  protected getDBName(): string {
+    return (this.session.parent as Database).formattedName_;
+  }
+
   /**
    * Generic create partition method. Handles common parameters used in both
    * {@link BatchTransaction#createQueryPartitions} and {@link
@@ -183,6 +189,7 @@ class BatchTransaction extends Snapshot {
   createPartitions_(config, callback) {
     const traceConfig: traceConfig = {
       opts: this._observabilityOptions,
+      dbName: this.getDBName(),
     };
 
     return startTrace(
@@ -260,6 +267,7 @@ class BatchTransaction extends Snapshot {
   createReadPartitions(options, callback) {
     const traceConfig: traceConfig = {
       opts: this._observabilityOptions,
+      dbName: this.getDBName(),
     };
 
     return startTrace(

--- a/src/session-pool.ts
+++ b/src/session-pool.ts
@@ -756,7 +756,12 @@ export class SessionPool extends EventEmitter implements SessionPoolInterface {
     let nReturned = 0;
     const nRequested: number = amount;
 
-    const traceConfig = {opts: this._observabilityOptions};
+    // TODO: Inlining this code for now and later on shall go
+    // extract _traceConfig to the constructor when we have plenty of time.
+    const traceConfig = {
+      opts: this._observabilityOptions,
+      dbName: this.database.formattedName_,
+    };
     return startTrace('SessionPool.createSessions', traceConfig, async span => {
       span.addEvent(`Requesting ${amount} sessions`);
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -191,6 +191,11 @@ class Table {
 
     this.database.createTable(schema, gaxOptions, callback!);
   }
+
+  protected getDBName(): string {
+    return this.database.formattedName_;
+  }
+
   /**
    * Create a readable object stream to receive rows from the database using key
    * lookups and scans.
@@ -1083,6 +1088,7 @@ class Table {
     const traceConfig: traceConfig = {
       opts: this._observabilityOptions,
       tableName: this.name,
+      dbName: this.getDBName(),
     };
 
     startTrace('Table.' + method, traceConfig, span => {


### PR DESCRIPTION
With this change customers shall always be able to identify which database is being connected to.

Updates #2079

## Exhibit
<img width="1581" alt="Screenshot 2024-10-08 at 10 52 56 PM" src="https://github.com/user-attachments/assets/8a4bcb5d-b346-4faf-823a-34d87e4b6ef5">