### PR TITLE
feat: multiplexed session as default session mode

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -7,7 +7,7 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - "ci/kokoro: Samples test"
       - "ci/kokoro: System test"
-      - "ci/kokoro: System test with Multiplexed Session"
+      - "ci/kokoro: System test with Regular Sessions"
       - lint
       - test (18)
       - test (20)

--- a/.kokoro/presubmit/node18/system-test-regular-session.cfg
+++ b/.kokoro/presubmit/node18/system-test-regular-session.cfg
@@ -13,15 +13,15 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS"
-  value: "true"
+  value: "false"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS"
-  value: "true"
+  value: "false"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW"
-  value: "true"
+  value: "false"
 }

--- a/observability-test/helper.ts
+++ b/observability-test/helper.ts
@@ -19,6 +19,11 @@ import * as assert from 'assert';
 const {ReadableSpan} = require('@opentelemetry/sdk-trace-base');
 import {SEMATTRS_DB_NAME} from '@opentelemetry/semantic-conventions';
 
+export const createSessionEvents = [
+  'Requesting a multiplexed session',
+  'Created a multiplexed session',
+];
+
 export const batchCreateSessionsEvents = [
   'Requesting 25 sessions',
   'Creating 25 sessions',
@@ -26,16 +31,14 @@ export const batchCreateSessionsEvents = [
 ];
 
 export const waitingSessionsEvents = [
-  'Acquiring session',
-  'Waiting for a session to become available',
-  'Acquired session',
+  'Waiting for a multiplexed session to become available',
+  'Acquired multiplexed session',
   'Using Session',
 ];
 
 export const cacheSessionEvents = [
-  'Acquiring session',
-  'Cache hit: has usable session',
-  'Acquired session',
+  'Cache hit: has usable multiplexed session',
+  'Acquired multiplexed session',
 ];
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1840,7 +1840,7 @@ class Spanner extends GrpcService {
       metricsTracer =
         MetricsTracerFactory?.getInstance(this.projectId_)?.createMetricsTracer(
           config.method,
-          config.reqOpts.session ?? config.reqOpts.database,
+          config.reqOpts.database ?? config.reqOpts.session,
           config.headers['x-goog-spanner-request-id'],
         ) ?? null;
     }

--- a/src/multiplexed-session.ts
+++ b/src/multiplexed-session.ts
@@ -126,9 +126,7 @@ export class MultiplexedSession
             multiplexed: true,
           });
           this._multiplexedSession = createSessionResponse;
-          span.addEvent(
-            `Created multiplexed session ${this._multiplexedSession.id}`,
-          );
+          span.addEvent('Created a multiplexed session');
           this.emit(MUX_SESSION_AVAILABLE);
         } catch (e) {
           setSpanError(span, e as Error);
@@ -197,7 +195,9 @@ export class MultiplexedSession
    *
    */
   async _acquire(): Promise<Session | null> {
+    const span = getActiveOrNoopSpan();
     const session = await this._getSession();
+    span.addEvent('Acquired multiplexed session');
     return session;
   }
 

--- a/system-test/spanner.ts
+++ b/system-test/spanner.ts
@@ -1246,9 +1246,9 @@ describe('Spanner', () => {
 
       const numericInsertOutOfBounds = (done, dialect, value) => {
         insert({NumericValue: value}, dialect, err => {
-          KOKORO_JOB_NAME?.includes('system-test-multiplexed-session')
-            ? assert.strictEqual(err.code, grpc.status.INVALID_ARGUMENT)
-            : assert.strictEqual(err.code, grpc.status.FAILED_PRECONDITION);
+          KOKORO_JOB_NAME?.includes('system-test-regular-session')
+            ? assert.strictEqual(err.code, grpc.status.FAILED_PRECONDITION)
+            : assert.strictEqual(err.code, grpc.status.INVALID_ARGUMENT);
           done();
         });
       };

--- a/test/database.ts
+++ b/test/database.ts
@@ -154,12 +154,12 @@ export class FakeSessionFactory extends EventEmitter {
   }
   release() {}
   isMultiplexedEnabled(): boolean {
-    return process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS === 'true';
+    return process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS! === 'false';
   }
   isMultiplexedEnabledForRW(): boolean {
     return (
-      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS === 'true' &&
-      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW === 'true'
+      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS! === 'false' &&
+      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW! === 'false'
     );
   }
 }
@@ -352,21 +352,30 @@ describe('Database', () => {
       assert(database.pool_ instanceof FakeSessionPool);
     });
 
-    it('should re-emit SessionPool errors', done => {
-      const error = new Error('err');
-
-      const sessionFactory = new SessionFactory(database, NAME);
-
-      database.on('error', err => {
-        assert.strictEqual(err, error);
-        done();
+    describe('when multiplexed session is disabled', () => {
+      before(() => {
+        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
       });
 
-      sessionFactory.pool_.emit('error', error);
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+      });
+
+      it('should re-emit SessionPool errors', done => {
+        const error = new Error('err');
+
+        const sessionFactory = new SessionFactory(database, NAME);
+
+        database.on('error', err => {
+          assert.strictEqual(err, error);
+          done();
+        });
+
+        sessionFactory.pool_.emit('error', error);
+      });
     });
 
     it('should re-emit Multiplexed Session errors', done => {
-      process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
       const error = new Error('err');
 
       const sessionFactory = new SessionFactory(database, NAME);
@@ -671,201 +680,167 @@ describe('Database', () => {
       gaxOptions: {autoPaginate: false},
     } as BatchWriteOptions;
 
-    // muxEnabled[i][0] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS
-    // muxEnabled[i][1] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW
-    const muxEnabled = [
-      [true, true],
-      [true, false],
-      [false, true],
-      [false, false],
-    ];
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      fakeSession = new FakeSession();
+      fakeDataStream = through.obj();
 
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled[0] ? 'enabled' : 'disable'}` +
-          ' and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW is ' +
-          `${isMuxEnabled[1] ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-              isMuxEnabled[0].toString();
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-              isMuxEnabled[1].toString();
-          });
+      getSessionStub = (
+        sandbox.stub(
+          fakeSessionFactory,
+          'getSessionForReadWrite',
+        ) as sinon.SinonStub
+      ).callsFake(callback => callback(null, fakeSession));
 
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
-          });
+      requestStreamStub = sandbox
+        .stub(database, 'requestStream')
+        .returns(fakeDataStream);
+    });
 
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            fakeSession = new FakeSession();
-            fakeDataStream = through.obj();
+    it('should get a session via `getSessionForReadWrite`', done => {
+      getSessionStub.callsFake(() => {});
+      database.batchWriteAtLeastOnce(mutationGroups, options);
+      assert.strictEqual(getSessionStub.callCount, 1);
+      done();
+    });
 
-            getSessionStub = (
-              sandbox.stub(
-                fakeSessionFactory,
-                'getSessionForReadWrite',
-              ) as sinon.SinonStub
-            ).callsFake(callback => callback(null, fakeSession));
+    it('should destroy the stream if `getSessionForReadWrite` errors', done => {
+      const fakeError = new Error('err');
 
-            requestStreamStub = sandbox
-              .stub(database, 'requestStream')
-              .returns(fakeDataStream);
-          });
+      getSessionStub.callsFake(callback => callback(fakeError));
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('error', err => {
+          assert.strictEqual(err, fakeError);
+          done();
+        });
+    });
 
-          it('should get a session via `getSessionForReadWrite`', done => {
-            getSessionStub.callsFake(() => {});
-            database.batchWriteAtLeastOnce(mutationGroups, options);
-            assert.strictEqual(getSessionStub.callCount, 1);
-            done();
-          });
-
-          it('should destroy the stream if `getSessionForReadWrite` errors', done => {
-            const fakeError = new Error('err');
-
-            getSessionStub.callsFake(callback => callback(fakeError));
-            database
-              .batchWriteAtLeastOnce(mutationGroups, options)
-              .on('error', err => {
-                assert.strictEqual(err, fakeError);
-                done();
-              });
-          });
-
-          it('should call `requestStream` with correct arguments', () => {
-            const expectedGaxOpts = extend(true, {}, options?.gaxOptions);
-            const expectedReqOpts = Object.assign(
-              {} as google.spanner.v1.BatchWriteRequest,
-              {
-                session: fakeSession!.formattedName_!,
-                mutationGroups: mutationGroups.map(mg => mg.proto()),
-                requestOptions: options?.requestOptions,
-                excludeTxnFromChangeStream:
-                  options?.excludeTxnFromChangeStreams,
-              },
-            );
-
-            database.batchWriteAtLeastOnce(mutationGroups, options);
-
-            assert.strictEqual(requestStreamStub.callCount, 1);
-            const args = requestStreamStub.firstCall.args[0];
-            assert.strictEqual(args.client, 'SpannerClient');
-            assert.strictEqual(args.method, 'batchWrite');
-            assert.deepStrictEqual(args.reqOpts, expectedReqOpts);
-            assert.deepStrictEqual(args.gaxOpts, expectedGaxOpts);
-            assert.deepStrictEqual(args.headers, database.commonHeaders_);
-          });
-
-          it('should return error when passing an empty list of mutationGroups', done => {
-            const fakeError = new Error('err');
-            database.batchWriteAtLeastOnce([], options).on('error', error => {
-              assert.strictEqual(error, fakeError);
-              done();
-            });
-            fakeDataStream.emit('error', fakeError);
-          });
-
-          it('should return data when passing a valid list of mutationGroups', done => {
-            database
-              .batchWriteAtLeastOnce(mutationGroups, options)
-              .on('data', data => {
-                assert.strictEqual(data, 'test');
-                done();
-              });
-            fakeDataStream.emit('data', 'test');
-          });
-
-          it('should emit correct event based on valid/invalid list of mutationGroups', done => {
-            const fakeError = new Error('err');
-            const FakeMutationGroup1 = new MutationGroup();
-            FakeMutationGroup1.insert('Singers', {
-              SingerId: 1,
-              FirstName: 'Scarlet',
-              LastName: 'Terry',
-            });
-            FakeMutationGroup1.insert('Singers', {
-              SingerId: 1000000000000000000000000000000000,
-              FirstName: 'Scarlet',
-              LastName: 'Terry',
-            });
-
-            const FakeMutationGroup2 = new MutationGroup();
-            FakeMutationGroup2.insert('Singers', {
-              SingerId: 2,
-              FirstName: 'Marc',
-            });
-            FakeMutationGroup2.insert('Singers', {
-              SingerId: 3,
-              FirstName: 'Catalina',
-              LastName: 'Smith',
-            });
-            FakeMutationGroup2.insert('Albums', {
-              AlbumId: 1,
-              SingerId: 2,
-              AlbumTitle: 'Total Junk',
-            });
-            FakeMutationGroup2.insert('Albums', {
-              AlbumId: 2,
-              SingerId: 3,
-              AlbumTitle: 'Go, Go, Go',
-            });
-            database
-              .batchWriteAtLeastOnce(
-                [FakeMutationGroup1, FakeMutationGroup2],
-                options,
-              )
-              .on('data', data => {
-                assert.strictEqual(data, 'testData');
-              })
-              .on('error', err => {
-                assert.strictEqual(err, fakeError);
-              });
-            fakeDataStream.emit('data', 'testData');
-            fakeDataStream.emit('error', fakeError);
-            done();
-          });
-
-          it('should retry on "Session not found" error', done => {
-            const sessionNotFoundError = {
-              code: grpc.status.NOT_FOUND,
-              message: 'Session not found',
-            } as grpc.ServiceError;
-            let retryCount = 0;
-
-            database
-              .batchWriteAtLeastOnce(mutationGroups, options)
-              .on('data', () => {})
-              .on('error', err => {
-                assert.fail(err);
-              })
-              .on('end', () => {
-                assert.strictEqual(retryCount, 1);
-                done();
-              });
-
-            fakeDataStream.emit('error', sessionNotFoundError);
-            retryCount++;
-          });
-
-          if (isMuxEnabled[0] === false && isMuxEnabled[1] === false) {
-            it('should release session on stream end', () => {
-              const releaseStub = sandbox.stub(
-                fakeSessionFactory,
-                'release',
-              ) as sinon.SinonStub;
-
-              database.batchWriteAtLeastOnce(mutationGroups, options);
-              fakeDataStream.emit('end');
-
-              assert.strictEqual(releaseStub.callCount, 1);
-              assert.strictEqual(releaseStub.firstCall.args[0], fakeSession);
-            });
-          }
+    it('should call `requestStream` with correct arguments', () => {
+      const expectedGaxOpts = extend(true, {}, options?.gaxOptions);
+      const expectedReqOpts = Object.assign(
+        {} as google.spanner.v1.BatchWriteRequest,
+        {
+          session: fakeSession!.formattedName_!,
+          mutationGroups: mutationGroups.map(mg => mg.proto()),
+          requestOptions: options?.requestOptions,
+          excludeTxnFromChangeStream: options?.excludeTxnFromChangeStreams,
         },
       );
+
+      database.batchWriteAtLeastOnce(mutationGroups, options);
+
+      assert.strictEqual(requestStreamStub.callCount, 1);
+      const args = requestStreamStub.firstCall.args[0];
+      assert.strictEqual(args.client, 'SpannerClient');
+      assert.strictEqual(args.method, 'batchWrite');
+      assert.deepStrictEqual(args.reqOpts, expectedReqOpts);
+      assert.deepStrictEqual(args.gaxOpts, expectedGaxOpts);
+      assert.deepStrictEqual(args.headers, database.commonHeaders_);
+    });
+
+    it('should return error when passing an empty list of mutationGroups', done => {
+      const fakeError = new Error('err');
+      database.batchWriteAtLeastOnce([], options).on('error', error => {
+        assert.strictEqual(error, fakeError);
+        done();
+      });
+      fakeDataStream.emit('error', fakeError);
+    });
+
+    it('should return data when passing a valid list of mutationGroups', done => {
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('data', data => {
+          assert.strictEqual(data, 'test');
+          done();
+        });
+      fakeDataStream.emit('data', 'test');
+    });
+
+    it('should emit correct event based on valid/invalid list of mutationGroups', done => {
+      const fakeError = new Error('err');
+      const FakeMutationGroup1 = new MutationGroup();
+      FakeMutationGroup1.insert('Singers', {
+        SingerId: 1,
+        FirstName: 'Scarlet',
+        LastName: 'Terry',
+      });
+      FakeMutationGroup1.insert('Singers', {
+        SingerId: 1000000000000000000000000000000000,
+        FirstName: 'Scarlet',
+        LastName: 'Terry',
+      });
+
+      const FakeMutationGroup2 = new MutationGroup();
+      FakeMutationGroup2.insert('Singers', {
+        SingerId: 2,
+        FirstName: 'Marc',
+      });
+      FakeMutationGroup2.insert('Singers', {
+        SingerId: 3,
+        FirstName: 'Catalina',
+        LastName: 'Smith',
+      });
+      FakeMutationGroup2.insert('Albums', {
+        AlbumId: 1,
+        SingerId: 2,
+        AlbumTitle: 'Total Junk',
+      });
+      FakeMutationGroup2.insert('Albums', {
+        AlbumId: 2,
+        SingerId: 3,
+        AlbumTitle: 'Go, Go, Go',
+      });
+      database
+        .batchWriteAtLeastOnce(
+          [FakeMutationGroup1, FakeMutationGroup2],
+          options,
+        )
+        .on('data', data => {
+          assert.strictEqual(data, 'testData');
+        })
+        .on('error', err => {
+          assert.strictEqual(err, fakeError);
+        });
+      fakeDataStream.emit('data', 'testData');
+      fakeDataStream.emit('error', fakeError);
+      done();
+    });
+
+    it('should retry on "Session not found" error', done => {
+      const sessionNotFoundError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as grpc.ServiceError;
+      let retryCount = 0;
+
+      database
+        .batchWriteAtLeastOnce(mutationGroups, options)
+        .on('data', () => {})
+        .on('error', err => {
+          assert.fail(err);
+        })
+        .on('end', () => {
+          assert.strictEqual(retryCount, 1);
+          done();
+        });
+
+      fakeDataStream.emit('error', sessionNotFoundError);
+      retryCount++;
+    });
+
+    it('should release session on stream end', () => {
+      const releaseStub = sandbox.stub(
+        fakeSessionFactory,
+        'release',
+      ) as sinon.SinonStub;
+
+      database.batchWriteAtLeastOnce(mutationGroups, options);
+      fakeDataStream.emit('end');
+
+      assert.strictEqual(releaseStub.callCount, 1);
+      assert.strictEqual(releaseStub.firstCall.args[0], fakeSession);
     });
   });
 
