### PR TITLE
chore: enable float32 support in node client

### DIFF
--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -367,7 +367,6 @@ describe('Spanner', () => {
       googleSqlTable = DATABASE.table(TABLE_NAME);
       postgreSqlTable = PG_DATABASE.table(TABLE_NAME);
       if (IS_EMULATOR_ENABLED) {
-        // TODO: add column Float32Value FLOAT32 and FLOAT32Array Array<FLOAT32> while using float32 feature.
         const [googleSqlOperationUpdateDDL] = await DATABASE.updateSchema(
           `
               CREATE TABLE ${TABLE_NAME}
@@ -376,6 +375,7 @@ describe('Spanner', () => {
                 BytesValue      BYTES( MAX),
                 BoolValue       BOOL,
                 DateValue       DATE,
+                Float32Value    FLOAT32,
                 FloatValue      FLOAT64,
                 IntValue        INT64,
                 NumericValue    NUMERIC,
@@ -384,6 +384,7 @@ describe('Spanner', () => {
                 BytesArray      ARRAY<BYTES(MAX)>,
                 BoolArray       ARRAY<BOOL>,
                 DateArray       ARRAY< DATE >,
+                Float32Array    ARRAY<FLOAT32>,
                 FloatArray      ARRAY<FLOAT64>,
                 IntArray        ARRAY<INT64>,
                 NumericArray    ARRAY< NUMERIC >,
@@ -394,7 +395,6 @@ describe('Spanner', () => {
             `
         );
         await googleSqlOperationUpdateDDL.promise();
-        // TODO: add column Float32Value DOUBLE PRECISION and FLOAT32Array DOUBLE PRECISION[] while using float32 feature.
         const [postgreSqlOperationUpdateDDL] = await PG_DATABASE.updateSchema(
           `
                 CREATE TABLE ${TABLE_NAME}
@@ -402,6 +402,7 @@ describe('Spanner', () => {
                   "Key"             VARCHAR NOT NULL PRIMARY KEY,
                   "BytesValue"      BYTEA,
                   "BoolValue"       BOOL,
+                  "Float32Value"    DOUBLE PRECISION,
                   "FloatValue"      DOUBLE PRECISION,
                   "IntValue"        BIGINT,
                   "NumericValue"    NUMERIC,
@@ -411,6 +412,7 @@ describe('Spanner', () => {
                   "JsonbValue"      JSONB,
                   "BytesArray"      BYTEA[],
                   "BoolArray"       BOOL[],
+                  "Float32Array"    DOUBLE PRECISION[],
                   "FloatArray"      DOUBLE PRECISION[],
                   "IntArray"        BIGINT[],
                   "NumericArray"    NUMERIC[],
@@ -424,7 +426,6 @@ describe('Spanner', () => {
         );
         await postgreSqlOperationUpdateDDL.promise();
       } else {
-        // TODO: add column Float32Value FLOAT32 and FLOAT32Array Array<FLOAT32> while using float32 feature.
         const [googleSqlOperationUpdateDDL] = await DATABASE.updateSchema(
           `
               CREATE TABLE ${TABLE_NAME}
@@ -459,7 +460,6 @@ describe('Spanner', () => {
             `
         );
         await googleSqlOperationUpdateDDL.promise();
-        // TODO: add column Float32Value DOUBLE PRECISION and FLOAT32Array DOUBLE PRECISION[] while using float32 feature.
         const [postgreSqlOperationUpdateDDL] = await PG_DATABASE.updateSchema(
           `
                 CREATE TABLE ${TABLE_NAME}
@@ -943,13 +943,7 @@ describe('Spanner', () => {
       });
     });
 
-    // TODO: Enable when the float32 feature has been released.
     describe('float32s', () => {
-      before(async function () {
-        if (IS_EMULATOR_ENABLED) {
-          this.skip();
-        }
-      });
       const float32Insert = (done, dialect, value) => {
         insert({Float32Value: value}, dialect, (err, row) => {
           assert.ifError(err);
@@ -3967,79 +3961,40 @@ describe('Spanner', () => {
     before(async () => {
       googleSqlTable = DATABASE.table(TABLE_NAME);
       postgreSqlTable = PG_DATABASE.table(TABLE_NAME);
-      if (IS_EMULATOR_ENABLED) {
-        // TODO: Add column Float32 FLOAT32 while using float32 feature.
-        const googleSqlCreateTable = await googleSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-                  (
-                    SingerId     STRING(1024) NOT NULL,
-                    Name         STRING(1024),
-                    Float        FLOAT64,
-                    Int          INT64,
-                    Info         BYTES( MAX),
-                    Created      TIMESTAMP,
-                    DOB          DATE,
-                    Accents      ARRAY<STRING(1024)>,
-                    PhoneNumbers ARRAY<INT64>,
-                    HasGear      BOOL,
-                  ) PRIMARY KEY(SingerId)`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(googleSqlCreateTable);
+      const googleSqlCreateTable = await googleSqlTable.create(
+        `CREATE TABLE ${TABLE_NAME}
+                (
+                  SingerId     STRING(1024) NOT NULL,
+                  Name         STRING(1024),
+                  Float32      FLOAT32,
+                  Float        FLOAT64,
+                  Int          INT64,
+                  Info         BYTES( MAX),
+                  Created      TIMESTAMP,
+                  DOB          DATE,
+                  Accents      ARRAY<STRING(1024)>,
+                  PhoneNumbers ARRAY<INT64>,
+                  HasGear      BOOL,
+                ) PRIMARY KEY(SingerId)`,
+        GAX_OPTIONS
+      );
+      await onPromiseOperationComplete(googleSqlCreateTable);
 
-        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
-        const postgreSqlCreateTable = await postgreSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-              (
-                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
-                "Name"     VARCHAR(1024),
-                "Float"    DOUBLE PRECISION,
-                "Int"      BIGINT,
-                "Info"     BYTEA,
-                "Created"  TIMESTAMPTZ,
-                "HasGear"  BOOL
-              )`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(postgreSqlCreateTable);
-      } else {
-        // TODO: Add column Float32 FLOAT32 while using float32 feature.
-        const googleSqlCreateTable = await googleSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-                  (
-                    SingerId     STRING(1024) NOT NULL,
-                    Name         STRING(1024),
-                    Float32      FLOAT32,
-                    Float        FLOAT64,
-                    Int          INT64,
-                    Info         BYTES( MAX),
-                    Created      TIMESTAMP,
-                    DOB          DATE,
-                    Accents      ARRAY<STRING(1024)>,
-                    PhoneNumbers ARRAY<INT64>,
-                    HasGear      BOOL,
-                  ) PRIMARY KEY(SingerId)`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(googleSqlCreateTable);
-
-        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
-        const postgreSqlCreateTable = await postgreSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-              (
-                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
-                "Name"     VARCHAR(1024),
-                "Float32"  DOUBLE PRECISION,
-                "Float"    DOUBLE PRECISION,
-                "Int"      BIGINT,
-                "Info"     BYTEA,
-                "Created"  TIMESTAMPTZ,
-                "HasGear"  BOOL
-              )`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(postgreSqlCreateTable);
-      }
+      const postgreSqlCreateTable = await postgreSqlTable.create(
+        `CREATE TABLE ${TABLE_NAME}
+            (
+              "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
+              "Name"     VARCHAR(1024),
+              "Float32"  DOUBLE PRECISION,
+              "Float"    DOUBLE PRECISION,
+              "Int"      BIGINT,
+              "Info"     BYTEA,
+              "Created"  TIMESTAMPTZ,
+              "HasGear"  BOOL
+            )`,
+        GAX_OPTIONS
+      );
+      await onPromiseOperationComplete(postgreSqlCreateTable);
     });
 
     const nonExistentTable = (done, database) => {
@@ -4544,7 +4499,7 @@ describe('Spanner', () => {
     describe('insert & query', () => {
       const ID = generateName('id');
       const NAME = generateName('name');
-      const FLOAT32 = 8.2; // TODO: Uncomment while using float32 feature.
+      const FLOAT32 = 8.2;
       const FLOAT = 8.2;
       const INT = 2;
       const INFO = Buffer.from(generateName('info'));
@@ -4554,9 +4509,10 @@ describe('Spanner', () => {
       const PHONE_NUMBERS = [123123123, 234234234];
       const HAS_GEAR = true;
 
-      const GOOGLE_SQL_INSERT_ROW: Record<string, any> = {
+      const GOOGLE_SQL_INSERT_ROW = {
         SingerId: ID,
         Name: NAME,
+        Float32: FLOAT32,
         Float: FLOAT,
         Int: INT,
         Info: INFO,
@@ -4567,20 +4523,16 @@ describe('Spanner', () => {
         HasGear: HAS_GEAR,
       };
 
-      const POSTGRESQL_INSERT_ROW: Record<string, any> = {
+      const POSTGRESQL_INSERT_ROW = {
         SingerId: ID,
         Name: NAME,
+        Float32: FLOAT32,
         Float: FLOAT,
         Int: INT,
         Info: INFO,
         Created: CREATED,
         HasGear: HAS_GEAR,
       };
-
-      if (!IS_EMULATOR_ENABLED) {
-        (GOOGLE_SQL_INSERT_ROW.Float32 = FLOAT32),
-          (POSTGRESQL_INSERT_ROW.Float32 = FLOAT32);
-      }
 
       const GOOGLE_SQL_EXPECTED_ROW = extend(true, {}, GOOGLE_SQL_INSERT_ROW);
       const POSTGRESQL_EXPECTED_ROW = extend(true, {}, POSTGRESQL_INSERT_ROW);
@@ -4812,32 +4764,28 @@ describe('Spanner', () => {
           params: {id: ID},
         });
         assert.strictEqual(rows.length, 1);
-        assert.deepStrictEqual(rows[0].toJSON(), GOOGLE_SQL_EXPECTED_ROW);
+        for (const [key, value] of Object.entries(rows[0].toJSON())) {
+          if (value && key === 'Float32') {
+            assert.ok(
+              GOOGLE_SQL_EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+            );
+          } else {
+            assert.deepStrictEqual(GOOGLE_SQL_EXPECTED_ROW[key], value);
+          }
+        }
         assert.ok(metadata);
-        assert.strictEqual(metadata.rowType!.fields!.length, 10);
+        assert.strictEqual(metadata.rowType!.fields!.length, 11);
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
-        // TODO: Uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        if (IS_EMULATOR_ENABLED) {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
-        } else {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
-        }
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
+        assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
+        assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
+        assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
       });
 
       it('POSTGRESQL should return metadata', async () => {
@@ -4846,28 +4794,25 @@ describe('Spanner', () => {
           params: {p1: ID},
         });
         assert.strictEqual(rows.length, 1);
-        assert.deepStrictEqual(rows[0].toJSON(), POSTGRESQL_EXPECTED_ROW);
+        for (const [key, value] of Object.entries(rows[0].toJSON())) {
+          if (value && key === 'Float32') {
+            assert.ok(
+              POSTGRESQL_EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+            );
+          } else {
+            assert.deepStrictEqual(POSTGRESQL_EXPECTED_ROW[key], value);
+          }
+        }
         assert.ok(metadata);
-        assert.strictEqual(metadata.rowType!.fields!.length, 7);
+        assert.strictEqual(metadata.rowType!.fields!.length, 8);
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
-        // uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        if (IS_EMULATOR_ENABLED) {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'HasGear');
-        } else {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
-        }
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'HasGear');
       });
 
       const invalidQueries = (done, database) => {
@@ -5211,7 +5156,6 @@ describe('Spanner', () => {
           });
         });
 
-        // TODO: Enable when the float32 feature has been released.
         describe('float32', () => {
           const float32Query = (done, database, query, value) => {
             database.run(query, (err, rows) => {

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -4540,9 +4540,9 @@ describe('Spanner', () => {
         HasGear: HAS_GEAR,
       };
 
-      if(!IS_EMULATOR_ENABLED) {
-        GOOGLE_SQL_INSERT_ROW.Float32 = FLOAT32,
-        POSTGRESQL_INSERT_ROW.Float32 = FLOAT32
+      if (!IS_EMULATOR_ENABLED) {
+        (GOOGLE_SQL_INSERT_ROW.Float32 = FLOAT32),
+          (POSTGRESQL_INSERT_ROW.Float32 = FLOAT32);
       }
 
       const GOOGLE_SQL_EXPECTED_ROW = extend(true, {}, GOOGLE_SQL_INSERT_ROW);
@@ -4560,12 +4560,21 @@ describe('Spanner', () => {
 
         database.run(query, options, (err, rows) => {
           assert.ifError(err);
-          assert.deepStrictEqual(rows!.shift()!.toJSON(), EXPECTED_ROW);
+          const actualRows = rows!.shift()!.toJSON() as {} as Row[];
+          for (const [key, value] of Object.entries(actualRows)) {
+            if (key === 'Float32') {
+              assert.ok(
+                EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+              );
+            } else {
+              assert.deepStrictEqual(EXPECTED_ROW[key], value);
+            }
+          }
           done();
         });
       };
 
-      it.only('GOOGLE_STANDARD_SQL should query in callback mode', done => {
+      it('GOOGLE_STANDARD_SQL should query in callback mode', done => {
         const query = {
           sql: `SELECT * FROM ${TABLE_NAME} WHERE SingerId=@id`,
           params: {id: ID},
@@ -4589,8 +4598,16 @@ describe('Spanner', () => {
         database
           .run(query, options)
           .then(data => {
-            const rows = data[0] as {} as Row[];
-            assert.deepStrictEqual(rows!.shift()!.toJSON(), EXPECTED_ROW);
+            const rows = data[0]!.shift()!.toJSON() as {} as Row[];
+            for (const [key, value] of Object.entries(rows)) {
+              if (key === 'Float32') {
+                assert.ok(
+                  EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+                );
+              } else {
+                assert.deepStrictEqual(EXPECTED_ROW[key], value);
+              }
+            }
             done();
           })
           .catch(done);
@@ -4626,7 +4643,16 @@ describe('Spanner', () => {
             stream.end();
           })
           .on('end', () => {
-            assert.deepStrictEqual(row.toJSON(), EXPECTED_ROW);
+            const actualRows = row!.toJSON() as {} as Row[];
+            for (const [key, value] of Object.entries(actualRows)) {
+              if (key === 'Float32') {
+                assert.ok(
+                  EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+                );
+              } else {
+                assert.deepStrictEqual(EXPECTED_ROW[key], value);
+              }
+            }
             done();
           });
       };
@@ -4755,15 +4781,15 @@ describe('Spanner', () => {
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
         // TODO: Uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        // assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-        assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-        assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-        assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-        assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
-        assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
-        assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
-        assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
+        assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
+        assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
+        assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
       });
 
       it('POSTGRESQL should return metadata', async () => {
@@ -4778,12 +4804,12 @@ describe('Spanner', () => {
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
         // uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        // assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-        assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-        assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-        assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-        assert.strictEqual(metadata.rowType!.fields![6].name, 'HasGear');
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'HasGear');
       });
 
       const invalidQueries = (done, database) => {

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -492,6 +492,7 @@ describe('Spanner', () => {
                 BytesValue      BYTES( MAX),
                 BoolValue       BOOL,
                 DateValue       DATE,
+                Float32Value    FLOAT32,
                 FloatValue      FLOAT64,
                 JsonValue       JSON,
                 IntValue        INT64,
@@ -503,6 +504,7 @@ describe('Spanner', () => {
                 BytesArray      ARRAY<BYTES(MAX)>,
                 BoolArray       ARRAY<BOOL>,
                 DateArray       ARRAY< DATE >,
+                Float32Array    ARRAY<FLOAT32>,
                 FloatArray      ARRAY<FLOAT64>,
                 JsonArray       ARRAY<JSON>,
                 IntArray        ARRAY<INT64>,
@@ -524,6 +526,7 @@ describe('Spanner', () => {
                   "Key"             VARCHAR NOT NULL PRIMARY KEY,
                   "BytesValue"      BYTEA,
                   "BoolValue"       BOOL,
+                  "Float32Value"    DOUBLE PRECISION,
                   "FloatValue"      DOUBLE PRECISION,
                   "IntValue"        BIGINT,
                   "NumericValue"    NUMERIC,
@@ -533,6 +536,7 @@ describe('Spanner', () => {
                   "JsonbValue"      JSONB,
                   "BytesArray"      BYTEA[],
                   "BoolArray"       BOOL[],
+                  "Float32Array"    DOUBLE PRECISION[],
                   "FloatArray"      DOUBLE PRECISION[],
                   "IntArray"        BIGINT[],
                   "NumericArray"    NUMERIC[],
@@ -931,7 +935,12 @@ describe('Spanner', () => {
     });
 
     // TODO: Enable when the float32 feature has been released.
-    describe.skip('float32s', () => {
+    describe('float32s', () => {
+      before(async function () {
+        if (IS_EMULATOR_ENABLED) {
+          this.skip();
+        }
+      });
       const float32Insert = (done, dialect, value) => {
         insert({Float32Value: value}, dialect, (err, row) => {
           assert.ifError(err);
@@ -4021,6 +4030,7 @@ describe('Spanner', () => {
                 (
                   SingerId     STRING(1024) NOT NULL,
                   Name         STRING(1024),
+                  Float32      FLOAT32,
                   Float        FLOAT64,
                   Int          INT64,
                   Info         BYTES( MAX),
@@ -4040,6 +4050,7 @@ describe('Spanner', () => {
             (
               "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
               "Name"     VARCHAR(1024),
+              "Float32"  DOUBLE PRECISION,
               "Float"    DOUBLE PRECISION,
               "Int"      BIGINT,
               "Info"     BYTEA,
@@ -4553,7 +4564,7 @@ describe('Spanner', () => {
     describe('insert & query', () => {
       const ID = generateName('id');
       const NAME = generateName('name');
-      // const FLOAT32 = 8.2; // TODO: Uncomment while using float32 feature.
+      const FLOAT32 = 8.2; // TODO: Uncomment while using float32 feature.
       const FLOAT = 8.2;
       const INT = 2;
       const INFO = Buffer.from(generateName('info'));
@@ -4563,10 +4574,9 @@ describe('Spanner', () => {
       const PHONE_NUMBERS = [123123123, 234234234];
       const HAS_GEAR = true;
 
-      const GOOGLE_SQL_INSERT_ROW = {
+      const GOOGLE_SQL_INSERT_ROW: Record<string, any> = {
         SingerId: ID,
         Name: NAME,
-        // Float32: FLOAT32, // TODO: Uncomment while using float32 feature.
         Float: FLOAT,
         Int: INT,
         Info: INFO,
@@ -4577,16 +4587,20 @@ describe('Spanner', () => {
         HasGear: HAS_GEAR,
       };
 
-      const POSTGRESQL_INSERT_ROW = {
+      const POSTGRESQL_INSERT_ROW: Record<string, any> = {
         SingerId: ID,
         Name: NAME,
-        // Float32: FLOAT32, // TODO: Uncomment while using float32 feature.
         Float: FLOAT,
         Int: INT,
         Info: INFO,
         Created: CREATED,
         HasGear: HAS_GEAR,
       };
+
+      if(!IS_EMULATOR_ENABLED) {
+        GOOGLE_SQL_INSERT_ROW.Float32 = FLOAT32,
+        POSTGRESQL_INSERT_ROW.Float32 = FLOAT32
+      }
 
       const GOOGLE_SQL_EXPECTED_ROW = extend(true, {}, GOOGLE_SQL_INSERT_ROW);
       const POSTGRESQL_EXPECTED_ROW = extend(true, {}, POSTGRESQL_INSERT_ROW);
@@ -4608,7 +4622,7 @@ describe('Spanner', () => {
         });
       };
 
-      it('GOOGLE_STANDARD_SQL should query in callback mode', done => {
+      it.only('GOOGLE_STANDARD_SQL should query in callback mode', done => {
         const query = {
           sql: `SELECT * FROM ${TABLE_NAME} WHERE SingerId=@id`,
           params: {id: ID},
@@ -5171,7 +5185,7 @@ describe('Spanner', () => {
         });
 
         // TODO: Enable when the float32 feature has been released.
-        describe.skip('float32', () => {
+        describe('float32', () => {
           const float32Query = (done, database, query, value) => {
             database.run(query, (err, rows) => {
               assert.ifError(err);

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -367,7 +367,6 @@ describe('Spanner', () => {
       googleSqlTable = DATABASE.table(TABLE_NAME);
       postgreSqlTable = PG_DATABASE.table(TABLE_NAME);
       if (IS_EMULATOR_ENABLED) {
-        // TODO: add column Float32Value FLOAT32 and FLOAT32Array Array<FLOAT32> while using float32 feature.
         const [googleSqlOperationUpdateDDL] = await DATABASE.updateSchema(
           `
               CREATE TABLE ${TABLE_NAME}
@@ -376,6 +375,7 @@ describe('Spanner', () => {
                 BytesValue      BYTES( MAX),
                 BoolValue       BOOL,
                 DateValue       DATE,
+                Float32Value    FLOAT32,
                 FloatValue      FLOAT64,
                 IntValue        INT64,
                 NumericValue    NUMERIC,
@@ -384,6 +384,7 @@ describe('Spanner', () => {
                 BytesArray      ARRAY<BYTES(MAX)>,
                 BoolArray       ARRAY<BOOL>,
                 DateArray       ARRAY< DATE >,
+                Float32Array    ARRAY<FLOAT32>,
                 FloatArray      ARRAY<FLOAT64>,
                 IntArray        ARRAY<INT64>,
                 NumericArray    ARRAY< NUMERIC >,
@@ -394,7 +395,6 @@ describe('Spanner', () => {
             `
         );
         await googleSqlOperationUpdateDDL.promise();
-        // TODO: add column Float32Value DOUBLE PRECISION and FLOAT32Array DOUBLE PRECISION[] while using float32 feature.
         const [postgreSqlOperationUpdateDDL] = await PG_DATABASE.updateSchema(
           `
                 CREATE TABLE ${TABLE_NAME}
@@ -402,6 +402,7 @@ describe('Spanner', () => {
                   "Key"             VARCHAR NOT NULL PRIMARY KEY,
                   "BytesValue"      BYTEA,
                   "BoolValue"       BOOL,
+                  "Float32Value"    DOUBLE PRECISION,
                   "FloatValue"      DOUBLE PRECISION,
                   "IntValue"        BIGINT,
                   "NumericValue"    NUMERIC,
@@ -411,6 +412,7 @@ describe('Spanner', () => {
                   "JsonbValue"      JSONB,
                   "BytesArray"      BYTEA[],
                   "BoolArray"       BOOL[],
+                  "Float32Array"    DOUBLE PRECISION[],
                   "FloatArray"      DOUBLE PRECISION[],
                   "IntArray"        BIGINT[],
                   "NumericArray"    NUMERIC[],
@@ -424,7 +426,6 @@ describe('Spanner', () => {
         );
         await postgreSqlOperationUpdateDDL.promise();
       } else {
-        // TODO: add column Float32Value FLOAT32 and FLOAT32Array Array<FLOAT32> while using float32 feature.
         const [googleSqlOperationUpdateDDL] = await DATABASE.updateSchema(
           `
               CREATE TABLE ${TABLE_NAME}
@@ -459,7 +460,6 @@ describe('Spanner', () => {
             `
         );
         await googleSqlOperationUpdateDDL.promise();
-        // TODO: add column Float32Value DOUBLE PRECISION and FLOAT32Array DOUBLE PRECISION[] while using float32 feature.
         const [postgreSqlOperationUpdateDDL] = await PG_DATABASE.updateSchema(
           `
                 CREATE TABLE ${TABLE_NAME}
@@ -943,13 +943,7 @@ describe('Spanner', () => {
       });
     });
 
-    // TODO: Enable when the float32 feature has been released.
     describe('float32s', () => {
-      before(async function () {
-        if (IS_EMULATOR_ENABLED) {
-          this.skip();
-        }
-      });
       const float32Insert = (done, dialect, value) => {
         insert({Float32Value: value}, dialect, (err, row) => {
           assert.ifError(err);
@@ -3967,79 +3961,40 @@ describe('Spanner', () => {
     before(async () => {
       googleSqlTable = DATABASE.table(TABLE_NAME);
       postgreSqlTable = PG_DATABASE.table(TABLE_NAME);
-      if (IS_EMULATOR_ENABLED) {
-        // TODO: Add column Float32 FLOAT32 while using float32 feature.
-        const googleSqlCreateTable = await googleSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-                  (
-                    SingerId     STRING(1024) NOT NULL,
-                    Name         STRING(1024),
-                    Float        FLOAT64,
-                    Int          INT64,
-                    Info         BYTES( MAX),
-                    Created      TIMESTAMP,
-                    DOB          DATE,
-                    Accents      ARRAY<STRING(1024)>,
-                    PhoneNumbers ARRAY<INT64>,
-                    HasGear      BOOL,
-                  ) PRIMARY KEY(SingerId)`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(googleSqlCreateTable);
+      const googleSqlCreateTable = await googleSqlTable.create(
+        `CREATE TABLE ${TABLE_NAME}
+                (
+                  SingerId     STRING(1024) NOT NULL,
+                  Name         STRING(1024),
+                  Float32      FLOAT32,
+                  Float        FLOAT64,
+                  Int          INT64,
+                  Info         BYTES( MAX),
+                  Created      TIMESTAMP,
+                  DOB          DATE,
+                  Accents      ARRAY<STRING(1024)>,
+                  PhoneNumbers ARRAY<INT64>,
+                  HasGear      BOOL,
+                ) PRIMARY KEY(SingerId)`,
+        GAX_OPTIONS
+      );
+      await onPromiseOperationComplete(googleSqlCreateTable);
 
-        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
-        const postgreSqlCreateTable = await postgreSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-              (
-                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
-                "Name"     VARCHAR(1024),
-                "Float"    DOUBLE PRECISION,
-                "Int"      BIGINT,
-                "Info"     BYTEA,
-                "Created"  TIMESTAMPTZ,
-                "HasGear"  BOOL
-              )`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(postgreSqlCreateTable);
-      } else {
-        // TODO: Add column Float32 FLOAT32 while using float32 feature.
-        const googleSqlCreateTable = await googleSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-                  (
-                    SingerId     STRING(1024) NOT NULL,
-                    Name         STRING(1024),
-                    Float32      FLOAT32,
-                    Float        FLOAT64,
-                    Int          INT64,
-                    Info         BYTES( MAX),
-                    Created      TIMESTAMP,
-                    DOB          DATE,
-                    Accents      ARRAY<STRING(1024)>,
-                    PhoneNumbers ARRAY<INT64>,
-                    HasGear      BOOL,
-                  ) PRIMARY KEY(SingerId)`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(googleSqlCreateTable);
-
-        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
-        const postgreSqlCreateTable = await postgreSqlTable.create(
-          `CREATE TABLE ${TABLE_NAME}
-              (
-                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
-                "Name"     VARCHAR(1024),
-                "Float32"  DOUBLE PRECISION,
-                "Float"    DOUBLE PRECISION,
-                "Int"      BIGINT,
-                "Info"     BYTEA,
-                "Created"  TIMESTAMPTZ,
-                "HasGear"  BOOL
-              )`,
-          GAX_OPTIONS
-        );
-        await onPromiseOperationComplete(postgreSqlCreateTable);
-      }
+      const postgreSqlCreateTable = await postgreSqlTable.create(
+        `CREATE TABLE ${TABLE_NAME}
+            (
+              "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
+              "Name"     VARCHAR(1024),
+              "Float32"  DOUBLE PRECISION,
+              "Float"    DOUBLE PRECISION,
+              "Int"      BIGINT,
+              "Info"     BYTEA,
+              "Created"  TIMESTAMPTZ,
+              "HasGear"  BOOL
+            )`,
+        GAX_OPTIONS
+      );
+      await onPromiseOperationComplete(postgreSqlCreateTable);
     });
 
     const nonExistentTable = (done, database) => {
@@ -4544,7 +4499,7 @@ describe('Spanner', () => {
     describe('insert & query', () => {
       const ID = generateName('id');
       const NAME = generateName('name');
-      const FLOAT32 = 8.2; // TODO: Uncomment while using float32 feature.
+      const FLOAT32 = 8.2;
       const FLOAT = 8.2;
       const INT = 2;
       const INFO = Buffer.from(generateName('info'));
@@ -4554,9 +4509,10 @@ describe('Spanner', () => {
       const PHONE_NUMBERS = [123123123, 234234234];
       const HAS_GEAR = true;
 
-      const GOOGLE_SQL_INSERT_ROW: Record<string, any> = {
+      const GOOGLE_SQL_INSERT_ROW = {
         SingerId: ID,
         Name: NAME,
+        Float32: FLOAT32,
         Float: FLOAT,
         Int: INT,
         Info: INFO,
@@ -4567,20 +4523,16 @@ describe('Spanner', () => {
         HasGear: HAS_GEAR,
       };
 
-      const POSTGRESQL_INSERT_ROW: Record<string, any> = {
+      const POSTGRESQL_INSERT_ROW = {
         SingerId: ID,
         Name: NAME,
+        Float32: FLOAT32,
         Float: FLOAT,
         Int: INT,
         Info: INFO,
         Created: CREATED,
         HasGear: HAS_GEAR,
       };
-
-      if (!IS_EMULATOR_ENABLED) {
-        (GOOGLE_SQL_INSERT_ROW.Float32 = FLOAT32),
-          (POSTGRESQL_INSERT_ROW.Float32 = FLOAT32);
-      }
 
       const GOOGLE_SQL_EXPECTED_ROW = extend(true, {}, GOOGLE_SQL_INSERT_ROW);
       const POSTGRESQL_EXPECTED_ROW = extend(true, {}, POSTGRESQL_INSERT_ROW);
@@ -4812,32 +4764,29 @@ describe('Spanner', () => {
           params: {id: ID},
         });
         assert.strictEqual(rows.length, 1);
-        assert.deepStrictEqual(rows[0].toJSON(), GOOGLE_SQL_EXPECTED_ROW);
+        for (const [key, value] of Object.entries(rows[0].toJSON())) {
+          if (value && key === 'Float32') {
+            assert.ok(
+              GOOGLE_SQL_EXPECTED_ROW[key] - (value as unknown as number) <=
+                0.00001
+            );
+          } else {
+            assert.deepStrictEqual(GOOGLE_SQL_EXPECTED_ROW[key], value);
+          }
+        }
         assert.ok(metadata);
-        assert.strictEqual(metadata.rowType!.fields!.length, 10);
+        assert.strictEqual(metadata.rowType!.fields!.length, 11);
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
-        // TODO: Uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        if (IS_EMULATOR_ENABLED) {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
-        } else {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
-        }
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
+        assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
+        assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
+        assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
       });
 
       it('POSTGRESQL should return metadata', async () => {
@@ -4846,28 +4795,26 @@ describe('Spanner', () => {
           params: {p1: ID},
         });
         assert.strictEqual(rows.length, 1);
-        assert.deepStrictEqual(rows[0].toJSON(), POSTGRESQL_EXPECTED_ROW);
+        for (const [key, value] of Object.entries(rows[0].toJSON())) {
+          if (value && key === 'Float32') {
+            assert.ok(
+              POSTGRESQL_EXPECTED_ROW[key] - (value as unknown as number) <=
+                0.00001
+            );
+          } else {
+            assert.deepStrictEqual(POSTGRESQL_EXPECTED_ROW[key], value);
+          }
+        }
         assert.ok(metadata);
-        assert.strictEqual(metadata.rowType!.fields!.length, 7);
+        assert.strictEqual(metadata.rowType!.fields!.length, 8);
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
-        // uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        if (IS_EMULATOR_ENABLED) {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'HasGear');
-        } else {
-          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
-          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
-          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
-          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
-          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
-          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
-          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
-          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
-        }
+        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+        assert.strictEqual(metadata.rowType!.fields![7].name, 'HasGear');
       });
 
       const invalidQueries = (done, database) => {
@@ -5211,7 +5158,6 @@ describe('Spanner', () => {
           });
         });
 
-        // TODO: Enable when the float32 feature has been released.
         describe('float32', () => {
           const float32Query = (done, database, query, value) => {
             database.run(query, (err, rows) => {

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -4767,7 +4767,8 @@ describe('Spanner', () => {
         for (const [key, value] of Object.entries(rows[0].toJSON())) {
           if (value && key === 'Float32') {
             assert.ok(
-              GOOGLE_SQL_EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+              GOOGLE_SQL_EXPECTED_ROW[key] - (value as unknown as number) <=
+                0.00001
             );
           } else {
             assert.deepStrictEqual(GOOGLE_SQL_EXPECTED_ROW[key], value);
@@ -4797,7 +4798,8 @@ describe('Spanner', () => {
         for (const [key, value] of Object.entries(rows[0].toJSON())) {
           if (value && key === 'Float32') {
             assert.ok(
-              POSTGRESQL_EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
+              POSTGRESQL_EXPECTED_ROW[key] - (value as unknown as number) <=
+                0.00001
             );
           } else {
             assert.deepStrictEqual(POSTGRESQL_EXPECTED_ROW[key], value);

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -3967,42 +3967,79 @@ describe('Spanner', () => {
     before(async () => {
       googleSqlTable = DATABASE.table(TABLE_NAME);
       postgreSqlTable = PG_DATABASE.table(TABLE_NAME);
-      // TODO: Add column Float32 FLOAT32 while using float32 feature.
-      const googleSqlCreateTable = await googleSqlTable.create(
-        `CREATE TABLE ${TABLE_NAME}
-                (
-                  SingerId     STRING(1024) NOT NULL,
-                  Name         STRING(1024),
-                  Float32      FLOAT32,
-                  Float        FLOAT64,
-                  Int          INT64,
-                  Info         BYTES( MAX),
-                  Created      TIMESTAMP,
-                  DOB          DATE,
-                  Accents      ARRAY<STRING(1024)>,
-                  PhoneNumbers ARRAY<INT64>,
-                  HasGear      BOOL,
-                ) PRIMARY KEY(SingerId)`,
-        GAX_OPTIONS
-      );
-      await onPromiseOperationComplete(googleSqlCreateTable);
+      if (IS_EMULATOR_ENABLED) {
+        // TODO: Add column Float32 FLOAT32 while using float32 feature.
+        const googleSqlCreateTable = await googleSqlTable.create(
+          `CREATE TABLE ${TABLE_NAME}
+                  (
+                    SingerId     STRING(1024) NOT NULL,
+                    Name         STRING(1024),
+                    Float        FLOAT64,
+                    Int          INT64,
+                    Info         BYTES( MAX),
+                    Created      TIMESTAMP,
+                    DOB          DATE,
+                    Accents      ARRAY<STRING(1024)>,
+                    PhoneNumbers ARRAY<INT64>,
+                    HasGear      BOOL,
+                  ) PRIMARY KEY(SingerId)`,
+          GAX_OPTIONS
+        );
+        await onPromiseOperationComplete(googleSqlCreateTable);
 
-      // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
-      const postgreSqlCreateTable = await postgreSqlTable.create(
-        `CREATE TABLE ${TABLE_NAME}
-            (
-              "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
-              "Name"     VARCHAR(1024),
-              "Float32"  DOUBLE PRECISION,
-              "Float"    DOUBLE PRECISION,
-              "Int"      BIGINT,
-              "Info"     BYTEA,
-              "Created"  TIMESTAMPTZ,
-              "HasGear"  BOOL
-            )`,
-        GAX_OPTIONS
-      );
-      await onPromiseOperationComplete(postgreSqlCreateTable);
+        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
+        const postgreSqlCreateTable = await postgreSqlTable.create(
+          `CREATE TABLE ${TABLE_NAME}
+              (
+                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
+                "Name"     VARCHAR(1024),
+                "Float"    DOUBLE PRECISION,
+                "Int"      BIGINT,
+                "Info"     BYTEA,
+                "Created"  TIMESTAMPTZ,
+                "HasGear"  BOOL
+              )`,
+          GAX_OPTIONS
+        );
+        await onPromiseOperationComplete(postgreSqlCreateTable);
+      } else {
+        // TODO: Add column Float32 FLOAT32 while using float32 feature.
+        const googleSqlCreateTable = await googleSqlTable.create(
+          `CREATE TABLE ${TABLE_NAME}
+                  (
+                    SingerId     STRING(1024) NOT NULL,
+                    Name         STRING(1024),
+                    Float32      FLOAT32,
+                    Float        FLOAT64,
+                    Int          INT64,
+                    Info         BYTES( MAX),
+                    Created      TIMESTAMP,
+                    DOB          DATE,
+                    Accents      ARRAY<STRING(1024)>,
+                    PhoneNumbers ARRAY<INT64>,
+                    HasGear      BOOL,
+                  ) PRIMARY KEY(SingerId)`,
+          GAX_OPTIONS
+        );
+        await onPromiseOperationComplete(googleSqlCreateTable);
+
+        // TODO: Add column "Float32" DOUBLE PRECISION while using float32 feature.
+        const postgreSqlCreateTable = await postgreSqlTable.create(
+          `CREATE TABLE ${TABLE_NAME}
+              (
+                "SingerId" VARCHAR(1024) NOT NULL PRIMARY KEY,
+                "Name"     VARCHAR(1024),
+                "Float32"  DOUBLE PRECISION,
+                "Float"    DOUBLE PRECISION,
+                "Int"      BIGINT,
+                "Info"     BYTEA,
+                "Created"  TIMESTAMPTZ,
+                "HasGear"  BOOL
+              )`,
+          GAX_OPTIONS
+        );
+        await onPromiseOperationComplete(postgreSqlCreateTable);
+      }
     });
 
     const nonExistentTable = (done, database) => {
@@ -4562,7 +4599,7 @@ describe('Spanner', () => {
           assert.ifError(err);
           const actualRows = rows!.shift()!.toJSON() as {} as Row[];
           for (const [key, value] of Object.entries(actualRows)) {
-            if (key === 'Float32') {
+            if (value && key === 'Float32') {
               assert.ok(
                 EXPECTED_ROW[key] - (value as unknown as number) <= 0.00001
               );
@@ -4781,15 +4818,26 @@ describe('Spanner', () => {
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
         // TODO: Uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
-        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
-        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
-        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
-        assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
-        assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
-        assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
-        assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
+        if (IS_EMULATOR_ENABLED) {
+          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
+          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
+          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
+          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
+          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
+          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
+          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
+          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
+        } else {
+          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
+          assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
+          assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
+          assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
+          assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
+          assert.strictEqual(metadata.rowType!.fields![7].name, 'DOB');
+          assert.strictEqual(metadata.rowType!.fields![8].name, 'Accents');
+          assert.strictEqual(metadata.rowType!.fields![9].name, 'PhoneNumbers');
+          assert.strictEqual(metadata.rowType!.fields![10].name, 'HasGear');
+        }
       });
 
       it('POSTGRESQL should return metadata', async () => {
@@ -4804,12 +4852,22 @@ describe('Spanner', () => {
         assert.strictEqual(metadata.rowType!.fields![0].name, 'SingerId');
         assert.strictEqual(metadata.rowType!.fields![1].name, 'Name');
         // uncomment while using float32 feature and increase the index by 1 for all the asserts below this.
-        assert.strictEqual(metadata.rowType!.fields![2].name, 'Float32');
-        assert.strictEqual(metadata.rowType!.fields![3].name, 'Float');
-        assert.strictEqual(metadata.rowType!.fields![4].name, 'Int');
-        assert.strictEqual(metadata.rowType!.fields![5].name, 'Info');
-        assert.strictEqual(metadata.rowType!.fields![6].name, 'Created');
-        assert.strictEqual(metadata.rowType!.fields![7].name, 'HasGear');
+        if (IS_EMULATOR_ENABLED) {
+          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
+          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
+          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
+          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
+          assert.strictEqual(metadata.rowType!.fields![6].name, 'HasGear');
+        } else {
+          assert.strictEqual(metadata.rowType!.fields![2].name, 'Float');
+          assert.strictEqual(metadata.rowType!.fields![3].name, 'Int');
+          assert.strictEqual(metadata.rowType!.fields![4].name, 'Info');
+          assert.strictEqual(metadata.rowType!.fields![5].name, 'Created');
+          assert.strictEqual(metadata.rowType!.fields![6].name, 'DOB');
+          assert.strictEqual(metadata.rowType!.fields![7].name, 'Accents');
+          assert.strictEqual(metadata.rowType!.fields![8].name, 'PhoneNumbers');
+          assert.strictEqual(metadata.rowType!.fields![9].name, 'HasGear');
+        }
       });
 
       const invalidQueries = (done, database) => {

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -169,7 +169,7 @@ describe('codec', () => {
     });
   });
 
-  describe.skip('Float32', () => {
+  describe('Float32', () => {
     it('should store the value', () => {
       const value = 8;
       const float32 = new codec.Float32(value);
@@ -680,7 +680,7 @@ describe('codec', () => {
       assert.deepStrictEqual(decoded, expected);
     });
 
-    it.skip('should decode FLOAT32', () => {
+    it('should decode FLOAT32', () => {
       const value = 'Infinity';
 
       const decoded = codec.decode(value, {
@@ -1070,7 +1070,7 @@ describe('codec', () => {
       assert.strictEqual(encoded, '10');
     });
 
-    it.skip('should encode FLOAT32', () => {
+    it('should encode FLOAT32', () => {
       const value = new codec.Float32(10);
 
       const encoded = codec.encode(value);
@@ -1165,7 +1165,7 @@ describe('codec', () => {
       });
     });
 
-    it.skip('should determine if the value is a float32', () => {
+    it('should determine if the value is a float32', () => {
       assert.deepStrictEqual(codec.getType(new codec.Float32(1.1)), {
         type: 'float32',
       });

--- a/test/index.ts
+++ b/test/index.ts
@@ -517,7 +517,7 @@ describe('Spanner', () => {
     });
   });
 
-  describe.skip('float32', () => {
+  describe('float32', () => {
     it('should create a Float32 instance', () => {
       const value = {};
       const customValue = {};


### PR DESCRIPTION
This PR contains code changes to enable float32 support in node client, since the support has been released in backend.