### PR TITLE
fix: allow undefined config in createInstance (2442)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -713,7 +713,7 @@ class Spanner extends GrpcService {
     delete reqOpts.instance.nodes;
     delete reqOpts.instance.gaxOptions;
 
-    if (config.config!.indexOf('/') === -1) {
+    if (config.config && config.config.indexOf('/') === -1) {
       reqOpts.instance.config = `projects/${this.projectId}/instanceConfigs/${config.config}`;
     }
     this.request(


### PR DESCRIPTION
## Description

When calling `spanner.createInstance("name", {})` wherein `config.config` is omitted, we were previously erroring out since we were calling `indexOf` on an undefined value.

As such, we add a check first prior calling `indexOf`

## Impact

Allows skipping of `config` key in `createInstance` options.

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-spanner/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #2442 