### PR TITLE
chore: lock order prevention

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -353,6 +353,7 @@ class Database extends common.GrpcServiceObject {
   pool_: SessionPoolInterface;
   sessionFactory_: SessionFactoryInterface;
   queryOptions_?: spannerClient.spanner.v1.ExecuteSqlRequest.IQueryOptions;
+  isMuxEnabledForRW_?: boolean;
   commonHeaders_: {[k: string]: string};
   request: DatabaseRequest;
   databaseRole?: string | null;
@@ -496,6 +497,7 @@ class Database extends common.GrpcServiceObject {
     this.requestStream = instance.requestStream as any;
     this.sessionFactory_ = new SessionFactory(this, name, poolOptions);
     this.pool_ = this.sessionFactory_.getPool();
+    this.isMuxEnabledForRW_ = this.sessionFactory_.isMultiplexedEnabledForRW();
     const sessionPoolInstance = this.pool_ as SessionPool;
     if (sessionPoolInstance) {
       sessionPoolInstance._observabilityOptions =

--- a/src/session-factory.ts
+++ b/src/session-factory.ts
@@ -93,6 +93,13 @@ export interface SessionFactoryInterface {
    * @name SessionFactoryInterface#isMultiplexedEnabled
    */
   isMultiplexedEnabled(): boolean;
+
+  /**
+   * When called returns if the multiplexed is enabled or not for read write transactions.
+   *
+   * @name SessionFactoryInterface#isMultiplexedEnabledForRW
+   */
+  isMultiplexedEnabledForRW(): boolean;
 }
 
 /**
@@ -242,5 +249,16 @@ export class SessionFactory
    */
   isMultiplexedEnabled(): boolean {
     return this.isMultiplexed;
+  }
+
+  /**
+   * Returns if a multiplexed is enabled or not for read write transaction.
+   *
+   * This method returns true if multiplexed session is enabled for read write transactions, otherwise returns false
+   *
+   * @returns {boolean}
+   */
+  isMultiplexedEnabledForRW(): boolean {
+    return this.isMultiplexedRW;
   }
 }

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -116,6 +116,7 @@ export abstract class Runner<T> {
   session: Session;
   transaction?: Transaction;
   options: RunTransactionOptions;
+  multiplexedSessionPreviousTransactionId?: Uint8Array | string;
   constructor(
     session: Session,
     transaction: Transaction,
@@ -210,6 +211,8 @@ export abstract class Runner<T> {
     transaction!.setReadWriteTransactionOptions(
       this.options as RunTransactionOptions,
     );
+    transaction.multiplexedSessionPreviousTransactionId =
+      this.multiplexedSessionPreviousTransactionId;
     if (this.attempts > 0) {
       await transaction.begin();
     }
@@ -239,6 +242,8 @@ export abstract class Runner<T> {
       } catch (e) {
         this.session.lastError = e as grpc.ServiceError;
         lastError = e as grpc.ServiceError;
+      } finally {
+        this.multiplexedSessionPreviousTransactionId = transaction.id;
       }
 
       // Note that if the error is a 'Session not found' error, it will be

--- a/test/database.ts
+++ b/test/database.ts
@@ -158,6 +158,16 @@ export class FakeSessionFactory extends EventEmitter {
       return true;
     }
   }
+  isMultiplexedEnabledForRW(): boolean {
+    if (
+      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS === 'true' &&
+      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW === 'true'
+    ) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }
 
 class FakeTable {

--- a/test/session-factory.ts
+++ b/test/session-factory.ts
@@ -409,4 +409,28 @@ describe('SessionFactory', () => {
       });
     });
   });
+
+  describe('isMultiplexedEnabledForRW', () => {
+    describe('when multiplexed session is enabled for read/write transactions', () => {
+      before(() => {
+        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
+        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
+      });
+      it('should have enabled the multiplexed', () => {
+        const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
+        assert.strictEqual(sessionFactory.isMultiplexedEnabledForRW(), true);
+      });
+    });
+
+    describe('when multiplexed session is disabled for read/write transactions', () => {
+      before(() => {
+        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
+      });
+      it('should not have enabled the multiplexed', () => {
+        const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
+        assert.strictEqual(sessionFactory.isMultiplexedEnabledForRW(), false);
+      });
+    });
+  });
 });

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -1702,6 +1702,64 @@ describe('Transaction', () => {
           ),
         );
       });
+
+      describe('when multiplexed session is enabled for read/write', () => {
+        before(() => {
+          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
+          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
+        });
+        after(() => {
+          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
+            'false';
+        });
+        it('should pass multiplexedSessionPreviousTransactionId in the BeginTransactionRequest upon retrying an aborted transaction', () => {
+          const fakePreviousTransactionId = 'fake-previous-transaction-id';
+          const database = {
+            formattedName_: 'formatted-database-name',
+            isMuxEnabledForRW_: true,
+            parent: INSTANCE,
+          };
+          const SESSION = {
+            parent: database,
+            formattedName_: SESSION_NAME,
+            request: REQUEST,
+            requestStream: REQUEST_STREAM,
+          };
+          // multiplexed session
+          const multiplexedSession = Object.assign(
+            {multiplexed: true},
+            SESSION,
+          );
+          transaction = new Transaction(multiplexedSession);
+          // transaction option must contain the previous transaction id for multiplexed session
+          transaction.multiplexedSessionPreviousTransactionId =
+            fakePreviousTransactionId;
+          const stub = sandbox.stub(transaction, 'request');
+          transaction.begin();
+
+          const expectedOptions = {
+            isolationLevel: 0,
+            readWrite: {
+              multiplexedSessionPreviousTransactionId:
+                fakePreviousTransactionId,
+            },
+          };
+          const {client, method, reqOpts, headers} = stub.lastCall.args[0];
+
+          assert.strictEqual(client, 'SpannerClient');
+          assert.strictEqual(method, 'beginTransaction');
+          // request options should contain the multiplexedSessionPreviousTransactionId
+          assert.deepStrictEqual(reqOpts.options, expectedOptions);
+          assert.deepStrictEqual(
+            headers,
+            Object.assign(
+              {[LEADER_AWARE_ROUTING_HEADER]: true},
+              transaction.commonHeaders_,
+            ),
+          );
+        });
+      });
     });
 
     describe('commit', () => {


### PR DESCRIPTION
This PR is the implementation of Lock Order Prevention (OR tracking multiplexed session previous transaction id), when retry of an aborted transaction takes place.