@@ -884,92 +859,74 @@ describe('Database', () => {
 
     let sessionFactory: FakeSessionFactory;
 
-    const muxEnabled = [true, false];
-
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            isMuxEnabled
-              ? (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true')
-              : (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-                  'false');
-          });
-
-          beforeEach(() => {
-            sandbox.restore();
-            sessionFactory = database.sessionFactory_;
-            (
-              sandbox.stub(sessionFactory, 'getSession') as sinon.SinonStub
-            ).callsFake(callback => {
-              callback(null, SESSION, TRANSACTION);
-            });
-          });
-
-          it('should return any errors getting a session', done => {
-            const fakeErr = new Error('err');
-
-            (sessionFactory.getSession as sinon.SinonStub).callsFake(callback =>
-              callback(fakeErr, null, null),
-            );
-
-            database.writeAtLeastOnce(mutations, err => {
-              assert.deepStrictEqual(err, fakeErr);
-              done();
-            });
-          });
-
-          it('should return successful CommitResponse when passing an empty mutation', done => {
-            const fakeMutations = new MutationSet();
-            try {
-              database.writeAtLeastOnce(fakeMutations, (err, response) => {
-                assert.ifError(err);
-                assert.deepStrictEqual(
-                  response.commitTimestamp,
-                  RESPONSE.commitTimestamp,
-                );
-              });
-              done();
-            } catch (error) {
-              assert(error instanceof Error);
-            }
-          });
-
-          it('should return an error when passing null mutation', done => {
-            try {
-              database.writeAtLeastOnce(null, () => {});
-            } catch (err) {
-              const errorMessage = (err as grpc.ServiceError).message;
-              assert.ok(
-                errorMessage.includes(
-                  "Cannot read properties of null (reading 'proto')",
-                ) ||
-                  errorMessage.includes("Cannot read property 'proto' of null"),
-              );
-
-              done();
-            }
-          });
-
-          it('should return CommitResponse on successful write using Callback', done => {
-            database.writeAtLeastOnce(mutations, (err, res) => {
-              assert.deepStrictEqual(err, null);
-              assert.deepStrictEqual(res, RESPONSE);
-              done();
-            });
-          });
-
-          it('should return CommitResponse on successful write using await', async () => {
-            sinon.stub(database, 'writeAtLeastOnce').resolves([RESPONSE]);
-            const [response] = await database.writeAtLeastOnce(mutations, {});
-            assert.deepStrictEqual(
-              response.commitTimestamp,
-              RESPONSE.commitTimestamp,
-            );
-          });
+    beforeEach(() => {
+      sandbox.restore();
+      sessionFactory = database.sessionFactory_;
+      (sandbox.stub(sessionFactory, 'getSession') as sinon.SinonStub).callsFake(
+        callback => {
+          callback(null, SESSION, TRANSACTION);
         },
+      );
+    });
+
+    it('should return any errors getting a session', done => {
+      const fakeErr = new Error('err');
+
+      (sessionFactory.getSession as sinon.SinonStub).callsFake(callback =>
+        callback(fakeErr, null, null),
+      );
+
+      database.writeAtLeastOnce(mutations, err => {
+        assert.deepStrictEqual(err, fakeErr);
+        done();
+      });
+    });
+
+    it('should return successful CommitResponse when passing an empty mutation', done => {
+      const fakeMutations = new MutationSet();
+      try {
+        database.writeAtLeastOnce(fakeMutations, (err, response) => {
+          assert.ifError(err);
+          assert.deepStrictEqual(
+            response.commitTimestamp,
+            RESPONSE.commitTimestamp,
+          );
+        });
+        done();
+      } catch (error) {
+        assert(error instanceof Error);
+      }
+    });
+
+    it('should return an error when passing null mutation', done => {
+      try {
+        database.writeAtLeastOnce(null, () => {});
+      } catch (err) {
+        const errorMessage = (err as grpc.ServiceError).message;
+        assert.ok(
+          errorMessage.includes(
+            "Cannot read properties of null (reading 'proto')",
+          ) || errorMessage.includes("Cannot read property 'proto' of null"),
+        );
+
+        done();
+      }
+    });
+
+    it('should return CommitResponse on successful write using Callback', done => {
+      database.writeAtLeastOnce(mutations, (err, res) => {
+        assert.deepStrictEqual(err, null);
+        assert.deepStrictEqual(res, RESPONSE);
+        done();
+      });
+    });
+
+    it('should return CommitResponse on successful write using await', async () => {
+      sinon.stub(database, 'writeAtLeastOnce').resolves([RESPONSE]);
+      const [response] = await database.writeAtLeastOnce(mutations, {});
+      assert.deepStrictEqual(
+        response.commitTimestamp,
+        RESPONSE.commitTimestamp,
       );
     });
   });
@@ -1032,98 +989,77 @@ describe('Database', () => {
     const SESSION = {};
     const RESPONSE = {a: 'b'};
 
-    const muxEnabled = [true, false];
-
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            isMuxEnabled
-              ? (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true')
-              : (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-                  'false');
-          });
-
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-          });
-
-          beforeEach(() => {
-            database.sessionFactory_ = {
-              getSession(callback) {
-                callback(null, SESSION);
-              },
-            };
-          });
-
-          it('should return any get session errors', done => {
-            const error = new Error('err');
-
-            database.sessionFactory_ = {
-              getSession(callback) {
-                callback(error);
-              },
-            };
-
-            database.createBatchTransaction((err, transaction, resp) => {
-              assert.strictEqual(err, error);
-              assert.strictEqual(transaction, null);
-              assert.strictEqual(resp, undefined);
-              done();
-            });
-          });
-
-          it('should create a transaction', done => {
-            const opts = {a: 'b'};
-
-            const fakeTransaction = {
-              begin(callback) {
-                callback(null, RESPONSE);
-              },
-
-              once() {},
-            };
-
-            database.batchTransaction = (identifier, options) => {
-              assert.deepStrictEqual(identifier, {session: SESSION});
-              assert.strictEqual(options, opts);
-              return fakeTransaction;
-            };
-
-            database.createBatchTransaction(opts, (err, transaction, resp) => {
-              assert.strictEqual(err, null);
-              assert.strictEqual(transaction, fakeTransaction);
-              assert.strictEqual(resp, RESPONSE);
-              done();
-            });
-          });
-
-          it('should return any transaction errors', done => {
-            const error = new Error('err');
-
-            const fakeTransaction = {
-              begin(callback) {
-                callback(error, RESPONSE);
-              },
-
-              once() {},
-            };
-
-            database.batchTransaction = () => {
-              return fakeTransaction;
-            };
-
-            database.createBatchTransaction((err, transaction, resp) => {
-              assert.strictEqual(err, error);
-              assert.strictEqual(transaction, null);
-              assert.strictEqual(resp, RESPONSE);
-              done();
-            });
-          });
+    beforeEach(() => {
+      database.sessionFactory_ = {
+        getSession(callback) {
+          callback(null, SESSION);
         },
-      );
+      };
+    });
+
+    it('should return any get session errors', done => {
+      const error = new Error('err');
+
+      database.sessionFactory_ = {
+        getSession(callback) {
+          callback(error);
+        },
+      };
+
+      database.createBatchTransaction((err, transaction, resp) => {
+        assert.strictEqual(err, error);
+        assert.strictEqual(transaction, null);
+        assert.strictEqual(resp, undefined);
+        done();
+      });
+    });
+
+    it('should create a transaction', done => {
+      const opts = {a: 'b'};
+
+      const fakeTransaction = {
+        begin(callback) {
+          callback(null, RESPONSE);
+        },
+
+        once() {},
+      };
+
+      database.batchTransaction = (identifier, options) => {
+        assert.deepStrictEqual(identifier, {session: SESSION});
+        assert.strictEqual(options, opts);
+        return fakeTransaction;
+      };
+
+      database.createBatchTransaction(opts, (err, transaction, resp) => {
+        assert.strictEqual(err, null);
+        assert.strictEqual(transaction, fakeTransaction);
+        assert.strictEqual(resp, RESPONSE);
+        done();
+      });
+    });
+
+    it('should return any transaction errors', done => {
+      const error = new Error('err');
+
+      const fakeTransaction = {
+        begin(callback) {
+          callback(error, RESPONSE);
+        },
+
+        once() {},
+      };
+
+      database.batchTransaction = () => {
+        return fakeTransaction;
+      };
+
+      database.createBatchTransaction((err, transaction, resp) => {
+        assert.strictEqual(err, error);
+        assert.strictEqual(transaction, null);
+        assert.strictEqual(resp, RESPONSE);
+        done();
+      });
     });
   });
 
@@ -1734,210 +1670,184 @@ describe('Database', () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const SESSIONFACTORY: any = {};
+    beforeEach(() => {
+      REQUEST_STREAM = through();
 
-    const muxEnabled = [true, false];
+      CONFIG = {
+        reqOpts: {},
+      };
 
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            isMuxEnabled
-              ? (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true')
-              : (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-                  'false');
-          });
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-          });
-          beforeEach(() => {
-            REQUEST_STREAM = through();
+      database.sessionFactory_ = SESSIONFACTORY;
 
-            CONFIG = {
-              reqOpts: {},
-            };
+      database.requestStream = () => {
+        return REQUEST_STREAM;
+      };
 
-            database.sessionFactory_ = SESSIONFACTORY;
+      SESSIONFACTORY.getSession = callback => {
+        callback(null, SESSION);
+      };
 
-            database.requestStream = () => {
-              return REQUEST_STREAM;
-            };
+      SESSIONFACTORY.release = util.noop;
+    });
 
-            SESSIONFACTORY.getSession = callback => {
-              callback(null, SESSION);
-            };
+    it('should get a session when stream opens', done => {
+      SESSIONFACTORY.getSession = () => {
+        done();
+      };
 
-            SESSIONFACTORY.release = util.noop;
-          });
+      database.makePooledStreamingRequest_(CONFIG).emit('reading');
+    });
 
