### PR TITLE
chore: remove types/uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@types/request": "^2.48.12",
     "@types/sinon": "^17.0.4",
     "@types/through2": "^2.0.41",
-    "@types/uuid": "^10.0.0",
     "binary-search-bounds": "^2.0.5",
     "c8": "^10.1.3",
     "codecov": "^3.8.3",


### PR DESCRIPTION
Removing this package as it has been [deprecated](https://www.npmjs.com/package/@types/uuid?activeTab=code) and uuid package now includes its own Typescript types.