### PR TITLE
fix: UUID type backward compatibility

### DIFF
--- a/samples/backups-cancel.js
+++ b/samples/backups-cancel.js
@@ -20,7 +20,6 @@ async function cancelBackup(instanceId, databaseId, backupId, projectId) {
 
   // Imports the Google Cloud client library and precise date library
   const {Spanner, protos} = require('@google-cloud/spanner');
-  //test
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */

--- a/samples/backups-cancel.js
+++ b/samples/backups-cancel.js
@@ -20,6 +20,7 @@ async function cancelBackup(instanceId, databaseId, backupId, projectId) {
 
   // Imports the Google Cloud client library and precise date library
   const {Spanner, protos} = require('@google-cloud/spanner');
+  //test
   /**
    * TODO(developer): Uncomment the following lines before running the sample.
    */

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1160,10 +1160,6 @@ function getType(value: Value): Type {
     return {type: 'bool'};
   }
 
-  if (uuid.validate(value)) {
-    return {type: 'unspecified'};
-  }
-
   if (isString(value)) {
     return {type: 'string'};
   }

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -38,6 +38,8 @@ import * as uuid from 'uuid';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Value = any;
 
+let uuidUntypedFlagWarned = false;
+
 export interface Field {
   name: string;
   value: Value;
@@ -1158,6 +1160,19 @@ function getType(value: Value): Type {
 
   if (isBoolean(value)) {
     return {type: 'bool'};
+  }
+
+  if (process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'] === 'true') {
+    if (!uuidUntypedFlagWarned) {
+      process.emitWarning(
+        'SPANNER_ENABLE_UUID_AS_UNTYPED environment variable is deprecated and will be removed in a future release.',
+        'DeprecationWarning',
+      );
+      uuidUntypedFlagWarned = true;
+    }
+    if (uuid.validate(value)) {
+      return {type: 'unspecified'};
+    }
   }
 
   if (isString(value)) {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1735,7 +1735,19 @@ export class Snapshot extends EventEmitter {
     if (!isEmpty(typeMap)) {
       Object.keys(typeMap).forEach(param => {
         const type = typeMap[param];
-        paramTypes[param] = codec.createTypeObject(type);
+        if (process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'] === 'true') {
+          const typeObject = codec.createTypeObject(type);
+          if (
+            (type.child &&
+              typeObject.code === 'ARRAY' &&
+              typeObject.arrayElementType?.code !== 'TYPE_CODE_UNSPECIFIED') ||
+            (!type.child && typeObject.code !== 'TYPE_CODE_UNSPECIFIED')
+          ) {
+            paramTypes[param] = typeObject;
+          }
+        } else {
+          paramTypes[param] = codec.createTypeObject(type);
+        }
       });
     }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1735,15 +1735,7 @@ export class Snapshot extends EventEmitter {
     if (!isEmpty(typeMap)) {
       Object.keys(typeMap).forEach(param => {
         const type = typeMap[param];
-        const typeObject = codec.createTypeObject(type);
-        if (
-          (type.child &&
-            typeObject.code === 'ARRAY' &&
-            typeObject.arrayElementType?.code !== 'TYPE_CODE_UNSPECIFIED') ||
-          (!type.child && typeObject.code !== 'TYPE_CODE_UNSPECIFIED')
-        ) {
-          paramTypes[param] = typeObject;
-        }
+        paramTypes[param] = codec.createTypeObject(type);
       });
     }
 

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -1784,6 +1784,35 @@ describe('codec', () => {
       });
     });
 
+    it('should determine if the uuid value is unspecified when SPANNER_ENABLE_UUID_AS_UNTYPED is true', () => {
+      const emitWarningStub = sandbox.stub(process, 'emitWarning');
+      try {
+        process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'] = 'true';
+        assert.deepStrictEqual(codec.getType(uuid.v4()), {
+          type: 'unspecified',
+        });
+        assert.strictEqual(emitWarningStub.calledOnce, true);
+        assert.strictEqual(
+          emitWarningStub.firstCall.args[0],
+          'SPANNER_ENABLE_UUID_AS_UNTYPED environment variable is deprecated and will be removed in a future release.',
+        );
+      } finally {
+        delete process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'];
+        emitWarningStub.restore();
+      }
+    });
+
+    it('should determine if the uuid value is string when SPANNER_ENABLE_UUID_AS_UNTYPED is false', () => {
+      try {
+        process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'] = 'false';
+        assert.deepStrictEqual(codec.getType(uuid.v4()), {
+          type: 'string',
+        });
+      } finally {
+        delete process.env['SPANNER_ENABLE_UUID_AS_UNTYPED'];
+      }
+    });
+
     it('should determine if the value is a float32', () => {
       assert.deepStrictEqual(codec.getType(new codec.Float32(1.1)), {
         type: 'float32',

--- a/test/codec.ts
+++ b/test/codec.ts
@@ -1778,9 +1778,9 @@ describe('codec', () => {
       });
     });
 
-    it('should determine if the uuid value is unspecified', () => {
+    it('should determine if the uuid value is string', () => {
       assert.deepStrictEqual(codec.getType(uuid.v4()), {
-        type: 'unspecified',
+        type: 'string',
       });
     });
 


### PR DESCRIPTION
This PR reverts the [recent change](https://github.com/googleapis/nodejs-spanner/pull/2482/files) where UUID-formatted strings were implicitly treated as unspecified (untyped). That change caused regressions for customers relying on UUID-like strings being sent as STRING-typed parameters. This PR restores the default behavior: UUID-formatted strings will now default to STRING, ensuring stability for existing applications.

It fixes #2501

Impact on v8.4.0 Users This change affects users who adopted [v8.4.0](https://www.npmjs.com/package/@google-cloud/spanner/v/8.4.0) and relied on the automatic UUID-to-untyped inference. To correctly send a UUID parameter, you must now explicitly specify the type:

javascript
const [rows1] = await database.run({
    sql: "SELECT @value",
    params: { value: '550e8400-e29b-41d4-a716-446655440000' },
    types: {
      value: "uuid" , //  Explicitly specifying the type
    },
});

Temporary Opt-in Flag To temporarily retain the behavior introduced in v8.4.0 (where UUIDs are treated as unspecified), customers can set the environment variable SPANNER_ENABLE_UUID_AS_UNTYPED=true.

Note: This flag causes a deprecation warning to be emitted and will be removed in a future release.
Recommendation: Customers are strongly encouraged to explicitly specify the type as 'uuid' instead of using this flag.