### PR TITLE
fix: ensure all data is consumed before emitting end event in Partial…

### DIFF
--- a/src/partial-result-stream.ts
+++ b/src/partial-result-stream.ts
@@ -246,7 +246,7 @@ export class PartialResultStream extends Transform implements ResultEvents {
     }
 
     if (chunk.last) {
-      this.emit('end');
+      this.push(null);
       return;
     }
 


### PR DESCRIPTION
…ResultStream

Replaced `this.emit('end')` with `this.push(null)` in `PartialResultStream` to correctly signal EOF to the stream state machine. This ensures that any buffered data is fully consumed by the reader before the 'end' event is emitted, preventing data loss when the stream is paused/resumed near the end of the stream.

Fixes #2502 
