### PR TITLE
feat(spanner): support setting read lock mode

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -266,8 +266,6 @@ export interface GetIamPolicyOptions {
 
 /**
  * @typedef {object} GetTransactionOptions
- * * @property {boolean} [readLockMode] The read lock mode a
- *     {@link Transaction} should use while running.
  */
 export type GetTransactionOptions = Omit<RunTransactionOptions, 'timeout'>;
 

--- a/src/database.ts
+++ b/src/database.ts
@@ -43,6 +43,7 @@ import {
   google as spannerClient,
 } from '../protos/protos';
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 import {
   CreateDatabaseCallback,
   CreateDatabaseOptions,
@@ -265,7 +266,7 @@ export interface GetIamPolicyOptions {
 
 /**
  * @typedef {object} GetTransactionOptions
- * * @property {boolean} [optimisticLock] The optimistic lock a
+ * * @property {boolean} [readLockMode] The read lock mode a
  *     {@link Transaction} should use while running.
  */
 export type GetTransactionOptions = Omit<RunTransactionOptions, 'timeout'>;
@@ -325,6 +326,7 @@ export interface RestoreOptions {
 }
 
 export interface WriteAtLeastOnceOptions extends CallOptions {
+  readLockMode?: ReadLockMode;
   isolationLevel?: IsolationLevel;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import {
 } from 'google-gax';
 import {google, google as instanceAdmin} from '../protos/protos';
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 import {
   PagedOptions,
   PagedResponse,
@@ -159,7 +160,10 @@ export interface SpannerOptions extends GrpcClientOptions {
   sslCreds?: grpc.ChannelCredentials;
   routeToLeaderEnabled?: boolean;
   directedReadOptions?: google.spanner.v1.IDirectedReadOptions | null;
-  defaultTransactionOptions?: Pick<RunTransactionOptions, 'isolationLevel'>;
+  defaultTransactionOptions?: Pick<
+    RunTransactionOptions,
+    'isolationLevel' | 'readLockMode'
+  >;
   observabilityOptions?: ObservabilityOptions;
   disableBuiltInMetrics?: boolean;
   interceptors?: any[];
@@ -432,6 +436,7 @@ class Spanner extends GrpcService {
       ? options.defaultTransactionOptions
       : {
           isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+          readLockMode: ReadLockMode.READ_LOCK_MODE_UNSPECIFIED,
         };
     delete options.defaultTransactionOptions;
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -39,6 +39,7 @@ import {
 } from './instrument';
 import {google} from '../protos/protos';
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 
 export type Key = string | string[];
 
@@ -56,6 +57,7 @@ interface MutateRowsOptions extends CommitOptions {
   requestOptions?: Omit<IRequestOptions, 'requestTag'>;
   excludeTxnFromChangeStreams?: boolean;
   isolationLevel?: IsolationLevel;
+  readLockMode?: ReadLockMode;
 }
 
 export type DeleteRowsCallback = CommitCallback;
@@ -1109,6 +1111,11 @@ class Table {
         'isolationLevel' in options
           ? options.isolationLevel
           : IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED;
+
+      const readLockMode =
+        'readLockMode' in options
+          ? options.readLockMode
+          : ReadLockMode.READ_LOCK_MODE_UNSPECIFIED;
 
       this.database.runTransaction(
         {

--- a/src/table.ts
+++ b/src/table.ts
@@ -1122,6 +1122,7 @@ class Table {
           requestOptions: requestOptions,
           excludeTxnFromChangeStreams: excludeTxnFromChangeStreams,
           isolationLevel: isolationLevel,
+          readLockMode: readLockMode,
         },
         (err, transaction) => {
           if (err) {

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -27,6 +27,7 @@ import {Database} from './database';
 import {google} from '../protos/protos';
 import IRequestOptions = google.spanner.v1.IRequestOptions;
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const jsonProtos = require('../protos/protos.json');
@@ -45,9 +46,9 @@ const RetryInfo = Root.fromJSON(jsonProtos).lookup('google.rpc.RetryInfo');
 export interface RunTransactionOptions {
   timeout?: number;
   requestOptions?: Pick<IRequestOptions, 'transactionTag'>;
-  optimisticLock?: boolean;
   excludeTxnFromChangeStreams?: boolean;
   isolationLevel?: IsolationLevel;
+  readLockMode?: ReadLockMode;
 }
 
 /**
@@ -130,6 +131,7 @@ export abstract class Runner<T> {
     const defaults = {
       timeout: 3600000,
       isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+      readLockMode: ReadLockMode.READ_LOCK_MODE_UNSPECIFIED,
     };
 
     this.options = Object.assign(defaults, options);

--- a/src/transaction-runner.ts
+++ b/src/transaction-runner.ts
@@ -46,6 +46,10 @@ const RetryInfo = Root.fromJSON(jsonProtos).lookup('google.rpc.RetryInfo');
 export interface RunTransactionOptions {
   timeout?: number;
   requestOptions?: Pick<IRequestOptions, 'transactionTag'>;
+  /**
+   * @deprecated Use readLockMode instead.
+   */
+  optimisticLock?: boolean;
   excludeTxnFromChangeStreams?: boolean;
   isolationLevel?: IsolationLevel;
   readLockMode?: ReadLockMode;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -2946,6 +2946,8 @@ export class Transaction extends Dml {
    * (when any needed locks are acquired). The validation process succeeds only
    * if there are no conflicting committed transactions (that committed
    * mutations to the read data at a commit timestamp after the read timestamp).
+   *
+   * @deprecated Set readLockMode through setReadWriteTransactionOptions instead.
    */
   useOptimisticLock(): void {
     this._options.readWrite!.readLockMode = ReadLockMode.OPTIMISTIC;
@@ -2965,12 +2967,6 @@ export class Transaction extends Dml {
 
   setReadWriteTransactionOptions(options: RunTransactionOptions) {
     /**
-     * Set optimistic concurrency control for the transaction.
-     */
-    if (options?.optimisticLock) {
-      this._options.readWrite!.readLockMode = ReadLockMode.OPTIMISTIC;
-    }
-    /**
      * Set option excludeTxnFromChangeStreams=true to exclude read/write transactions
      * from being tracked in change streams.
      */
@@ -2978,11 +2974,18 @@ export class Transaction extends Dml {
       this._options.excludeTxnFromChangeStreams = true;
     }
     /**
-     * Set isolation level .
+     * Set isolation level.
      */
     this._options.isolationLevel = options?.isolationLevel
       ? options?.isolationLevel
       : this._getSpanner().defaultTransactionOptions.isolationLevel;
+
+    /**
+     * Set read lock mode.
+     */
+    this._options.readWrite!.readLockMode = options?.readLockMode
+      ? options?.readLockMode
+      : this._getSpanner().defaultTransactionOptions.readLockMode;
   }
 }
 

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -49,6 +49,7 @@ import {google} from '../protos/protos';
 import CreateDatabaseMetadata = google.spanner.admin.database.v1.CreateDatabaseMetadata;
 import CreateBackupMetadata = google.spanner.admin.database.v1.CreateBackupMetadata;
 import CreateInstanceConfigMetadata = google.spanner.admin.instance.v1.CreateInstanceConfigMetadata;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 const singer = require('../test/data/singer');
 const music = singer.examples.spanner.music;
 import {util} from 'protobufjs';
@@ -9152,7 +9153,7 @@ describe('Spanner', () => {
 
       it('GOOGLE_STANDARD_SQL should use getTransaction for executing sql', async () => {
         const transaction = (
-          await DATABASE.getTransaction({optimisticLock: true})
+          await DATABASE.getTransaction({readLockMode: ReadLockMode.OPTIMISTIC})
         )[0];
 
         try {

--- a/test/database.ts
+++ b/test/database.ts
@@ -3535,9 +3535,9 @@ describe('Database', () => {
               readLockMode: ReadLockMode.PESSIMISTIC,
             };
 
-            await database.runTransaction(fakeOptions, assert.ifError);
+            await database.runTransactionAsync(fakeOptions, assert.ifError);
 
-            const options = fakeTransactionRunner.calledWith_[3];
+            const options = fakeAsyncTransactionRunner.calledWith_[3];
             assert.strictEqual(options, fakeOptions);
           });
 

--- a/test/database.ts
+++ b/test/database.ts
@@ -3402,6 +3402,17 @@ describe('Database', () => {
             assert.strictEqual(options, fakeOptions);
           });
 
+          it('should optionally accept runner `option` readLockMode', async () => {
+            const fakeOptions = {
+              readLockMode: ReadLockMode.PESSIMISTIC,
+            };
+
+            await database.runTransaction(fakeOptions, assert.ifError);
+
+            const options = fakeTransactionRunner.calledWith_[3];
+            assert.strictEqual(options, fakeOptions);
+          });
+
           it('should release the session when finished', done => {
             const releaseStub = (
               sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
@@ -3516,6 +3527,17 @@ describe('Database', () => {
             await database.runTransactionAsync(fakeOptions, assert.ifError);
 
             const options = fakeAsyncTransactionRunner.calledWith_[3];
+            assert.strictEqual(options, fakeOptions);
+          });
+
+          it('should optionally accept runner `option` readLockMode', async () => {
+            const fakeOptions = {
+              readLockMode: ReadLockMode.PESSIMISTIC,
+            };
+
+            await database.runTransaction(fakeOptions, assert.ifError);
+
+            const options = fakeTransactionRunner.calledWith_[3];
             assert.strictEqual(options, fakeOptions);
           });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -40,6 +40,7 @@ import {
 import {CLOUD_RESOURCE_HEADER, AFE_SERVER_TIMING_HEADER} from '../src/common';
 import {MetricsTracerFactory} from '../src/metrics/metrics-tracer-factory';
 import IsolationLevel = protos.google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = protos.google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 const singer = require('./data/singer');
 const music = singer.examples.spanner.music;
 
@@ -357,6 +358,7 @@ describe('Spanner', () => {
       const fakeDefaultTxnOptions = {
         defaultTransactionOptions: {
           isolationLevel: IsolationLevel.REPEATABLE_READ,
+          readLockMode: ReadLockMode.PESSIMISTIC,
         },
       };
 

--- a/test/table.ts
+++ b/test/table.ts
@@ -28,6 +28,7 @@ import {TimestampBounds} from '../src/transaction';
 import {google} from '../protos/protos';
 import RequestOptions = google.spanner.v1.RequestOptions;
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 
 let promisified = false;
 const fakePfy = extend({}, pfy, {
@@ -408,6 +409,17 @@ describe('Table', () => {
       table.deleteRows(KEYS, deleteRowsOptions, assert.ifError);
     });
 
+    it('should accept readLockMode option', done => {
+      const deleteRowsOptions = {
+        readLockMode: ReadLockMode.OPTIMISTIC,
+      };
+      transaction.commit = options => {
+        assert.strictEqual(options, deleteRowsOptions);
+        done();
+      };
+      table.deleteRows(KEYS, deleteRowsOptions, assert.ifError);
+    });
+
     it('should delete the rows via transaction', done => {
       const stub = (
         sandbox.stub(transaction, 'deleteRows') as sinon.SinonStub
@@ -541,6 +553,22 @@ describe('Table', () => {
     it('should accept isolationLevel options', done => {
       const insertRowsOptions = {
         isolationLevel: IsolationLevel.REPEATABLE_READ,
+      };
+      (sandbox.stub(transaction, 'insert') as sinon.SinonStub).withArgs(
+        table.name,
+        ROW,
+      );
+      transaction.commit = options => {
+        assert.strictEqual(options, insertRowsOptions);
+        done();
+      };
+
+      table.insert(ROW, insertRowsOptions, assert.ifError);
+    });
+
+    it('should accept readLockMode options', done => {
+      const insertRowsOptions = {
+        readLockMode: ReadLockMode.OPTIMISTIC,
       };
       (sandbox.stub(transaction, 'insert') as sinon.SinonStub).withArgs(
         table.name,
@@ -726,6 +754,22 @@ describe('Table', () => {
 
       table.replace(ROW, replaceRowsOptions, assert.ifError);
     });
+
+    it('should accept readLockMode options', done => {
+      const replaceRowsOptions = {
+        readLockMode: ReadLockMode.OPTIMISTIC,
+      };
+      (sandbox.stub(transaction, 'replace') as sinon.SinonStub).withArgs(
+        table.name,
+        ROW,
+      );
+      transaction.commit = options => {
+        assert.strictEqual(options, replaceRowsOptions);
+        done();
+      };
+
+      table.replace(ROW, replaceRowsOptions, assert.ifError);
+    });
   });
 
   describe('update', () => {
@@ -832,6 +876,22 @@ describe('Table', () => {
 
       table.update(ROW, updateRowsOptions, assert.ifError);
     });
+
+    it('should accept readLockMode option', done => {
+      const updateRowsOptions = {
+        readLockMode: ReadLockMode.OPTIMISTIC,
+      };
+      (sandbox.stub(transaction, 'update') as sinon.SinonStub).withArgs(
+        table.name,
+        ROW,
+      );
+      transaction.commit = options => {
+        assert.strictEqual(options, updateRowsOptions);
+        done();
+      };
+
+      table.update(ROW, updateRowsOptions, assert.ifError);
+    });
   });
 
   describe('upsert', () => {
@@ -926,6 +986,22 @@ describe('Table', () => {
     it('should accept isolationLevel option', done => {
       const upsertRowsOptions = {
         isolationLevel: IsolationLevel.REPEATABLE_READ,
+      };
+      (sandbox.stub(transaction, 'upsert') as sinon.SinonStub).withArgs(
+        table.name,
+        ROW,
+      );
+      transaction.commit = options => {
+        assert.strictEqual(options, upsertRowsOptions);
+        done();
+      };
+
+      table.upsert(ROW, upsertRowsOptions, assert.ifError);
+    });
+
+    it('should accept readLockMode option', done => {
+      const upsertRowsOptions = {
+        readLockMode: ReadLockMode.OPTIMISTIC,
       };
       (sandbox.stub(transaction, 'upsert') as sinon.SinonStub).withArgs(
         table.name,

--- a/test/transaction-runner.ts
+++ b/test/transaction-runner.ts
@@ -24,6 +24,7 @@ import * as through from 'through2';
 import {RunTransactionOptions} from '../src/transaction-runner';
 import {google} from '../protos/protos';
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
+import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
 import {randomUUID} from 'crypto';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -120,6 +121,7 @@ describe('TransactionRunner', () => {
         const expectedOptions = {
           timeout: 3600000,
           isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+          readLockMode: ReadLockMode.READ_LOCK_MODE_UNSPECIFIED,
         };
 
         assert.deepStrictEqual(runner.options, expectedOptions);
@@ -127,7 +129,8 @@ describe('TransactionRunner', () => {
 
       it('should accept user `options`', () => {
         const options = {
-          isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+          isolationLevel: IsolationLevel.SERIALIZABLE,
+          readLockMode: ReadLockMode.OPTIMISTIC,
           timeout: 1000,
         };
         const r = new ExtendedRunner(SESSION, fakeTransaction, options);
@@ -425,7 +428,8 @@ describe('TransactionRunner', () => {
 
       it('should pass `options` to `Runner`', () => {
         const options = {
-          isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+          isolationLevel: IsolationLevel.REPEATABLE_READ,
+          readLockMode: ReadLockMode.PESSIMISTIC,
           timeout: 1,
         };
         const r = new TransactionRunner(
@@ -624,7 +628,8 @@ describe('TransactionRunner', () => {
 
       it('should pass `options` to `Runner`', () => {
         const options = {
-          isolationLevel: IsolationLevel.ISOLATION_LEVEL_UNSPECIFIED,
+          isolationLevel: IsolationLevel.REPEATABLE_READ,
+          readLockMode: ReadLockMode.OPTIMISTIC,
           timeout: 1,
         };
         const r = new AsyncTransactionRunner(


### PR DESCRIPTION
Supports setting the read lock mode in R/W transactions at both the client level and at an individual transaction level.

This change allows for the read lock mode to be set independently or alongside the transaction isolation level selection. Therefore transactions can be run in the following modes:
- Serializable isolation with pessimistic locking (default isolation level and locking mode in Spanner)
- Serializable isolation with optimistic locking
- Repeatable read isolation with optimistic locking (default locking mode for Repeatable Read isolation)
- Repeatable read isolation with pessimistic locking

If no isolation level is selected, Spanner transactions default to Serializable isolation with pessimistic locking. If no read lock mode is chosen for Repeatable Read isolation, transactions default to optimistic locking.