### PR TITLE
feat: add option to opt out of  SPANNER_EMULATOR_HOST

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,7 @@ export interface SpannerOptions extends GrpcClientOptions {
   observabilityOptions?: ObservabilityOptions;
   disableBuiltInMetrics?: boolean;
   interceptors?: any[];
+  ignoreEnvSpannerEmulatorHost?: boolean;
   /**
    * The Trusted Cloud Domain (TPC) DNS of the service used to make requests.
    * Defaults to `googleapis.com`.
@@ -450,7 +451,9 @@ class Spanner extends GrpcService {
       );
     }
 
-    const emulatorHost = Spanner.getSpannerEmulatorHost();
+    const emulatorHost = options.ignoreEnvSpannerEmulatorHost
+      ? undefined
+      : Spanner.getSpannerEmulatorHost();
     if (
       emulatorHost &&
       emulatorHost.endpoint &&

--- a/test/index.ts
+++ b/test/index.ts
@@ -467,6 +467,26 @@ describe('Spanner', () => {
         assert.strictEqual(config.baseUrl, EMULATOR_HOST);
         assert.strictEqual(options.port, EMULATOR_PORT);
       });
+
+      it('should ignore SPANNER_EMULATOR_HOST when ignoreEnvSpannerEmulatorHost is set', () => {
+        const EMULATOR_HOST = 'somehost.local';
+        const EMULATOR_PORT = 1610;
+        process.env.SPANNER_EMULATOR_HOST = `${EMULATOR_HOST}:${EMULATOR_PORT}`;
+
+        const spanner = new Spanner({
+          ignoreEnvSpannerEmulatorHost: true,
+        });
+
+        const config = getFake(spanner).calledWith_[0];
+        const options = getFake(spanner).calledWith_[1];
+
+        // ensure we are NOT pointing to the emulator
+        assert.notStrictEqual(config.baseUrl, EMULATOR_HOST);
+        assert.notStrictEqual(options.port, EMULATOR_PORT);
+
+        // ensure we defaulted back to the real API
+        assert.strictEqual(config.baseUrl, 'spanner.googleapis.com');
+      });
     });
   });
 


### PR DESCRIPTION
This adds a new `ignoreEnvSpannerEmulatorHost` option to the `SpannerOptions`. This new option allows users to explicitly disable the automatic detection of the emulator environment variable, which is useful when integrating with configuration providers or running hybrid tests