-          it('should get a session when stream opens', done => {
-            SESSIONFACTORY.getSession = () => {
-              done();
-            };
+    describe('could not get session', () => {
+      const ERROR = new Error('Error.');
 
-            database.makePooledStreamingRequest_(CONFIG).emit('reading');
-          });
+      beforeEach(() => {
+        SESSIONFACTORY.getSession = callback => {
+          callback(ERROR);
+        };
+      });
 
-          describe('could not get session', () => {
-            const ERROR = new Error('Error.');
+      it('should destroy the stream', done => {
+        database
+          .makePooledStreamingRequest_(CONFIG)
+          .on('error', err => {
+            assert.strictEqual(err, ERROR);
+            done();
+          })
+          .emit('reading');
+      });
+    });
 
-            beforeEach(() => {
-              SESSIONFACTORY.getSession = callback => {
-                callback(ERROR);
-              };
-            });
+    describe('session retrieved successfully', () => {
+      beforeEach(() => {
+        SESSIONFACTORY.getSession = callback => {
+          callback(null, SESSION);
+        };
+      });
 
-            it('should destroy the stream', done => {
-              database
-                .makePooledStreamingRequest_(CONFIG)
-                .on('error', err => {
-                  assert.strictEqual(err, ERROR);
-                  done();
-                })
-                .emit('reading');
-            });
-          });
+      it('should assign session to request options', done => {
+        database.requestStream = config => {
+          assert.strictEqual(config.reqOpts.session, SESSION.formattedName_);
+          setImmediate(done);
+          return through.obj();
+        };
 
-          describe('session retrieved successfully', () => {
-            beforeEach(() => {
-              SESSIONFACTORY.getSession = callback => {
-                callback(null, SESSION);
-              };
-            });
+        database.makePooledStreamingRequest_(CONFIG).emit('reading');
+      });
 
-            it('should assign session to request options', done => {
-              database.requestStream = config => {
-                assert.strictEqual(
-                  config.reqOpts.session,
-                  SESSION.formattedName_,
-                );
-                setImmediate(done);
-                return through.obj();
-              };
+      it('should make request and pipe to the stream', done => {
+        const responseData = Buffer.from('response-data');
 
-              database.makePooledStreamingRequest_(CONFIG).emit('reading');
-            });
+        database.makePooledStreamingRequest_(CONFIG).on('data', data => {
+          assert.deepStrictEqual(data, responseData);
+          done();
+        });
 
-            it('should make request and pipe to the stream', done => {
-              const responseData = Buffer.from('response-data');
+        REQUEST_STREAM.end(responseData);
+      });
 
-              database.makePooledStreamingRequest_(CONFIG).on('data', data => {
-                assert.deepStrictEqual(data, responseData);
-                done();
-              });
+      it('should release session when request stream ends', done => {
+        SESSIONFACTORY.release = session => {
+          assert.strictEqual(session, SESSION);
+          done();
+        };
 
-              REQUEST_STREAM.end(responseData);
-            });
+        database.makePooledStreamingRequest_(CONFIG).emit('reading');
 
-            it('should release session when request stream ends', done => {
-              SESSIONFACTORY.release = session => {
-                assert.strictEqual(session, SESSION);
-                done();
-              };
+        REQUEST_STREAM.end();
+      });
 
-              database.makePooledStreamingRequest_(CONFIG).emit('reading');
+      it('should release session when request stream errors', done => {
+        SESSIONFACTORY.release = session => {
+          assert.strictEqual(session, SESSION);
+          done();
+        };
 
-              REQUEST_STREAM.end();
-            });
+        database.makePooledStreamingRequest_(CONFIG).emit('reading');
 
-            it('should release session when request stream errors', done => {
-              SESSIONFACTORY.release = session => {
-                assert.strictEqual(session, SESSION);
-                done();
-              };
+        setImmediate(() => {
+          REQUEST_STREAM.emit('error');
+        });
+      });
 
-              database.makePooledStreamingRequest_(CONFIG).emit('reading');
+      it('should error user stream when request stream errors', done => {
+        const error = new Error('Error.');
 
-              setImmediate(() => {
-                REQUEST_STREAM.emit('error');
-              });
-            });
+        database
+          .makePooledStreamingRequest_(CONFIG)
+          .on('error', err => {
+            assert.strictEqual(err, error);
+            done();
+          })
+          .emit('reading');
 
-            it('should error user stream when request stream errors', done => {
-              const error = new Error('Error.');
+        setImmediate(() => {
+          REQUEST_STREAM.destroy(error);
+        });
+      });
+    });
 
-              database
-                .makePooledStreamingRequest_(CONFIG)
-                .on('error', err => {
-                  assert.strictEqual(err, error);
-                  done();
-                })
-                .emit('reading');
+    describe('abort', () => {
+      let SESSION;
 
-              setImmediate(() => {
-                REQUEST_STREAM.destroy(error);
-              });
-            });
-          });
+      beforeEach(() => {
+        REQUEST_STREAM.cancel = util.noop;
 
-          describe('abort', () => {
-            let SESSION;
+        SESSION = {
+          cancel: util.noop,
+        };
 
-            beforeEach(() => {
-              REQUEST_STREAM.cancel = util.noop;
+        SESSIONFACTORY.getSession = callback => {
+          callback(null, SESSION);
+        };
+      });
 
-              SESSION = {
-                cancel: util.noop,
-              };
+      it('should release the session', done => {
+        SESSIONFACTORY.release = session => {
+          assert.strictEqual(session, SESSION);
+          done();
+        };
 
-              SESSIONFACTORY.getSession = callback => {
-                callback(null, SESSION);
-              };
-            });
+        const requestStream = database.makePooledStreamingRequest_(CONFIG);
 
-            it('should release the session', done => {
-              SESSIONFACTORY.release = session => {
-                assert.strictEqual(session, SESSION);
-                done();
-              };
+        requestStream.emit('reading');
 
-              const requestStream =
-                database.makePooledStreamingRequest_(CONFIG);
+        setImmediate(() => {
+          requestStream.abort();
+        });
+      });
 
-              requestStream.emit('reading');
+      it('should not release the session more than once', done => {
+        let numTimesReleased = 0;
 
-              setImmediate(() => {
-                requestStream.abort();
-              });
-            });
+        SESSIONFACTORY.release = session => {
+          numTimesReleased++;
+          assert.strictEqual(session, SESSION);
+        };
 
-            it('should not release the session more than once', done => {
-              let numTimesReleased = 0;
+        const requestStream = database.makePooledStreamingRequest_(CONFIG);
 
-              SESSIONFACTORY.release = session => {
-                numTimesReleased++;
-                assert.strictEqual(session, SESSION);
-              };
+        requestStream.emit('reading');
 
-              const requestStream =
-                database.makePooledStreamingRequest_(CONFIG);
+        setImmediate(() => {
+          requestStream.abort();
+          assert.strictEqual(numTimesReleased, 1);
 
-              requestStream.emit('reading');
+          requestStream.abort();
+          assert.strictEqual(numTimesReleased, 1);
 
-              setImmediate(() => {
-                requestStream.abort();
-                assert.strictEqual(numTimesReleased, 1);
+          done();
+        });
+      });
 
-                requestStream.abort();
-                assert.strictEqual(numTimesReleased, 1);
-
-                done();
-              });
-            });
-
-            it('should cancel the request stream', done => {
-              REQUEST_STREAM.cancel = done;
-              const requestStream =
-                database.makePooledStreamingRequest_(CONFIG);
-              requestStream.emit('reading');
-              setImmediate(() => {
-                requestStream.abort();
-              });
-            });
-          });
-        },
-      );
+      it('should cancel the request stream', done => {
+        REQUEST_STREAM.cancel = done;
+        const requestStream = database.makePooledStreamingRequest_(CONFIG);
+        requestStream.emit('reading');
+        setImmediate(() => {
+          requestStream.abort();
+        });
+      });
     });
   });
 
