### PR TITLE
feat(observability): trace Database.batchWriteAtLeastOnce

### DIFF
--- a/observability-test/database.ts
+++ b/observability-test/database.ts
@@ -21,7 +21,12 @@ import {EventEmitter} from 'events';
 import * as assert from 'assert';
 import * as extend from 'extend';
 import {google} from '../protos/protos';
-import {CommitCallback, CommitOptions, MutationSet} from '../src/transaction';
+import {
+  BatchWriteOptions,
+  CommitCallback,
+  CommitOptions,
+  MutationSet,
+} from '../src/transaction';
 import {util} from '@google-cloud/common';
 import {Transform} from 'stream';
 import * as proxyquire from 'proxyquire';
@@ -35,7 +40,7 @@ const {
 // eslint-disable-next-line n/no-extraneous-require
 const {SimpleSpanProcessor} = require('@opentelemetry/sdk-trace-base');
 import * as db from '../src/database';
-import {Instance, Spanner} from '../src';
+import {Instance, MutationGroup, Spanner} from '../src';
 import * as pfy from '@google-cloud/promisify';
 import {grpc} from 'google-gax';
 import {MockError} from '../test/mockserver/mockspanner';
@@ -1212,6 +1217,224 @@ describe('Database', () => {
 
         done();
       }
+    });
+  });
+
+  describe('batchWriteAtLeastOnce', () => {
+    const mutationGroup1 = new MutationGroup();
+    mutationGroup1.insert('MyTable', {
+      Key: 'ks1',
+      Thing: 'abc',
+    });
+    const mutationGroup2 = new MutationGroup();
+    mutationGroup2.insert('MyTable', {
+      Key: 'ks2',
+      Thing: 'xyz',
+    });
+
+    const mutationGroups = [mutationGroup1, mutationGroup2];
+
+    let fakePool: FakeSessionPool;
+    let fakeSession: FakeSession;
+    let fakeDataStream: Transform;
+    let getSessionStub: sinon.SinonStub;
+    let requestStreamStub: sinon.SinonStub;
+
+    const options = {
+      requestOptions: {
+        transactionTag: 'batch-write-tag',
+      },
+      excludeTxnFromChangeStream: true,
+      gaxOptions: {autoPaginate: false},
+    } as BatchWriteOptions;
+
+    beforeEach(() => {
+      fakePool = database.pool_;
+      fakeSession = new FakeSession();
+      fakeDataStream = through.obj();
+
+      getSessionStub = (
+        sandbox.stub(fakePool, 'getSession') as sinon.SinonStub
+      ).callsFake(callback => callback(null, fakeSession));
+
+      requestStreamStub = sandbox
+        .stub(database, 'requestStream')
+        .returns(fakeDataStream);
+    });
+
+    it('on retry with "Session not found" error', done => {
+      const sessionNotFoundError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as grpc.ServiceError;
+      let retryCount = 0;
+
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('data', () => {})
+        .on('error', err => {
+          assert.fail(err);
+        })
+        .on('end', () => {
+          assert.strictEqual(retryCount, 1);
+
+          const spans = traceExporter.getFinishedSpans();
+          withAllSpansHaveDBName(spans);
+
+          const actualSpanNames: string[] = [];
+          const actualEventNames: string[] = [];
+          spans.forEach(span => {
+            actualSpanNames.push(span.name);
+            span.events.forEach(event => {
+              actualEventNames.push(event.name);
+            });
+          });
+
+          const expectedSpanNames = [
+            'CloudSpanner.Database.batchWriteAtLeastOnce',
+            'CloudSpanner.Database.batchWriteAtLeastOnce',
+          ];
+          assert.deepStrictEqual(
+            actualSpanNames,
+            expectedSpanNames,
+            `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+          );
+
+          // Ensure that the span actually produced an error that was recorded.
+          const firstSpan = spans[0];
+          assert.strictEqual(
+            SpanStatusCode.ERROR,
+            firstSpan.status.code,
+            'Expected an ERROR span status'
+          );
+
+          const errorMessage = firstSpan.status.message;
+          assert.deepStrictEqual(
+            firstSpan.status.message,
+            sessionNotFoundError.message
+          );
+
+          // The last span should not have an error status.
+          const lastSpan = spans[spans.length - 1];
+          assert.strictEqual(
+            SpanStatusCode.UNSET,
+            lastSpan.status.code,
+            'Unexpected span status'
+          );
+
+          assert.deepStrictEqual(lastSpan.status.message, undefined);
+
+          const expectedEventNames = [
+            'Using Session',
+            'No session available',
+            'Using Session',
+          ];
+          assert.deepStrictEqual(actualEventNames, expectedEventNames);
+
+          done();
+        });
+
+      fakeDataStream.emit('error', sessionNotFoundError);
+      retryCount++;
+    });
+
+    it('on getSession errors', done => {
+      const fakeError = new Error('err');
+
+      getSessionStub.callsFake(callback => callback(fakeError));
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('error', err => {
+          assert.strictEqual(err, fakeError);
+
+          const spans = traceExporter.getFinishedSpans();
+          withAllSpansHaveDBName(spans);
+
+          const actualSpanNames: string[] = [];
+          const actualEventNames: string[] = [];
+          spans.forEach(span => {
+            actualSpanNames.push(span.name);
+            span.events.forEach(event => {
+              actualEventNames.push(event.name);
+            });
+          });
+
+          const expectedSpanNames = [
+            'CloudSpanner.Database.batchWriteAtLeastOnce',
+          ];
+          assert.deepStrictEqual(
+            actualSpanNames,
+            expectedSpanNames,
+            `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+          );
+
+          // Ensure that the span actually produced an error that was recorded.
+          const firstSpan = spans[0];
+          assert.strictEqual(
+            SpanStatusCode.ERROR,
+            firstSpan.status.code,
+            'Expected an ERROR span status'
+          );
+
+          assert.deepStrictEqual(firstSpan.status.message, fakeError.message);
+
+          const expectedEventNames = [];
+          assert.deepStrictEqual(expectedEventNames, actualEventNames);
+
+          done();
+        });
+    });
+
+    it('with no errors', done => {
+      getSessionStub.callsFake(callback => callback(null, {}));
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('data', () => {})
+        .on('error', assert.ifError)
+        .on('end', () => {
+          const spans = traceExporter.getFinishedSpans();
+          withAllSpansHaveDBName(spans);
+
+          const actualSpanNames: string[] = [];
+          const actualEventNames: string[] = [];
+          spans.forEach(span => {
+            actualSpanNames.push(span.name);
+            span.events.forEach(event => {
+              actualEventNames.push(event.name);
+            });
+          });
+
+          const expectedSpanNames = [
+            'CloudSpanner.Database.batchWriteAtLeastOnce',
+          ];
+          assert.deepStrictEqual(
+            actualSpanNames,
+            expectedSpanNames,
+            `span names mismatch:\n\tGot:  ${actualSpanNames}\n\tWant: ${expectedSpanNames}`
+          );
+
+          // Ensure that the span actually produced an error that was recorded.
+          const firstSpan = spans[0];
+          assert.strictEqual(
+            SpanStatusCode.UNSET,
+            firstSpan.status.code,
+            'Unexpected span status code'
+          );
+
+          assert.strictEqual(
+            undefined,
+            firstSpan.status.message,
+            'Unexpected span status message'
+          );
+
+          const expectedEventNames = ['Using Session'];
+          assert.deepStrictEqual(actualEventNames, expectedEventNames);
+
+          done();
+        });
+
+      fakeDataStream.emit('data', 'response');
+      fakeDataStream.end('end');
     });
   });
 


### PR DESCRIPTION
This change traces Database.batchWriteAtLeastOnce. Sadly though MockSpanner doesn't yet support batch writes hence no end-to-end test with it.

Updates #2079