### PR TITLE
fix: Configure gRPC keep alive as 120 sec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -417,8 +417,7 @@ class Spanner extends GrpcService {
         libVersion: require('../../package.json').version,
         scopes,
         // Add grpc keep alive setting
-        'grpc.keepalive_time_ms': 30000,
-        'grpc.keepalive_timeout_ms': 10000,
+        'grpc.keepalive_time_ms': 120000,
         // Enable grpc-gcp support
         'grpc.callInvocationTransformer': grpcGcp.gcpCallInvocationTransformer,
         'grpc.channelFactoryOverride': grpcGcp.gcpChannelFactoryOverride,

--- a/test/index.ts
+++ b/test/index.ts
@@ -228,8 +228,7 @@ describe('Spanner', () => {
       libVersion: require('../../package.json').version,
       scopes: [],
       grpc,
-      'grpc.keepalive_time_ms': 30000,
-      'grpc.keepalive_timeout_ms': 10000,
+      'grpc.keepalive_time_ms': 120000,
       'grpc.callInvocationTransformer':
         fakeGrpcGcp().gcpCallInvocationTransformer,
       'grpc.channelFactoryOverride': fakeGrpcGcp().gcpChannelFactoryOverride,


### PR DESCRIPTION
This PR modifies gRPC keepalive_time_ms from 30 sec to 120 sec as per the other languages (Refer [Java](https://github.com/googleapis/java-spanner/blob/2967a124df26f3b97f1fb07b073e9d603ddf4af2/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java#L353) )

This also removes the gRPC keepalive_timeout_ms configuration, the default configured for gRPC is 20 seconds

These settings can be over written by passing to spanner options

```
const spanner = new Spanner({ 
    'grpc.keepalive_time_ms': 30000,
  });
```