@@ -2025,190 +1935,169 @@ describe('Database', () => {
     let snapshotStub: sinon.SinonStub;
     let runStreamStub: sinon.SinonStub;
 
-    const muxEnabled = [true, false];
-
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED is ' +
-          `${isMuxEnabled ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            isMuxEnabled
-              ? (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true')
-              : (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-                  'false');
-          });
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            fakeSession = new FakeSession();
-            fakeSession2 = new FakeSession();
-            fakeSnapshot = new FakeTransaction(
-              {} as google.spanner.v1.TransactionOptions.ReadOnly,
-            );
-            fakeSnapshot2 = new FakeTransaction(
-              {} as google.spanner.v1.TransactionOptions.ReadOnly,
-            );
-            fakeStream = through.obj();
-            fakeStream2 = through.obj();
-
-            getSessionStub = (
-              sandbox.stub(fakeSessionFactory, 'getSession') as sinon.SinonStub
-            )
-              .onFirstCall()
-              .callsFake(callback => callback(null, fakeSession))
-              .onSecondCall()
-              .callsFake(callback => callback(null, fakeSession2));
-
-            snapshotStub = sandbox
-              .stub(fakeSession, 'snapshot')
-              .returns(fakeSnapshot);
-
-            sandbox.stub(fakeSession2, 'snapshot').returns(fakeSnapshot2);
-
-            runStreamStub = sandbox
-              .stub(fakeSnapshot, 'runStream')
-              .returns(fakeStream);
-
-            sandbox.stub(fakeSnapshot2, 'runStream').returns(fakeStream2);
-
-            sandbox
-              .stub(fakeSessionFactory, 'isMultiplexedEnabled')
-              .returns(isMuxEnabled ? true : false);
-          });
-
-          it('should get a read session via `getSession`', () => {
-            getSessionStub.callsFake(() => {});
-            database.runStream(QUERY);
-
-            assert.strictEqual(getSessionStub.callCount, 1);
-          });
-
-          it('should destroy the stream if `getSession` errors', done => {
-            const fakeError = new Error('err');
-
-            getSessionStub
-              .onFirstCall()
-              .callsFake(callback => callback(fakeError));
-
-            database.runStream(QUERY).on('error', err => {
-              assert.strictEqual(err, fakeError);
-              done();
-            });
-          });
-
-          it('should pass through timestamp bounds', () => {
-            const fakeOptions = {strong: false};
-            database.runStream(QUERY, fakeOptions);
-
-            const options = snapshotStub.lastCall.args[0];
-            assert.strictEqual(options, fakeOptions);
-          });
-
-          it('should call through to `snapshot.runStream`', () => {
-            const pipeStub = sandbox.stub(fakeStream, 'pipe');
-            const proxyStream = database.runStream(QUERY);
-
-            const query = runStreamStub.lastCall.args[0];
-            assert.strictEqual(query, QUERY);
-
-            const stream = pipeStub.lastCall.args[0];
-            assert.strictEqual(stream, proxyStream);
-          });
-
-          it('should end the snapshot on stream end', done => {
-            const endStub = sandbox.stub(fakeSnapshot, 'end');
-
-            database
-              .runStream(QUERY)
-              .on('data', done)
-              .on('end', () => {
-                assert.strictEqual(endStub.callCount, 1);
-                done();
-              });
-
-            fakeStream.push(null);
-          });
-
-          it('should clean up the stream/transaction on error', done => {
-            const fakeError = new Error('err');
-            const endStub = sandbox.stub(fakeSnapshot, 'end');
-
-            database.runStream(QUERY).on('error', err => {
-              assert.strictEqual(err, fakeError);
-              assert.strictEqual(endStub.callCount, 1);
-              done();
-            });
-
-            fakeStream.destroy(fakeError);
-          });
-
-          if (isMuxEnabled) {
-            it('should not retry on "Session not found" error', done => {
-              const sessionNotFoundError = {
-                code: grpc.status.NOT_FOUND,
-                message: 'Session not found',
-              } as grpc.ServiceError;
-              const endStub = sandbox.stub(fakeSnapshot, 'end');
-              const endStub2 = sandbox.stub(fakeSnapshot2, 'end');
-              const rows = 0;
-
-              database.runStream(QUERY).on('error', err => {
-                assert.strictEqual(err, sessionNotFoundError);
-                assert.strictEqual(endStub.callCount, 1);
-                // make sure it is not retrying the stream
-                assert.strictEqual(endStub2.callCount, 0);
-                // row count should be 0
-                assert.strictEqual(rows, 0);
-                done();
-              });
-
-              fakeStream.emit('error', sessionNotFoundError);
-              fakeStream2.push('row1');
-              fakeStream2.push(null);
-            });
-          } else {
-            it('should release the session on transaction end', () => {
-              const releaseStub = sandbox.stub(
-                fakeSessionFactory,
-                'release',
-              ) as sinon.SinonStub;
-
-              database.runStream(QUERY);
-              fakeSnapshot.emit('end');
-
-              const session = releaseStub.lastCall.args[0];
-              assert.strictEqual(session, fakeSession);
-            });
-
-            it('should retry "Session not found" error', done => {
-              const sessionNotFoundError = {
-                code: grpc.status.NOT_FOUND,
-                message: 'Session not found',
-              } as grpc.ServiceError;
-              const endStub = sandbox.stub(fakeSnapshot, 'end');
-              const endStub2 = sandbox.stub(fakeSnapshot2, 'end');
-              let rows = 0;
-
-              database
-                .runStream(QUERY)
-                .on('data', () => rows++)
-                .on('error', err => {
-                  assert.fail(err);
-                })
-                .on('end', () => {
-                  assert.strictEqual(endStub.callCount, 1);
-                  assert.strictEqual(endStub2.callCount, 1);
-                  assert.strictEqual(rows, 1);
-                  done();
-                });
-
-              fakeStream.emit('error', sessionNotFoundError);
-              fakeStream2.push('row1');
-              fakeStream2.push(null);
-            });
-          }
-        },
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      fakeSession = new FakeSession();
+      fakeSession2 = new FakeSession();
+      fakeSnapshot = new FakeTransaction(
+        {} as google.spanner.v1.TransactionOptions.ReadOnly,
       );
+      fakeSnapshot2 = new FakeTransaction(
+        {} as google.spanner.v1.TransactionOptions.ReadOnly,
+      );
+      fakeStream = through.obj();
+      fakeStream2 = through.obj();
+
+      getSessionStub = (
+        sandbox.stub(fakeSessionFactory, 'getSession') as sinon.SinonStub
+      )
+        .onFirstCall()
+        .callsFake(callback => callback(null, fakeSession))
+        .onSecondCall()
+        .callsFake(callback => callback(null, fakeSession2));
+
+      snapshotStub = sandbox
+        .stub(fakeSession, 'snapshot')
+        .returns(fakeSnapshot);
+
+      sandbox.stub(fakeSession2, 'snapshot').returns(fakeSnapshot2);
+
+      runStreamStub = sandbox
+        .stub(fakeSnapshot, 'runStream')
+        .returns(fakeStream);
+
+      sandbox.stub(fakeSnapshot2, 'runStream').returns(fakeStream2);
+
+      sandbox.stub(fakeSessionFactory, 'isMultiplexedEnabled').returns(true);
+    });
+
+    it('should get a read session via `getSession`', () => {
+      getSessionStub.callsFake(() => {});
+      database.runStream(QUERY);
+
+      assert.strictEqual(getSessionStub.callCount, 1);
+    });
+
+    it('should destroy the stream if `getSession` errors', done => {
+      const fakeError = new Error('err');
+
+      getSessionStub.onFirstCall().callsFake(callback => callback(fakeError));
+
+      database.runStream(QUERY).on('error', err => {
+        assert.strictEqual(err, fakeError);
+        done();
+      });
+    });
+
+    it('should pass through timestamp bounds', () => {
+      const fakeOptions = {strong: false};
+      database.runStream(QUERY, fakeOptions);
+
+      const options = snapshotStub.lastCall.args[0];
+      assert.strictEqual(options, fakeOptions);
+    });
+
+    it('should call through to `snapshot.runStream`', () => {
+      const pipeStub = sandbox.stub(fakeStream, 'pipe');
+      const proxyStream = database.runStream(QUERY);
+
+      const query = runStreamStub.lastCall.args[0];
+      assert.strictEqual(query, QUERY);
+
+      const stream = pipeStub.lastCall.args[0];
+      assert.strictEqual(stream, proxyStream);
+    });
+
+    it('should end the snapshot on stream end', done => {
+      const endStub = sandbox.stub(fakeSnapshot, 'end');
+
+      database
+        .runStream(QUERY)
+        .on('data', done)
+        .on('end', () => {
+          assert.strictEqual(endStub.callCount, 1);
+          done();
+        });
+
+      fakeStream.push(null);
+    });
+
+    it('should clean up the stream/transaction on error', done => {
+      const fakeError = new Error('err');
+      const endStub = sandbox.stub(fakeSnapshot, 'end');
+
+      database.runStream(QUERY).on('error', err => {
+        assert.strictEqual(err, fakeError);
+        assert.strictEqual(endStub.callCount, 1);
+        done();
+      });
+
+      fakeStream.destroy(fakeError);
+    });
+
+    it('should not retry on "Session not found" error', done => {
+      const sessionNotFoundError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as grpc.ServiceError;
+      const endStub = sandbox.stub(fakeSnapshot, 'end');
+      const endStub2 = sandbox.stub(fakeSnapshot2, 'end');
+      const rows = 0;
+
+      database.runStream(QUERY).on('error', err => {
+        assert.strictEqual(err, sessionNotFoundError);
+        assert.strictEqual(endStub.callCount, 1);
+        // make sure it is not retrying the stream
+        assert.strictEqual(endStub2.callCount, 0);
+        // row count should be 0
+        assert.strictEqual(rows, 0);
+        done();
+      });
+
+      fakeStream.emit('error', sessionNotFoundError);
+      fakeStream2.push('row1');
+      fakeStream2.push(null);
+    });
+
+    it('should release the session on transaction end', () => {
+      const releaseStub = sandbox.stub(
+        fakeSessionFactory,
+        'release',
+      ) as sinon.SinonStub;
+
+      database.runStream(QUERY);
+      fakeSnapshot.emit('end');
+
+      const session = releaseStub.lastCall.args[0];
+      assert.strictEqual(session, fakeSession);
+    });
+
+    // since mux is default enabled, session pool is not getting created
+    it.skip('should retry "Session not found" error', done => {
+      const sessionNotFoundError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as grpc.ServiceError;
+      const endStub = sandbox.stub(fakeSnapshot, 'end');
+      const endStub2 = sandbox.stub(fakeSnapshot2, 'end');
+      let rows = 0;
+
+      database
+        .runStream(QUERY)
+        .on('data', () => rows++)
+        .on('error', err => {
+          assert.fail(err);
+        })
+        .on('end', () => {
+          assert.strictEqual(endStub.callCount, 1);
+          assert.strictEqual(endStub2.callCount, 1);
+          assert.strictEqual(rows, 1);
+          done();
+        });
+
+      fakeStream.emit('error', sessionNotFoundError);
+      fakeStream2.push('row1');
+      fakeStream2.push(null);
     });
   });
 
@@ -2468,201 +2357,178 @@ describe('Database', () => {
     let getSessionStub: sinon.SinonStub;
     let snapshotStub: sinon.SinonStub;
 
-    const muxEnabled = [true, false];
-
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            isMuxEnabled
-              ? (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true')
-              : (process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-                  'false');
-          });
-
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            fakeSession = new FakeSession();
-            fakeSnapshot = new FakeTransaction(
-              {} as google.spanner.v1.TransactionOptions.ReadOnly,
-            );
-
-            beginSnapshotStub = (
-              sandbox.stub(fakeSnapshot, 'begin') as sinon.SinonStub
-            ).callsFake(callback => callback(null));
-
-            getSessionStub = (
-              sandbox.stub(fakeSessionFactory, 'getSession') as sinon.SinonStub
-            ).callsFake(callback => callback(null, fakeSession));
-
-            snapshotStub = (
-              sandbox.stub(fakeSession, 'snapshot') as sinon.SinonStub
-            ).returns(fakeSnapshot);
-
-            (
-              sandbox.stub(
-                fakeSessionFactory,
-                'isMultiplexedEnabled',
-              ) as sinon.SinonStub
-            ).returns(isMuxEnabled ? true : false);
-          });
-
-          it(
-            'should return any ' +
-              `${isMuxEnabled ? 'multiplexed session' : 'pool'}` +
-              ' errors',
-            done => {
-              const fakeError = new Error('err');
-
-              getSessionStub.callsFake(callback => callback(fakeError));
-
-              database.getSnapshot(err => {
-                assert.strictEqual(err, fakeError);
-                done();
-              });
-            },
-          );
-
-          it('should pass the timestamp bounds to the snapshot', () => {
-            const fakeTimestampBounds = {};
-
-            database.getSnapshot(fakeTimestampBounds, assert.ifError);
-
-            const bounds = snapshotStub.lastCall.args[0];
-            assert.strictEqual(bounds, fakeTimestampBounds);
-          });
-
-          it('should throw error if maxStaleness is passed in the timestamp bounds to the snapshot', () => {
-            const fakeTimestampBounds = {maxStaleness: 10};
-
-            database.getSnapshot(fakeTimestampBounds, err => {
-              assert.strictEqual(err.code, 3);
-              assert.strictEqual(
-                err.message,
-                'maxStaleness / minReadTimestamp is not supported for multi-use read-only transactions.',
-              );
-            });
-          });
-
-          it('should throw error if minReadTimestamp is passed in the timestamp bounds to the snapshot', () => {
-            const fakeTimestampBounds = {minReadTimestamp: 10};
-
-            database.getSnapshot(fakeTimestampBounds, err => {
-              assert.strictEqual(err.code, 3);
-              assert.strictEqual(
-                err.message,
-                'maxStaleness / minReadTimestamp is not supported for multi-use read-only transactions.',
-              );
-            });
-          });
-
-          it('should pass when maxStaleness is undefined', () => {
-            const fakeTimestampBounds = {minReadTimestamp: undefined};
-
-            database.getSnapshot(fakeTimestampBounds, assert.ifError);
-
-            const bounds = snapshotStub.lastCall.args[0];
-            assert.strictEqual(bounds, fakeTimestampBounds);
-          });
-
-          it('should return the `snapshot`', done => {
-            database.getSnapshot((err, snapshot) => {
-              assert.ifError(err);
-              assert.strictEqual(snapshot, fakeSnapshot);
-              done();
-            });
-          });
-
-          if (isMuxEnabled) {
-            it('should throw an error if `begin` errors with `Session not found`', done => {
-              const fakeError = {
-                code: grpc.status.NOT_FOUND,
-                message: 'Session not found',
-              } as MockError;
-
-              beginSnapshotStub.callsFake(callback => callback(fakeError));
-
-              database.getSnapshot((err, snapshot) => {
-                assert.strictEqual(err, fakeError);
-                assert.strictEqual(snapshot, undefined);
-                done();
-              });
-            });
-          } else {
-            it('should release the session if `begin` errors', done => {
-              const fakeError = new Error('err');
-
-              beginSnapshotStub.callsFake(callback => callback(fakeError));
-
-              const releaseStub = (
-                sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-              ).withArgs(fakeSession);
-
-              database.getSnapshot(err => {
-                assert.strictEqual(err, fakeError);
-                assert.strictEqual(releaseStub.callCount, 1);
-                done();
-              });
-            });
-
-            it('should retry if `begin` errors with `Session not found`', done => {
-              const fakeError = {
-                code: grpc.status.NOT_FOUND,
-                message: 'Session not found',
-              } as MockError;
-
-              const fakeSession2 = new FakeSession();
-              const fakeSnapshot2 = new FakeTransaction(
-                {} as google.spanner.v1.TransactionOptions.ReadOnly,
-              );
-              (
-                sandbox.stub(fakeSnapshot2, 'begin') as sinon.SinonStub
-              ).callsFake(callback => callback(null));
-              sandbox.stub(fakeSession2, 'snapshot').returns(fakeSnapshot2);
-
-              getSessionStub
-                .onFirstCall()
-                .callsFake(callback => callback(null, fakeSession))
-                .onSecondCall()
-                .callsFake(callback => callback(null, fakeSession2));
-
-              beginSnapshotStub.callsFake(callback => callback(fakeError));
-
-              // The first session that was not found should be released back into the
-              // pool, so that the pool can remove it from its inventory.
-              const releaseStub = sandbox.stub(fakeSessionFactory, 'release');
-
-              database.getSnapshot((err, snapshot) => {
-                assert.ifError(err);
-                assert.strictEqual(snapshot, fakeSnapshot2);
-                // The first session that error should already have been released back
-                // to the pool.
-                assert.strictEqual(releaseStub.callCount, 1);
-                // Ending the valid snapshot will release its session back into the
-                // pool.
-                snapshot.emit('end');
-                assert.strictEqual(releaseStub.callCount, 2);
-                done();
-              });
-            });
-
-            it('should release the snapshot on `end`', done => {
-              const releaseStub = (
-                sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-              ).withArgs(fakeSession);
-
-              database.getSnapshot(err => {
-                assert.ifError(err);
-                fakeSnapshot.emit('end');
-                assert.strictEqual(releaseStub.callCount, 1);
-                done();
-              });
-            });
-          }
-        },
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      fakeSession = new FakeSession();
+      fakeSnapshot = new FakeTransaction(
+        {} as google.spanner.v1.TransactionOptions.ReadOnly,
       );
+
+      beginSnapshotStub = (
+        sandbox.stub(fakeSnapshot, 'begin') as sinon.SinonStub
+      ).callsFake(callback => callback(null));
+
+      getSessionStub = (
+        sandbox.stub(fakeSessionFactory, 'getSession') as sinon.SinonStub
+      ).callsFake(callback => callback(null, fakeSession));
+
+      snapshotStub = (
+        sandbox.stub(fakeSession, 'snapshot') as sinon.SinonStub
+      ).returns(fakeSnapshot);
+
+      (
+        sandbox.stub(
+          fakeSessionFactory,
+          'isMultiplexedEnabled',
+        ) as sinon.SinonStub
+      ).returns(true);
+    });
+
+    it('should return any multiplexed session errors', done => {
+      const fakeError = new Error('err');
+
+      getSessionStub.callsFake(callback => callback(fakeError));
+
+      database.getSnapshot(err => {
+        assert.strictEqual(err, fakeError);
+        done();
+      });
+    });
+
+    it('should pass the timestamp bounds to the snapshot', () => {
+      const fakeTimestampBounds = {};
+
+      database.getSnapshot(fakeTimestampBounds, assert.ifError);
+
+      const bounds = snapshotStub.lastCall.args[0];
+      assert.strictEqual(bounds, fakeTimestampBounds);
+    });
+
+    it('should throw error if maxStaleness is passed in the timestamp bounds to the snapshot', () => {
+      const fakeTimestampBounds = {maxStaleness: 10};
+
+      database.getSnapshot(fakeTimestampBounds, err => {
+        assert.strictEqual(err.code, 3);
+        assert.strictEqual(
+          err.message,
+          'maxStaleness / minReadTimestamp is not supported for multi-use read-only transactions.',
+        );
+      });
+    });
+
+    it('should throw error if minReadTimestamp is passed in the timestamp bounds to the snapshot', () => {
+      const fakeTimestampBounds = {minReadTimestamp: 10};
+
+      database.getSnapshot(fakeTimestampBounds, err => {
+        assert.strictEqual(err.code, 3);
+        assert.strictEqual(
+          err.message,
+          'maxStaleness / minReadTimestamp is not supported for multi-use read-only transactions.',
+        );
+      });
+    });
+
+    it('should pass when maxStaleness is undefined', () => {
+      const fakeTimestampBounds = {minReadTimestamp: undefined};
+
+      database.getSnapshot(fakeTimestampBounds, assert.ifError);
+
+      const bounds = snapshotStub.lastCall.args[0];
+      assert.strictEqual(bounds, fakeTimestampBounds);
+    });
+
+    it('should return the `snapshot`', done => {
+      database.getSnapshot((err, snapshot) => {
+        assert.ifError(err);
+        assert.strictEqual(snapshot, fakeSnapshot);
+        done();
+      });
+    });
+
+    it('should throw an error if `begin` errors with `Session not found`', done => {
+      const fakeError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as MockError;
+
+      beginSnapshotStub.callsFake(callback => callback(fakeError));
+
+      database.getSnapshot((err, snapshot) => {
+        assert.strictEqual(err, fakeError);
+        assert.strictEqual(snapshot, undefined);
+        done();
+      });
+    });
+
+    it('should release the session if `begin` errors', done => {
+      const fakeError = new Error('err');
+
+      beginSnapshotStub.callsFake(callback => callback(fakeError));
+
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(fakeSession);
+
+      database.getSnapshot(err => {
+        assert.strictEqual(err, fakeError);
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
+    });
+
+    // since mux is default enabled, session pool is not getting created
+    it.skip('should retry if `begin` errors with `Session not found`', done => {
+      const fakeError = {
+        code: grpc.status.NOT_FOUND,
+        message: 'Session not found',
+      } as MockError;
+
+      const fakeSession2 = new FakeSession();
+      const fakeSnapshot2 = new FakeTransaction(
+        {} as google.spanner.v1.TransactionOptions.ReadOnly,
+      );
+      (sandbox.stub(fakeSnapshot2, 'begin') as sinon.SinonStub).callsFake(
+        callback => callback(null),
+      );
+      sandbox.stub(fakeSession2, 'snapshot').returns(fakeSnapshot2);
+
+      getSessionStub
+        .onFirstCall()
+        .callsFake(callback => callback(null, fakeSession))
+        .onSecondCall()
+        .callsFake(callback => callback(null, fakeSession2));
+
+      beginSnapshotStub.callsFake(callback => callback(fakeError));
+
+      // The first session that was not found should be released back into the
+      // pool, so that the pool can remove it from its inventory.
+      const releaseStub = sandbox.stub(fakeSessionFactory, 'release');
+
+      database.getSnapshot((err, snapshot) => {
+        assert.ifError(err);
+        assert.strictEqual(snapshot, fakeSnapshot2);
+        // The first session that error should already have been released back
+        // to the pool.
+        assert.strictEqual(releaseStub.callCount, 1);
+        // Ending the valid snapshot will release its session back into the
+        // pool.
+        snapshot.emit('end');
+        assert.strictEqual(releaseStub.callCount, 2);
+        done();
+      });
+    });
+
+    it('should release the snapshot on `end`', done => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(fakeSession);
+
+      database.getSnapshot(err => {
+        assert.ifError(err);
+        fakeSnapshot.emit('end');
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
     });
   });
 
@@ -2673,109 +2539,78 @@ describe('Database', () => {
 
     let getSessionStub: sinon.SinonStub;
 
-    // muxEnabled[i][0] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS
-    // muxEnabled[i][1] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW
-    const muxEnabled = [
-      [true, true],
-      [true, false],
-      [false, true],
-      [false, false],
-    ];
-
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled[0] ? 'enabled' : 'disable'}` +
-          ' and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW is ' +
-          `${isMuxEnabled[1] ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-              isMuxEnabled[0].toString();
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-              isMuxEnabled[1].toString();
-          });
-
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
-          });
-
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            fakeSession = new FakeSession();
-            fakeTransaction = new FakeTransaction(
-              {} as google.spanner.v1.TransactionOptions.ReadWrite,
-            );
-
-            getSessionStub = (
-              sandbox.stub(
-                fakeSessionFactory,
-                'getSessionForReadWrite',
-              ) as sinon.SinonStub
-            ).callsFake(callback => {
-              callback(null, fakeSession, fakeTransaction);
-            });
-          });
-
-          it('should get a read/write transaction', () => {
-            getSessionStub.callsFake(() => {});
-
-            database.getTransaction(assert.ifError);
-
-            assert.strictEqual(getSessionStub.callCount, 1);
-          });
-
-          it(`should return any ${isMuxEnabled[0] && isMuxEnabled[1] ? 'multiplexed session' : 'pool'} errors`, done => {
-            const fakeError = new Error('err');
-
-            getSessionStub.callsFake(callback => callback(fakeError));
-
-            database.getTransaction(err => {
-              assert.strictEqual(err, fakeError);
-              done();
-            });
-          });
-
-          it('should return the read/write transaction', done => {
-            database.getTransaction((err, transaction) => {
-              assert.ifError(err);
-              assert.strictEqual(transaction, fakeTransaction);
-              done();
-            });
-          });
-
-          it('should propagate an error', done => {
-            const error = new Error('resource');
-            (sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub)
-              .withArgs(fakeSession)
-              .throws(error);
-
-            database.on('error', err => {
-              assert.deepStrictEqual(err, error);
-              done();
-            });
-
-            database.getTransaction((err, transaction) => {
-              assert.ifError(err);
-              transaction.emit('end');
-            });
-          });
-
-          it('should release the session on transaction end', done => {
-            const releaseStub = (
-              sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-            ).withArgs(fakeSession);
-
-            database.getTransaction((err, transaction) => {
-              assert.ifError(err);
-              transaction.emit('end');
-              assert.strictEqual(releaseStub.callCount, 1);
-              done();
-            });
-          });
-        },
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      fakeSession = new FakeSession();
+      fakeTransaction = new FakeTransaction(
+        {} as google.spanner.v1.TransactionOptions.ReadWrite,
       );
+
+      getSessionStub = (
+        sandbox.stub(
+          fakeSessionFactory,
+          'getSessionForReadWrite',
+        ) as sinon.SinonStub
+      ).callsFake(callback => {
+        callback(null, fakeSession, fakeTransaction);
+      });
+    });
+
+    it('should get a read/write transaction', () => {
+      getSessionStub.callsFake(() => {});
+
+      database.getTransaction(assert.ifError);
+
+      assert.strictEqual(getSessionStub.callCount, 1);
+    });
+
+    it('should return any multiplexed session errors', done => {
+      const fakeError = new Error('err');
+
+      getSessionStub.callsFake(callback => callback(fakeError));
+
+      database.getTransaction(err => {
+        assert.strictEqual(err, fakeError);
+        done();
+      });
+    });
+
+    it('should return the read/write transaction', done => {
+      database.getTransaction((err, transaction) => {
+        assert.ifError(err);
+        assert.strictEqual(transaction, fakeTransaction);
+        done();
+      });
+    });
+
+    it('should propagate an error', done => {
+      const error = new Error('resource');
+      (sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub)
+        .withArgs(fakeSession)
+        .throws(error);
+
+      database.on('error', err => {
+        assert.deepStrictEqual(err, error);
+        done();
+      });
+
+      database.getTransaction((err, transaction) => {
+        assert.ifError(err);
+        transaction.emit('end');
+      });
+    });
+
+    it('should release the session on transaction end', done => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(fakeSession);
+
+      database.getTransaction((err, transaction) => {
+        assert.ifError(err);
+        transaction.emit('end');
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
     });
   });
 
@@ -3089,220 +2924,184 @@ describe('Database', () => {
       },
     };
 
-    // muxEnabled[i][0] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS
-    // muxEnabled[i][1] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS
-    const muxEnabled = [
-      [true, true],
-      [true, false],
-      [false, true],
-      [false, false],
-    ];
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      fakeSession = new FakeSession();
+      fakePartitionedDml = fakeSession.partitionedDml();
 
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled[0] ? 'enabled' : 'disable'}` +
-          ' and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS is ' +
-          `${isMuxEnabled[1] ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-              isMuxEnabled[0].toString();
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS =
-              isMuxEnabled[1].toString();
-          });
+      getSessionStub = (
+        sandbox.stub(
+          fakeSessionFactory,
+          'getSessionForPartitionedOps',
+        ) as sinon.SinonStub
+      ).callsFake(callback => {
+        callback(null, fakeSession);
+      });
 
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-            delete process.env
-              .GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS;
-          });
+      sandbox.stub(fakeSession, 'partitionedDml').returns(fakePartitionedDml);
 
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            fakeSession = new FakeSession();
-            fakePartitionedDml = fakeSession.partitionedDml();
+      beginStub = (
+        sandbox.stub(fakePartitionedDml, 'begin') as sinon.SinonStub
+      ).callsFake(callback => callback(null));
 
-            getSessionStub = (
-              sandbox.stub(
-                fakeSessionFactory,
-                'getSessionForPartitionedOps',
-              ) as sinon.SinonStub
-            ).callsFake(callback => {
-              callback(null, fakeSession);
-            });
+      runUpdateStub = (
+        sandbox.stub(fakePartitionedDml, 'runUpdate') as sinon.SinonStub
+      ).callsFake((_, callback) => callback(null));
+    });
 
-            sandbox
-              .stub(fakeSession, 'partitionedDml')
-              .returns(fakePartitionedDml);
+    it('should make a call to getSessionForPartitionedOps', () => {
+      getSessionStub.callsFake(() => {});
 
-            beginStub = (
-              sandbox.stub(fakePartitionedDml, 'begin') as sinon.SinonStub
-            ).callsFake(callback => callback(null));
+      database.runPartitionedUpdate(QUERY, assert.ifError);
 
-            runUpdateStub = (
-              sandbox.stub(fakePartitionedDml, 'runUpdate') as sinon.SinonStub
-            ).callsFake((_, callback) => callback(null));
-          });
+      assert.strictEqual(getSessionStub.callCount, 1);
+    });
 
-          it('should make a call to getSessionForPartitionedOps', () => {
-            getSessionStub.callsFake(() => {});
+    it('should get a session from the session factory', () => {
+      const fakeCallback = sandbox.spy();
+      getSessionStub.callsFake(callback => callback(fakeSession));
+      database.runPartitionedUpdate(QUERY, fakeCallback);
+      const [resp] = fakeCallback.lastCall.args;
+      assert.strictEqual(resp, fakeSession);
+    });
 
-            database.runPartitionedUpdate(QUERY, assert.ifError);
+    it('should return errors from getSessionForPartitionedOps', () => {
+      const fakeError = new Error('err');
+      const fakeCallback = sandbox.spy();
 
-            assert.strictEqual(getSessionStub.callCount, 1);
-          });
+      getSessionStub.callsFake(callback => callback(fakeError));
+      database.runPartitionedUpdate(QUERY, fakeCallback);
 
-          it('should get a session from the session factory', () => {
-            const fakeCallback = sandbox.spy();
-            getSessionStub.callsFake(callback => callback(fakeSession));
-            database.runPartitionedUpdate(QUERY, fakeCallback);
-            const [resp] = fakeCallback.lastCall.args;
-            assert.strictEqual(resp, fakeSession);
-          });
+      const [err, rowCount] = fakeCallback.lastCall.args;
 
-          it('should return errors from getSessionForPartitionedOps', () => {
-            const fakeError = new Error('err');
-            const fakeCallback = sandbox.spy();
+      assert.strictEqual(err, fakeError);
+      assert.strictEqual(rowCount, 0);
+    });
 
-            getSessionStub.callsFake(callback => callback(fakeError));
-            database.runPartitionedUpdate(QUERY, fakeCallback);
+    it('should get a partitioned dml transaction from the session factory', () => {
+      const fakeCallback = sandbox.spy();
+      getSessionStub.callsFake(callback => callback(fakePartitionedDml));
+      database.runPartitionedUpdate(QUERY, fakeCallback);
+      const [resp] = fakeCallback.lastCall.args;
+      assert.strictEqual(resp, fakePartitionedDml);
+    });
 
-            const [err, rowCount] = fakeCallback.lastCall.args;
+    it('should call transaction begin', () => {
+      beginStub.callsFake(() => {});
+      database.runPartitionedUpdate(QUERY, assert.ifError);
 
-            assert.strictEqual(err, fakeError);
-            assert.strictEqual(rowCount, 0);
-          });
+      assert.strictEqual(beginStub.callCount, 1);
+    });
 
-          it('should get a partitioned dml transaction from the session factory', () => {
-            const fakeCallback = sandbox.spy();
-            getSessionStub.callsFake(callback => callback(fakePartitionedDml));
-            database.runPartitionedUpdate(QUERY, fakeCallback);
-            const [resp] = fakeCallback.lastCall.args;
-            assert.strictEqual(resp, fakePartitionedDml);
-          });
+    it('should return any begin errors', done => {
+      const fakeError = new Error('err');
 
-          it('should call transaction begin', () => {
-            beginStub.callsFake(() => {});
-            database.runPartitionedUpdate(QUERY, assert.ifError);
+      beginStub.callsFake(callback => callback(fakeError));
 
-            assert.strictEqual(beginStub.callCount, 1);
-          });
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(fakeSession);
 
-          it('should return any begin errors', done => {
-            const fakeError = new Error('err');
+      database.runPartitionedUpdate(QUERY, (err, rowCount) => {
+        assert.strictEqual(err, fakeError);
+        assert.strictEqual(rowCount, 0);
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
+    });
 
-            beginStub.callsFake(callback => callback(fakeError));
+    it('call `runUpdate` on the transaction', () => {
+      const fakeCallback = sandbox.spy();
 
-            const releaseStub = (
-              sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-            ).withArgs(fakeSession);
+      database.runPartitionedUpdate(QUERY, fakeCallback);
 
-            database.runPartitionedUpdate(QUERY, (err, rowCount) => {
-              assert.strictEqual(err, fakeError);
-              assert.strictEqual(rowCount, 0);
-              assert.strictEqual(releaseStub.callCount, 1);
-              done();
-            });
-          });
+      const [query] = runUpdateStub.lastCall.args;
 
-          it('call `runUpdate` on the transaction', () => {
-            const fakeCallback = sandbox.spy();
+      assert.strictEqual(query.sql, QUERY.sql);
+      assert.deepStrictEqual(query.params, QUERY.params);
+      assert.ok(fakeCallback.calledOnce);
+    });
 
-            database.runPartitionedUpdate(QUERY, fakeCallback);
+    it('should release the session on transaction end', () => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(fakeSession);
 
-            const [query] = runUpdateStub.lastCall.args;
+      database.runPartitionedUpdate(QUERY, assert.ifError);
+      fakePartitionedDml.emit('end');
 
-            assert.strictEqual(query.sql, QUERY.sql);
-            assert.deepStrictEqual(query.params, QUERY.params);
-            assert.ok(fakeCallback.calledOnce);
-          });
+      assert.strictEqual(releaseStub.callCount, 1);
+    });
 
-          if (!isMuxEnabled) {
-            it('should release the session on transaction end', () => {
-              const releaseStub = (
-                sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-              ).withArgs(fakeSession);
+    it('should accept requestOptions', () => {
+      const fakeCallback = sandbox.spy();
 
-              database.runPartitionedUpdate(QUERY, assert.ifError);
-              fakePartitionedDml.emit('end');
-
-              assert.strictEqual(releaseStub.callCount, 1);
-            });
-          }
-
-          it('should accept requestOptions', () => {
-            const fakeCallback = sandbox.spy();
-
-            database.runPartitionedUpdate(
-              {
-                sql: QUERY.sql,
-                params: QUERY.params,
-                requestOptions: {
-                  priority: RequestOptions.Priority.PRIORITY_LOW,
-                },
-              },
-              fakeCallback,
-            );
-
-            const [query] = runUpdateStub.lastCall.args;
-
-            assert.deepStrictEqual(query, {
-              sql: QUERY.sql,
-              params: QUERY.params,
-              requestOptions: {priority: RequestOptions.Priority.PRIORITY_LOW},
-            });
-            assert.ok(fakeCallback.calledOnce);
-          });
-
-          it('should accept excludeTxnFromChangeStreams', () => {
-            const fakeCallback = sandbox.spy();
-
-            database.runPartitionedUpdate(
-              {
-                excludeTxnFromChangeStream: true,
-              },
-              fakeCallback,
-            );
-
-            const [query] = runUpdateStub.lastCall.args;
-
-            assert.deepStrictEqual(query, {
-              excludeTxnFromChangeStream: true,
-            });
-            assert.ok(fakeCallback.calledOnce);
-          });
-
-          it('should ignore directedReadOptions set for client', () => {
-            const fakeCallback = sandbox.spy();
-
-            database.parent.parent = {
-              routeToLeaderEnabled: true,
-              directedReadOptions: fakeDirectedReadOptions,
-            };
-
-            database.runPartitionedUpdate(
-              {
-                sql: QUERY.sql,
-                params: QUERY.params,
-                requestOptions: {
-                  priority: RequestOptions.Priority.PRIORITY_LOW,
-                },
-              },
-              fakeCallback,
-            );
-
-            const [query] = runUpdateStub.lastCall.args;
-
-            assert.deepStrictEqual(query, {
-              sql: QUERY.sql,
-              params: QUERY.params,
-              requestOptions: {priority: RequestOptions.Priority.PRIORITY_LOW},
-            });
-            assert.ok(fakeCallback.calledOnce);
-          });
+      database.runPartitionedUpdate(
+        {
+          sql: QUERY.sql,
+          params: QUERY.params,
+          requestOptions: {
+            priority: RequestOptions.Priority.PRIORITY_LOW,
+          },
         },
+        fakeCallback,
       );
+
+      const [query] = runUpdateStub.lastCall.args;
+
+      assert.deepStrictEqual(query, {
+        sql: QUERY.sql,
+        params: QUERY.params,
+        requestOptions: {priority: RequestOptions.Priority.PRIORITY_LOW},
+      });
+      assert.ok(fakeCallback.calledOnce);
+    });
+
+    it('should accept excludeTxnFromChangeStreams', () => {
+      const fakeCallback = sandbox.spy();
+
+      database.runPartitionedUpdate(
+        {
+          excludeTxnFromChangeStream: true,
+        },
+        fakeCallback,
+      );
+
+      const [query] = runUpdateStub.lastCall.args;
+
+      assert.deepStrictEqual(query, {
+        excludeTxnFromChangeStream: true,
+      });
+      assert.ok(fakeCallback.calledOnce);
+    });
+
+    it('should ignore directedReadOptions set for client', () => {
+      const fakeCallback = sandbox.spy();
+
+      database.parent.parent = {
+        routeToLeaderEnabled: true,
+        directedReadOptions: fakeDirectedReadOptions,
+      };
+
+      database.runPartitionedUpdate(
+        {
+          sql: QUERY.sql,
+          params: QUERY.params,
+          requestOptions: {
+            priority: RequestOptions.Priority.PRIORITY_LOW,
+          },
+        },
+        fakeCallback,
+      );
+
+      const [query] = runUpdateStub.lastCall.args;
+
+      assert.deepStrictEqual(query, {
+        sql: QUERY.sql,
+        params: QUERY.params,
+        requestOptions: {priority: RequestOptions.Priority.PRIORITY_LOW},
+      });
+      assert.ok(fakeCallback.calledOnce);
     });
   });
 
@@ -3314,138 +3113,105 @@ describe('Database', () => {
 
     let fakeSessionFactory: FakeSessionFactory;
 
-    // muxEnabled[i][0] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS
-    // muxEnabled[i][1] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW
-    const muxEnabled = [
-      [true, true],
-      [true, false],
-      [false, true],
-      [false, false],
-    ];
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
 
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled[0] ? 'enabled' : 'disable'}` +
-          ' and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW is ' +
-          `${isMuxEnabled[1] ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-              isMuxEnabled[0].toString();
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-              isMuxEnabled[1].toString();
-          });
+      (
+        sandbox.stub(
+          fakeSessionFactory,
+          'getSessionForReadWrite',
+        ) as sinon.SinonStub
+      ).callsFake(callback => {
+        callback(null, SESSION, TRANSACTION);
+      });
+    });
 
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
-          });
+    it('should return any errors getting a session', done => {
+      const fakeErr = new Error('err');
 
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-
-            (
-              sandbox.stub(
-                fakeSessionFactory,
-                'getSessionForReadWrite',
-              ) as sinon.SinonStub
-            ).callsFake(callback => {
-              callback(null, SESSION, TRANSACTION);
-            });
-          });
-
-          it('should return any errors getting a session', done => {
-            const fakeErr = new Error('err');
-
-            (
-              fakeSessionFactory.getSessionForReadWrite as sinon.SinonStub
-            ).callsFake(callback => callback(fakeErr));
-
-            database.runTransaction(err => {
-              assert.strictEqual(err, fakeErr);
-              done();
-            });
-          });
-
-          it('should create a `TransactionRunner`', () => {
-            const fakeRunFn = sandbox.spy();
-
-            database.runTransaction(fakeRunFn);
-
-            const [session, transaction, runFn, options] =
-              fakeTransactionRunner.calledWith_;
-
-            assert.strictEqual(session, SESSION);
-            assert.strictEqual(transaction, TRANSACTION);
-            assert.deepStrictEqual(options, {});
-          });
-
-          it('should optionally accept runner `options`', () => {
-            const fakeOptions = {timeout: 1};
-
-            database.runTransaction(fakeOptions, assert.ifError);
-
-            const options = fakeTransactionRunner.calledWith_[3];
-
-            assert.strictEqual(options, fakeOptions);
-          });
-
-          it('should optionally accept runner `option` isolationLevel', async () => {
-            const fakeOptions = {
-              isolationLevel: IsolationLevel.REPEATABLE_READ,
-            };
-
-            await database.runTransaction(fakeOptions, assert.ifError);
-
-            const options = fakeTransactionRunner.calledWith_[3];
-            assert.strictEqual(options, fakeOptions);
-          });
-
-          it('should optionally accept runner `option` readLockMode', async () => {
-            const fakeOptions = {
-              readLockMode: ReadLockMode.PESSIMISTIC,
-            };
-
-            await database.runTransaction(fakeOptions, assert.ifError);
-
-            const options = fakeTransactionRunner.calledWith_[3];
-            assert.strictEqual(options, fakeOptions);
-          });
-
-          it('should release the session when finished', done => {
-            const releaseStub = (
-              sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-            ).withArgs(SESSION);
-
-            sandbox.stub(FakeTransactionRunner.prototype, 'run').resolves();
-
-            database.runTransaction(assert.ifError);
-
-            setImmediate(() => {
-              assert.strictEqual(releaseStub.callCount, 1);
-              done();
-            });
-          });
-
-          it('should catch any run errors and return them', done => {
-            const releaseStub = (
-              sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-            ).withArgs(SESSION);
-            const fakeError = new Error('err');
-
-            sandbox
-              .stub(FakeTransactionRunner.prototype, 'run')
-              .rejects(fakeError);
-
-            database.runTransaction(err => {
-              assert.strictEqual(err, fakeError);
-              assert.strictEqual(releaseStub.callCount, 1);
-              done();
-            });
-          });
-        },
+      (fakeSessionFactory.getSessionForReadWrite as sinon.SinonStub).callsFake(
+        callback => callback(fakeErr),
       );
+
+      database.runTransaction(err => {
+        assert.strictEqual(err, fakeErr);
+        done();
+      });
+    });
+
+    it('should create a `TransactionRunner`', () => {
+      const fakeRunFn = sandbox.spy();
+
+      database.runTransaction(fakeRunFn);
+
+      const [session, transaction, runFn, options] =
+        fakeTransactionRunner.calledWith_;
+
+      assert.strictEqual(session, SESSION);
+      assert.strictEqual(transaction, TRANSACTION);
+      assert.deepStrictEqual(options, {});
+    });
+
+    it('should optionally accept runner `options`', () => {
+      const fakeOptions = {timeout: 1};
+
+      database.runTransaction(fakeOptions, assert.ifError);
+
+      const options = fakeTransactionRunner.calledWith_[3];
+
+      assert.strictEqual(options, fakeOptions);
+    });
+
+    it('should optionally accept runner `option` isolationLevel', async () => {
+      const fakeOptions = {
+        isolationLevel: IsolationLevel.REPEATABLE_READ,
+      };
+
+      await database.runTransaction(fakeOptions, assert.ifError);
+
+      const options = fakeTransactionRunner.calledWith_[3];
+      assert.strictEqual(options, fakeOptions);
+    });
+
+    it('should optionally accept runner `option` readLockMode', async () => {
+      const fakeOptions = {
+        readLockMode: ReadLockMode.PESSIMISTIC,
+      };
+
+      await database.runTransaction(fakeOptions, assert.ifError);
+
+      const options = fakeTransactionRunner.calledWith_[3];
+      assert.strictEqual(options, fakeOptions);
+    });
+
+    it('should release the session when finished', done => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(SESSION);
+
+      sandbox.stub(FakeTransactionRunner.prototype, 'run').resolves();
+
+      database.runTransaction(assert.ifError);
+
+      setImmediate(() => {
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
+    });
+
+    it('should catch any run errors and return them', done => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(SESSION);
+      const fakeError = new Error('err');
+
+      sandbox.stub(FakeTransactionRunner.prototype, 'run').rejects(fakeError);
+
+      database.runTransaction(err => {
+        assert.strictEqual(err, fakeError);
+        assert.strictEqual(releaseStub.callCount, 1);
+        done();
+      });
     });
   });
 
@@ -3457,115 +3223,82 @@ describe('Database', () => {
 
     let fakeSessionFactory: FakeSessionFactory;
 
-    // muxEnabled[i][0] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS
-    // muxEnabled[i][1] is to enable/disable env GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW
-    const muxEnabled = [
-      [true, true],
-      [true, false],
-      [false, true],
-      [false, false],
-    ];
+    beforeEach(() => {
+      fakeSessionFactory = database.sessionFactory_;
+      (
+        sandbox.stub(
+          fakeSessionFactory,
+          'getSessionForReadWrite',
+        ) as sinon.SinonStub
+      ).callsFake(callback => {
+        callback(null, SESSION, TRANSACTION);
+      });
+    });
 
-    muxEnabled.forEach(isMuxEnabled => {
-      describe(
-        'when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is ' +
-          `${isMuxEnabled[0] ? 'enabled' : 'disable'}` +
-          ' and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW is ' +
-          `${isMuxEnabled[1] ? 'enabled' : 'disable'}`,
-        () => {
-          before(() => {
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS =
-              isMuxEnabled[0].toString();
-            process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-              isMuxEnabled[1].toString();
-          });
+    it('should create an `AsyncTransactionRunner`', async () => {
+      const fakeRunFn = sandbox.spy();
 
-          after(() => {
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
-            delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
-          });
+      await database.runTransactionAsync(fakeRunFn);
 
-          beforeEach(() => {
-            fakeSessionFactory = database.sessionFactory_;
-            (
-              sandbox.stub(
-                fakeSessionFactory,
-                'getSessionForReadWrite',
-              ) as sinon.SinonStub
-            ).callsFake(callback => {
-              callback(null, SESSION, TRANSACTION);
-            });
-          });
+      const [session, transaction, runFn, options] =
+        fakeAsyncTransactionRunner.calledWith_;
+      assert.strictEqual(session, SESSION);
+      assert.strictEqual(transaction, TRANSACTION);
+      assert.strictEqual(runFn, fakeRunFn);
+      assert.deepStrictEqual(options, {});
+    });
 
-          it('should create an `AsyncTransactionRunner`', async () => {
-            const fakeRunFn = sandbox.spy();
+    it('should optionally accept runner `options`', async () => {
+      const fakeOptions = {timeout: 1};
 
-            await database.runTransactionAsync(fakeRunFn);
+      await database.runTransactionAsync(fakeOptions, assert.ifError);
 
-            const [session, transaction, runFn, options] =
-              fakeAsyncTransactionRunner.calledWith_;
-            assert.strictEqual(session, SESSION);
-            assert.strictEqual(transaction, TRANSACTION);
-            assert.strictEqual(runFn, fakeRunFn);
-            assert.deepStrictEqual(options, {});
-          });
+      const options = fakeAsyncTransactionRunner.calledWith_[3];
+      assert.strictEqual(options, fakeOptions);
+    });
 
-          it('should optionally accept runner `options`', async () => {
-            const fakeOptions = {timeout: 1};
+    it('should optionally accept runner `option` isolationLevel', async () => {
+      const fakeOptions = {
+        isolationLevel: IsolationLevel.REPEATABLE_READ,
+      };
 
-            await database.runTransactionAsync(fakeOptions, assert.ifError);
+      await database.runTransactionAsync(fakeOptions, assert.ifError);
 
-            const options = fakeAsyncTransactionRunner.calledWith_[3];
-            assert.strictEqual(options, fakeOptions);
-          });
+      const options = fakeAsyncTransactionRunner.calledWith_[3];
+      assert.strictEqual(options, fakeOptions);
+    });
 
-          it('should optionally accept runner `option` isolationLevel', async () => {
-            const fakeOptions = {
-              isolationLevel: IsolationLevel.REPEATABLE_READ,
-            };
+    it('should optionally accept runner `option` readLockMode', async () => {
+      const fakeOptions = {
+        readLockMode: ReadLockMode.PESSIMISTIC,
+      };
 
-            await database.runTransactionAsync(fakeOptions, assert.ifError);
+      await database.runTransactionAsync(fakeOptions, assert.ifError);
 
-            const options = fakeAsyncTransactionRunner.calledWith_[3];
-            assert.strictEqual(options, fakeOptions);
-          });
+      const options = fakeAsyncTransactionRunner.calledWith_[3];
+      assert.strictEqual(options, fakeOptions);
+    });
 
-          it('should optionally accept runner `option` readLockMode', async () => {
-            const fakeOptions = {
-              readLockMode: ReadLockMode.PESSIMISTIC,
-            };
+    it('should return the runners resolved value', async () => {
+      const fakeValue = {};
 
-            await database.runTransactionAsync(fakeOptions, assert.ifError);
+      sandbox
+        .stub(FakeAsyncTransactionRunner.prototype, 'run')
+        .resolves(fakeValue);
 
-            const options = fakeAsyncTransactionRunner.calledWith_[3];
-            assert.strictEqual(options, fakeOptions);
-          });
+      const value = await database.runTransactionAsync(assert.ifError);
+      assert.strictEqual(value, fakeValue);
+    });
 
-          it('should return the runners resolved value', async () => {
-            const fakeValue = {};
+    it('should release the session when finished', async () => {
+      const releaseStub = (
+        sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
+      ).withArgs(SESSION);
 
-            sandbox
-              .stub(FakeAsyncTransactionRunner.prototype, 'run')
-              .resolves(fakeValue);
+      sandbox.stub(FakeAsyncTransactionRunner.prototype, 'run').resolves();
 
-            const value = await database.runTransactionAsync(assert.ifError);
-            assert.strictEqual(value, fakeValue);
-          });
-
-          it('should release the session when finished', async () => {
-            const releaseStub = (
-              sandbox.stub(fakeSessionFactory, 'release') as sinon.SinonStub
-            ).withArgs(SESSION);
-
-            sandbox
-              .stub(FakeAsyncTransactionRunner.prototype, 'run')
-              .resolves();
-
-            await database.runTransactionAsync(assert.ifError);
-            assert.strictEqual(releaseStub.callCount, 1);
-          });
-        },
-      );
+      await database.runTransactionAsync(assert.ifError);
+      assert.strictEqual(releaseStub.callCount, 1);
     });
   });
 

--- a/test/metrics/metrics.ts
+++ b/test/metrics/metrics.ts
@@ -238,7 +238,7 @@ describe('Test metrics with mock server', () => {
 
       const elapsedTime = endTime.valueOf() - startTime.valueOf();
 
-      const methods = ['batchCreateSessions', 'executeStreamingSql'];
+      const methods = ['createSession', 'executeStreamingSql'];
 
       const {resourceMetrics} = await reader.collect();
       const operationCountData = getMetricData(
@@ -369,7 +369,7 @@ describe('Test metrics with mock server', () => {
       const sessionAttributes = {
         ...commonAttributes,
         database: `database-${dbCounter}`,
-        method: 'batchCreateSessions',
+        method: 'createSession',
       };
       // Verify batchCreateSession metrics are unaffected
       assert.strictEqual(
@@ -462,7 +462,7 @@ describe('Test metrics with mock server', () => {
       // Verify GFE AFE latency doesn't exist
       assert.ok(!hasMetricData(resourceMetrics, METRIC_NAME_GFE_LATENCIES));
       assert.ok(!hasMetricData(resourceMetrics, METRIC_NAME_AFE_LATENCIES));
-      const methods = ['batchCreateSessions', 'executeStreamingSql'];
+      const methods = ['createSession', 'executeStreamingSql'];
       methods.forEach(method => {
         const attributes = {
           ...commonAttributes,
@@ -554,9 +554,9 @@ describe('Test metrics with mock server', () => {
       const sessionAttributes = {
         ...commonAttributes,
         database: `database-${dbCounter}`,
-        method: 'batchCreateSessions',
+        method: 'createSession',
       };
-      // Verify batchCreateSession metrics are unaffected
+      // Verify createSession metrics are unaffected
       assert.strictEqual(
         1,
         getAggregatedValue(operationCountData, sessionAttributes),
@@ -659,7 +659,7 @@ describe('Test metrics with mock server', () => {
 
       const elapsedTime = endTime.valueOf() - startTime.valueOf();
 
-      const methods = ['batchCreateSessions', 'executeStreamingSql'];
+      const methods = ['createSession', 'executeStreamingSql'];
 
       const {resourceMetrics} = await reader.collect();
       const operationCountData = getMetricData(

--- a/test/session-factory.ts
+++ b/test/session-factory.ts
@@ -87,9 +87,13 @@ describe('SessionFactory', () => {
   });
 
   describe('instantiation', () => {
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is disabled', () => {
+    describe('when multiplexed session is disabled', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+      });
+
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
       });
 
       it('should create a SessionPool object', () => {
@@ -125,15 +129,7 @@ describe('SessionFactory', () => {
       });
     });
 
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-      });
-
-      after(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-      });
-
+    describe('when multiplexed session is default', () => {
       it('should create a MultiplexedSession object', () => {
         assert(
           sessionFactory.multiplexedSession_ instanceof MultiplexedSession,
@@ -151,16 +147,20 @@ describe('SessionFactory', () => {
       });
 
       it('should correctly initialize the isMultiplexedEnabled field when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is enabled', () => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
         assert.strictEqual(sessionFactory.isMultiplexed, true);
       });
     });
 
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW both are disabled', () => {
+    describe('when multiplexed session is disabled for r/w', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
+      });
+
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
       });
 
       it('should correctly initialize the isMultiplexedRW field', () => {
@@ -169,17 +169,7 @@ describe('SessionFactory', () => {
       });
     });
 
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS and GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW both are enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
-      });
-
-      after(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
-      });
-
+    describe('when multiplexed session is default for r/w', () => {
       it('should correctly initialize the isMultiplexedRW field', () => {
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
         assert.strictEqual(sessionFactory.isMultiplexedRW, true);
@@ -188,9 +178,13 @@ describe('SessionFactory', () => {
   });
 
   describe('getSession', () => {
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is disabled', () => {
+    describe('when multiplexed session is disabled', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+      });
+
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
       });
 
       it('should retrieve a regular session from the pool', done => {
@@ -217,15 +211,7 @@ describe('SessionFactory', () => {
       });
     });
 
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-      });
-
-      after(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-      });
-
+    describe('when multiplexed session is default', () => {
       it('should return the multiplexed session', done => {
         (
           sandbox.stub(
@@ -266,6 +252,11 @@ describe('SessionFactory', () => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
       });
 
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
+      });
+
       it('should retrieve a regular session from the pool', done => {
         (
           sandbox.stub(sessionFactory.pool_, 'getSession') as sinon.SinonStub
@@ -290,17 +281,7 @@ describe('SessionFactory', () => {
       });
     });
 
-    describe('when multiplexed session for r/w enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
-      });
-
-      after(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
-      });
-
+    describe('when multiplexed session for r/w not disabled', () => {
       it('should return the multiplexed session', done => {
         (
           sandbox.stub(
@@ -343,15 +324,7 @@ describe('SessionFactory', () => {
   });
 
   describe('release', () => {
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-      });
-
-      after(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-      });
-
+    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is not disabled', () => {
       it('should not call the release method', () => {
         const releaseStub = sandbox.stub(sessionFactory.pool_, 'release');
         const fakeMuxSession = createMuxSession();
@@ -363,6 +336,10 @@ describe('SessionFactory', () => {
     describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is disabled', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+      });
+
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
       });
 
       it('should call the release method to release a regular session', () => {
@@ -389,10 +366,7 @@ describe('SessionFactory', () => {
   });
 
   describe('isMultiplexedEnabled', () => {
-    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is enabled', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-      });
+    describe('when GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS is not disabled', () => {
       it('should have enabled the multiplexed', () => {
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
         assert.strictEqual(sessionFactory.isMultiplexedEnabled(), true);
@@ -403,6 +377,9 @@ describe('SessionFactory', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
       });
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+      });
       it('should not have enabled the multiplexed', () => {
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
         assert.strictEqual(sessionFactory.isMultiplexedEnabled(), false);
@@ -411,11 +388,7 @@ describe('SessionFactory', () => {
   });
 
   describe('isMultiplexedEnabledForRW', () => {
-    describe('when multiplexed session is enabled for read/write transactions', () => {
-      before(() => {
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-        process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
-      });
+    describe('when multiplexed session is not disabled for read/write transactions', () => {
       it('should have enabled the multiplexed', () => {
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);
         assert.strictEqual(sessionFactory.isMultiplexedEnabledForRW(), true);
@@ -426,6 +399,10 @@ describe('SessionFactory', () => {
       before(() => {
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
         process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
+      });
+      after(() => {
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+        delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
       });
       it('should not have enabled the multiplexed', () => {
         const sessionFactory = new SessionFactory(DATABASE, NAME, POOL_OPTIONS);

--- a/test/session-pool.ts
+++ b/test/session-pool.ts
@@ -97,12 +97,20 @@ describe('SessionPool', () => {
   });
 
   beforeEach(() => {
+    process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
+    process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS =
+      'false';
+    process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false';
     DATABASE.session = createSession;
     sessionPool = new SessionPool(DATABASE);
     inventory = sessionPool._inventory;
   });
 
   afterEach(() => {
+    delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS;
+    delete process.env
+      .GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS;
+    delete process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW;
     pQueueOverride = null;
     sandbox.restore();
   });

--- a/test/transaction.ts
+++ b/test/transaction.ts
@@ -1739,112 +1739,94 @@ describe('Transaction', () => {
         );
       });
 
-      describe('when multiplexed session is enabled for read/write', () => {
-        before(() => {
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
-        });
-        after(() => {
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-            'false';
-        });
-        it('should pass multiplexedSessionPreviousTransactionId in the BeginTransactionRequest upon retrying an aborted transaction', () => {
-          const fakePreviousTransactionId = 'fake-previous-transaction-id';
-          const database = {
-            formattedName_: 'formatted-database-name',
-            isMuxEnabledForRW_: true,
-            parent: INSTANCE,
-          };
-          const SESSION = {
-            parent: database,
-            formattedName_: SESSION_NAME,
-            request: REQUEST,
-            requestStream: REQUEST_STREAM,
-          };
-          // multiplexed session
-          const multiplexedSession = Object.assign(
-            {multiplexed: true},
-            SESSION,
-          );
-          const transaction = new Transaction(multiplexedSession);
-          // transaction option must contain the previous transaction id for multiplexed session
-          transaction.multiplexedSessionPreviousTransactionId =
-            fakePreviousTransactionId;
-          const stub = sandbox.stub(transaction, 'request');
-          transaction.begin();
+      it('should pass multiplexedSessionPreviousTransactionId in the BeginTransactionRequest upon retrying an aborted transaction', () => {
+        const fakePreviousTransactionId = 'fake-previous-transaction-id';
+        const database = {
+          formattedName_: 'formatted-database-name',
+          isMuxEnabledForRW_: true,
+          parent: INSTANCE,
+        };
+        const SESSION = {
+          parent: database,
+          formattedName_: SESSION_NAME,
+          request: REQUEST,
+          requestStream: REQUEST_STREAM,
+        };
+        // multiplexed session
+        const multiplexedSession = Object.assign({multiplexed: true}, SESSION);
+        const transaction = new Transaction(multiplexedSession);
+        // transaction option must contain the previous transaction id for multiplexed session
+        transaction.multiplexedSessionPreviousTransactionId =
+          fakePreviousTransactionId;
+        const stub = sandbox.stub(transaction, 'request');
+        transaction.begin();
 
-          const expectedOptions = {
-            isolationLevel: 0,
-            readWrite: {
-              multiplexedSessionPreviousTransactionId:
-                fakePreviousTransactionId,
-            },
-          };
-          const {client, method, reqOpts, headers} = stub.lastCall.args[0];
+        const expectedOptions = {
+          isolationLevel: 0,
+          readWrite: {
+            multiplexedSessionPreviousTransactionId: fakePreviousTransactionId,
+          },
+        };
+        const {client, method, reqOpts, headers} = stub.lastCall.args[0];
 
-          assert.strictEqual(client, 'SpannerClient');
-          assert.strictEqual(method, 'beginTransaction');
-          // request options should contain the multiplexedSessionPreviousTransactionId
-          assert.deepStrictEqual(reqOpts.options, expectedOptions);
-          assert.deepStrictEqual(
-            headers,
-            Object.assign(
-              {[LEADER_AWARE_ROUTING_HEADER]: true},
-              transaction.commonHeaders_,
-            ),
-          );
-        });
+        assert.strictEqual(client, 'SpannerClient');
+        assert.strictEqual(method, 'beginTransaction');
+        // request options should contain the multiplexedSessionPreviousTransactionId
+        assert.deepStrictEqual(reqOpts.options, expectedOptions);
+        assert.deepStrictEqual(
+          headers,
+          Object.assign(
+            {[LEADER_AWARE_ROUTING_HEADER]: true},
+            transaction.commonHeaders_,
+          ),
+        );
+      });
 
-        it('should send the correct options if _mutationKey is set in the transaction object', () => {
-          // session with multiplexed enabled
-          const multiplexedSession = Object.assign(
-            {multiplexed: true},
-            SESSION,
-          );
+      it('should send the correct options if _mutationKey is set in the transaction object', () => {
+        // session with multiplexed enabled
+        const multiplexedSession = Object.assign({multiplexed: true}, SESSION);
 
-          // fake mutation key
-          const fakeMutationKey = {
-            insertOrUpdate: {
-              table: 'my-table-123',
-              columns: ['Id', 'Name'],
-              values: [
-                {
-                  values: [{stringValue: 'Id3'}, {stringValue: 'Name3'}],
-                },
-              ],
-            },
-          } as google.spanner.v1.Mutation;
+        // fake mutation key
+        const fakeMutationKey = {
+          insertOrUpdate: {
+            table: 'my-table-123',
+            columns: ['Id', 'Name'],
+            values: [
+              {
+                values: [{stringValue: 'Id3'}, {stringValue: 'Name3'}],
+              },
+            ],
+          },
+        } as google.spanner.v1.Mutation;
 
-          const transaction = new Transaction(multiplexedSession);
+        const transaction = new Transaction(multiplexedSession);
 
-          // stub the transaction request
-          const stub = sandbox.stub(transaction, 'request');
+        // stub the transaction request
+        const stub = sandbox.stub(transaction, 'request');
 
-          // set the _mutationKey in the transaction object
-          transaction._mutationKey = fakeMutationKey;
+        // set the _mutationKey in the transaction object
+        transaction._mutationKey = fakeMutationKey;
 
-          // make a call to begin
-          transaction.begin();
+        // make a call to begin
+        transaction.begin();
 
-          const expectedOptions = {isolationLevel: 0, readWrite: {}};
-          const {client, method, reqOpts, headers} = stub.lastCall.args[0];
+        const expectedOptions = {isolationLevel: 0, readWrite: {}};
+        const {client, method, reqOpts, headers} = stub.lastCall.args[0];
 
-          // assert on the begin transaction call
-          assert.strictEqual(client, 'SpannerClient');
-          assert.strictEqual(method, 'beginTransaction');
-          assert.deepStrictEqual(reqOpts.options, expectedOptions);
-          // assert that if the _mutationKey is set in the transaction object
-          // it is getting pass in the request as well along with request options
-          assert.deepStrictEqual(reqOpts.mutationKey, fakeMutationKey);
-          assert.deepStrictEqual(
-            headers,
-            Object.assign(
-              {[LEADER_AWARE_ROUTING_HEADER]: true},
-              transaction.commonHeaders_,
-            ),
-          );
-        });
+        // assert on the begin transaction call
+        assert.strictEqual(client, 'SpannerClient');
+        assert.strictEqual(method, 'beginTransaction');
+        assert.deepStrictEqual(reqOpts.options, expectedOptions);
+        // assert that if the _mutationKey is set in the transaction object
+        // it is getting pass in the request as well along with request options
+        assert.deepStrictEqual(reqOpts.mutationKey, fakeMutationKey);
+        assert.deepStrictEqual(
+          headers,
+          Object.assign(
+            {[LEADER_AWARE_ROUTING_HEADER]: true},
+            transaction.commonHeaders_,
+          ),
+        );
       });
     });
 
@@ -1996,96 +1978,80 @@ describe('Transaction', () => {
         assert.deepStrictEqual(reqOpts.singleUseTransaction, expectedOptions);
       });
 
-      describe('when multiplexed session is enabled for read write', () => {
-        before(() => {
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'true';
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'true';
+      it('should call _setMutationKey when neither `id` is set nor `singleUseTransaction` is used', async () => {
+        // fake mutation key
+        const fakeMutations = [
+          {
+            insertOrUpdate: {
+              table: 'my-table-123',
+              columns: ['Id', 'Name'],
+              values: [
+                {
+                  values: [{stringValue: 'Id1'}, {stringValue: 'Name1'}],
+                },
+              ],
+            },
+          } as google.spanner.v1.Mutation,
+        ];
+
+        // fake transaction id
+        const fakeTransactionId = 'fake-tx-id-12345';
+
+        const database = {
+          formattedName_: 'formatted-database-name',
+          isMuxEnabledForRW_: true,
+          parent: INSTANCE,
+        };
+        const SESSION = {
+          parent: database,
+          formattedName_: SESSION_NAME,
+          request: REQUEST,
+          requestStream: REQUEST_STREAM,
+        };
+        // multiplexed session
+        const multiplexedSession = Object.assign({multiplexed: true}, SESSION);
+
+        // transaction object
+        const transaction = new Transaction(multiplexedSession);
+
+        // ensure transaction is not single use transaction
+        transaction._useInRunner = true;
+
+        // ensure transaction ID is not set
+        transaction.id = undefined;
+
+        // set the _queuedMutations with the fakeMutations list
+        transaction._queuedMutations = fakeMutations;
+
+        // spy on _setMutationKey
+        const setMutationKeySpy = sandbox.spy(transaction, '_setMutationKey');
+
+        // stub the begin method
+        const beginStub = sandbox.stub(transaction, 'begin').callsFake(() => {
+          transaction.id = fakeTransactionId;
+          return Promise.resolve();
         });
 
-        after(() => {
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false';
-          process.env.GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW =
-            'false';
-        });
+        // stub transaction request
+        sandbox.stub(transaction, 'request');
 
-        it('should call _setMutationKey when neither `id` is set nor `singleUseTransaction` is used', async () => {
-          // fake mutation key
-          const fakeMutations = [
-            {
-              insertOrUpdate: {
-                table: 'my-table-123',
-                columns: ['Id', 'Name'],
-                values: [
-                  {
-                    values: [{stringValue: 'Id1'}, {stringValue: 'Name1'}],
-                  },
-                ],
-              },
-            } as google.spanner.v1.Mutation,
-          ];
+        // make a call to commit
+        transaction.commit();
 
-          // fake transaction id
-          const fakeTransactionId = 'fake-tx-id-12345';
+        // ensure that _setMutationKey was got called once
+        sinon.assert.calledOnce(setMutationKeySpy);
 
-          const database = {
-            formattedName_: 'formatted-database-name',
-            isMuxEnabledForRW_: true,
-            parent: INSTANCE,
-          };
-          const SESSION = {
-            parent: database,
-            formattedName_: SESSION_NAME,
-            request: REQUEST,
-            requestStream: REQUEST_STREAM,
-          };
-          // multiplexed session
-          const multiplexedSession = Object.assign(
-            {multiplexed: true},
-            SESSION,
-          );
+        // ensure that _setMutationKey got called with correct arguments
+        sinon.assert.calledWith(setMutationKeySpy, fakeMutations);
 
-          // transaction object
-          const transaction = new Transaction(multiplexedSession);
+        // ensure begin was called
+        sinon.assert.calledOnce(beginStub);
 
-          // ensure transaction is not single use transaction
-          transaction._useInRunner = true;
+        // ensure begin set the transaction id
+        assert.strictEqual(transaction.id, fakeTransactionId);
 
-          // ensure transaction ID is not set
-          transaction.id = undefined;
-
-          // set the _queuedMutations with the fakeMutations list
-          transaction._queuedMutations = fakeMutations;
-
-          // spy on _setMutationKey
-          const setMutationKeySpy = sandbox.spy(transaction, '_setMutationKey');
-
-          // stub the begin method
-          const beginStub = sandbox.stub(transaction, 'begin').callsFake(() => {
-            transaction.id = fakeTransactionId;
-            return Promise.resolve();
-          });
-
-          // stub transaction request
-          sandbox.stub(transaction, 'request');
-
-          // make a call to commit
-          transaction.commit();
-
-          // ensure that _setMutationKey was got called once
-          sinon.assert.calledOnce(setMutationKeySpy);
-
-          // ensure that _setMutationKey got called with correct arguments
-          sinon.assert.calledWith(setMutationKeySpy, fakeMutations);
-
-          // ensure begin was called
-          sinon.assert.calledOnce(beginStub);
-
-          // ensure begin set the transaction id
-          assert.strictEqual(transaction.id, fakeTransactionId);
-
-          // ensure _mutationKey is set
-          assert.strictEqual(transaction._mutationKey, fakeMutations[0]);
-        });
+        // ensure _mutationKey is set
+        assert.strictEqual(transaction._mutationKey, fakeMutations[0]);
       });
 
       it('should call `end` once complete', () => {


### PR DESCRIPTION
This PR contains code changes for making multiplexed session as default enabled session mode.

To disable the multiplexed session:
For RO Transactions - 
`GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false'`

For Partitioned DML - 
```
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false'
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_PARTITIONED_OPS = 'false'
```

For RW Transactions - 
```
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS = 'false'
GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS_FOR_RW = 'false'
```

Additionally, this PR includes code changes in the kokoro pipeline to run the integration test against regular sessions.