### PR TITLE
fix: type mismatch in Snapshot.run error handler

### DIFF
--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1289,10 +1289,17 @@ export class Snapshot extends EventEmitter {
       },
       span => {
         return this.runStream(query)
-          .on('error', (err, rows, stats, metadata) => {
+          .on('error', err => {
             setSpanError(span, err);
             span.end();
-            callback!(err, rows, stats, metadata);
+            if (!('code' in err)) {
+              Object.assign(err, {
+                code: grpc.status.UNKNOWN,
+                details: err.message,
+                metadata: new grpc.Metadata(),
+              });
+            }
+            callback!(err as ServiceError, rows, stats, metadata);
           })
           .on('response', response => {
             if (response.metadata) {


### PR DESCRIPTION
This PR fixes a TypeScript compilation error in the `Snapshot.run` method.

**The problem**

**1. Type Mismatch:** The RunCallback expects a ServiceError (with code, metadata, etc.), but the Node.js stream error event is typed to emit a generic Error. This caused a compilation failure: `Argument of type 'Error' is not assignable to parameter of type 'ServiceError'`

**2. Undefined Variables as a argument:** The .on('error', (err, rows, stats, metadata) => ...) handler was declaring rows, stats, and metadata as arguments. Since the standard error event only emits a single argument (err), these variables were always undefined inside the handler

**The Fix**

**1. Removed undefined arguments:** The error handler now only accepts (err). This allows the closure to access the correct rows, stats, and metadata variables from the outer scope, ensuring that partial results collected before the error are correctly passed to the user

**2. Added Type Cast:** Explicitly cast err to ServiceError. In the context of the Spanner client, runtime errors from the stream are expected to be ServiceError objects, making this cast safe and compatible with our callback signature



