### PR TITLE
fix: disable afe_connectivity_error_count metric

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         node: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: node --version
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: node --version
@@ -44,7 +44,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install --engine-strict
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install

--- a/.github/workflows/issues-no-repro.yaml
+++ b/.github/workflows/issues-no-repro.yaml
@@ -11,12 +11,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - run: npm install
         working-directory: ./.github/scripts
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./.github/scripts/close-invalid-link.cjs')

--- a/.github/workflows/response.yaml
+++ b/.github/workflows/response.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./.github/scripts/close-unresponsive.cjs')
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@v7
         with:
           script: |
             const script = require('./.github/scripts/remove-response-label.cjs')

--- a/src/metrics/interceptor.ts
+++ b/src/metrics/interceptor.ts
@@ -67,7 +67,9 @@ export const MetricInterceptor = (options, nextCall) => {
           if (metricsTracer?.afeLatency) {
             metricsTracer?.recordAfeLatency(status.code);
           } else {
-            metricsTracer?.recordAfeConnectivityErrorCount(status.code);
+            // Disable afe_connectivity_error_count metric as AFE header is disabled in backend
+            // currently.
+            // metricsTracer?.recordAfeConnectivityErrorCount(status.code);
           }
         },
       };

--- a/test/metrics/interceptor.ts
+++ b/test/metrics/interceptor.ts
@@ -193,7 +193,7 @@ describe('MetricInterceptor', () => {
       );
     });
 
-    it('AFE Metrics - Connectivity Error Count', () => {
+    it.skip('AFE Metrics - Connectivity Error Count', () => {
       const interceptingCall = MetricInterceptor(mockOptions, mockNextCall);
       interceptingCall.start(testMetadata, mockListener);
 

--- a/test/metrics/metrics.ts
+++ b/test/metrics/metrics.ts
@@ -457,10 +457,6 @@ describe('Test metrics with mock server', () => {
         resourceMetrics,
         METRIC_NAME_GFE_CONNECTIVITY_ERROR_COUNT,
       );
-      const afeConnectivityErrorCountData = getMetricData(
-        resourceMetrics,
-        METRIC_NAME_AFE_CONNECTIVITY_ERROR_COUNT,
-      );
 
       // Verify GFE AFE latency doesn't exist
       assert.ok(!hasMetricData(resourceMetrics, METRIC_NAME_GFE_LATENCIES));
@@ -484,10 +480,6 @@ describe('Test metrics with mock server', () => {
         // Verify that GFE AFE connectivity error count increased
         assert.strictEqual(
           getAggregatedValue(connectivityErrorCountData, attributes),
-          1,
-        );
-        assert.strictEqual(
-          getAggregatedValue(afeConnectivityErrorCountData, attributes),
           1,
         );
       });


### PR DESCRIPTION
This PR disables afe_connectivity_error_count . The afe Header is disabled on backend currently

BEGIN_COMMIT_OVERRIDE
fix: disable afe_connectivity_error_count metric
END_COMMIT_OVERRIDE