### PR TITLE
fix: type check for key in deleteRows

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -40,8 +40,22 @@ import {
 import {google} from '../protos/protos';
 import IsolationLevel = google.spanner.v1.TransactionOptions.IsolationLevel;
 import ReadLockMode = google.spanner.v1.TransactionOptions.ReadWrite.ReadLockMode;
+import {Int, SpannerDate, Numeric, Float32, Float} from './codec';
 
-export type Key = string | string[];
+// valid scalar types that Spanner accepts in a Key
+export type KeyScalar =
+  | string
+  | number
+  | boolean
+  | SpannerDate
+  | Buffer
+  | Uint8Array
+  | Int
+  | Numeric
+  | Float32
+  | Float;
+
+export type Key = KeyScalar | KeyScalar[];
 
 export type CreateTableResponse = [
   Table,


### PR DESCRIPTION
Currently, the `Key` type is restricted to `string`. However, Cloud Spanner supports various scalar types as Primary Keys (e.g., INT64, BOOL, BYTES, TIMESTAMP), and the underlying runtime code handles these types correctly without issues.

This PR is to correct the type definition to explicitly include all supported Spanner types.