### PR TITLE
fix: createQueryPartition with query params

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -127,6 +127,8 @@ export interface Statement {
   sql: string;
   params?: {[param: string]: Value};
   types?: Type | {[param: string]: Value};
+  // This property is used internally as a mapping for types. Do not set it manually
+  paramTypes?: {[k: string]: google.spanner.v1.Type} | null;
 }
 
 export interface ExecuteSqlRequest extends Statement, RequestOptions {
@@ -1500,10 +1502,11 @@ export class Snapshot extends EventEmitter {
   static encodeParams(request: ExecuteSqlRequest) {
     const typeMap = request.types || {};
 
-    const params: p.IStruct = {};
-    const paramTypes: {[field: string]: spannerClient.spanner.v1.Type} = {};
+    const params: p.IStruct = request.params || {};
+    const paramTypes: {[field: string]: spannerClient.spanner.v1.Type} =
+      request.paramTypes || {};
 
-    if (request.params) {
+    if (request.params && !request.params.fields) {
       const fields = {};
 
       Object.keys(request.params).forEach(param => {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1502,7 +1502,7 @@ export class Snapshot extends EventEmitter {
   static encodeParams(request: ExecuteSqlRequest) {
     const typeMap = request.types || {};
 
-    const params: p.IStruct = request.params || {};
+    const params: p.IStruct = {fields: request.params?.fields || {}};
     const paramTypes: {[field: string]: spannerClient.spanner.v1.Type} =
       request.paramTypes || {};
 

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -9420,7 +9420,10 @@ describe('Spanner', () => {
           this.skip();
         }
         const selectQuery = {
-          sql: 'SELECT * FROM TxnTable where Key = "k998"',
+          sql: 'SELECT * FROM TxnTable where Key = @id',
+          params: {
+            id: 'k998',
+          },
         };
 
         let row_count = 0;


### PR DESCRIPTION
Create Query Partition with query params throw error, as params are encoded twice , once while creating partition and once while executing
```
const query = {
    sql: 'SELECT * FROM Singers where SingerId > @id',
    params: {
      id: 1200,
    },
  };

const [partitions] = await transaction.createQueryPartitions(query);
partitions.forEach(partition => {
    transaction.execute(partition).then(results => {
      const rows = results[0].map(row => row.toJSON());
      row_count += rows.length;
  });
});
```

BEGIN_COMMIT_OVERRIDE
fix: createQueryPartition with query params
END_COMMIT_OVERRIDE
