### PR TITLE
chore: remove test(14) and test(16) from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -8,6 +8,8 @@ branchProtectionRules:
       - "ci/kokoro: Samples test"
       - "ci/kokoro: System test"
       - lint
+      - test (14)
+      - test (16)
       - test (18)
       - cla/google
       - windows

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -8,8 +8,6 @@ branchProtectionRules:
       - "ci/kokoro: Samples test"
       - "ci/kokoro: System test"
       - lint
-      - test (14)
-      - test (16)
       - test (18)
       - cla/google
       - windows

--- a/owlbot.py
+++ b/owlbot.py
@@ -64,7 +64,7 @@ if staging.is_dir():
 
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
-s.copy(templates, excludes=[".kokoro/samples-test.sh", ".kokoro/trampoline_v2.sh", ".github/release-trigger.yml"])
+s.copy(templates, excludes=[".kokoro/samples-test.sh", ".kokoro/trampoline_v2.sh", ".github/release-trigger.yml", ".github/sync-repo-settings.yaml"])
 
 node.postprocess_gapic_library_hermetic()
 


### PR DESCRIPTION
This PR changes will skip the required test checks for node version 14 and 16.