### PR TITLE
chore: Add gcp resouce name span attribute

### DIFF
--- a/observability-test/observability.ts
+++ b/observability-test/observability.ts
@@ -126,7 +126,10 @@ describe('startTrace', () => {
   });
 
   it('with semantic attributes', () => {
-    const opts = {tableName: 'table', dbName: 'db'};
+    const opts = {
+      tableName: 'table',
+      dbName: 'projects/PROJECT_ID/instances/INSTANCE_ID/databases/DATABASE_ID',
+    };
     startTrace('aSpan', opts, span => {
       assert.equal(
         span.attributes[ATTR_OTEL_SCOPE_NAME],
@@ -159,6 +162,12 @@ describe('startTrace', () => {
       );
 
       assert.equal(
+        span.attributes['gcp.resource.name'],
+        '//spanner.googleapis.com/projects/PROJECT_ID/instances/INSTANCE_ID/databases/DATABASE_ID',
+        'Missing gcp.resource.name attribute',
+      );
+
+      assert.equal(
         span.attributes[SEMATTRS_DB_SQL_TABLE],
         'table',
         'Missing DB_SQL_TABLE attribute',
@@ -166,7 +175,7 @@ describe('startTrace', () => {
 
       assert.equal(
         span.attributes[SEMATTRS_DB_NAME],
-        'db',
+        'projects/PROJECT_ID/instances/INSTANCE_ID/databases/DATABASE_ID',
         'Missing DB_NAME attribute',
       );
     });

--- a/samples/observability-traces.js
+++ b/samples/observability-traces.js
@@ -37,7 +37,7 @@ async function main(
   } = require('@opentelemetry/sdk-trace-base');
   const {Spanner} = require('@google-cloud/spanner');
 
-  const traceExporter = new TraceExporter();
+  const traceExporter = new TraceExporter({projectId: projectId});
 
   // Create a provider with a custom sampler
   const provider = new NodeTracerProvider({
@@ -81,7 +81,7 @@ async function main(
     spanner.close();
   }
 
-  provider.forceFlush();
+  await provider.forceFlush();
 
   // This sleep gives ample time for the trace
   // spans to be exported to Google Cloud Trace.

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -150,6 +150,10 @@ export function startTrace<T>(
         span.setAttribute('db.sql.table', config.tableName);
       }
       if (config.dbName) {
+        span.setAttribute(
+          'gcp.resource.name',
+          `//spanner.googleapis.com/${config.dbName}`,
+        );
         span.setAttribute('db.name', config.dbName);
       }
       if (config.requestTag) {


### PR DESCRIPTION
Adding a new span attribute called gcp.resource.name which contains an identifier to a particular spanner instance and database in the following format:

//spanner.googleapis.com/projects/{project}/instances/{instance_id}/databases/{database_id}
Example:

//spanner.googleapis.com/projects/my_project/instances/my_instance/databases/my_database
